### PR TITLE
Do not show port in hints when port is a default one

### DIFF
--- a/typesafe_conductr_cli/conduct.py
+++ b/typesafe_conductr_cli/conduct.py
@@ -115,7 +115,7 @@ def get_cli_parameters(args):
     parameters = [""]
     if args.host != default_host:
         parameters.append("--host {}".format(args.host))
-    if args.port != default_port:
+    if args.port != int(default_port):
         parameters.append("--port {}".format(args.port))
     return " ".join(parameters)
 

--- a/typesafe_conductr_cli/test/test_conduct.py
+++ b/typesafe_conductr_cli/test/test_conduct.py
@@ -63,14 +63,14 @@ class TestConduct(TestCase):
         self.assertEqual(args.bundle, "path-to-bundle")
 
     def test_get_cli_parameters(self):
-        args = Namespace(host="127.0.0.1", port="9005")
+        args = Namespace(host="127.0.0.1", port=9005)
         self.assertEqual(get_cli_parameters(args), "")
 
-        args = Namespace(host="127.0.1.1", port="9005")
+        args = Namespace(host="127.0.1.1", port=9005)
         self.assertEqual(get_cli_parameters(args), " --host 127.0.1.1")
 
-        args = Namespace(host="127.0.0.1", port="9006")
+        args = Namespace(host="127.0.0.1", port=9006)
         self.assertEqual(get_cli_parameters(args), " --port 9006")
 
-        args = Namespace(host="127.0.1.1", port="9006")
+        args = Namespace(host="127.0.1.1", port=9006)
         self.assertEqual(get_cli_parameters(args), " --host 127.0.1.1 --port 9006")


### PR DESCRIPTION
Port is provided by argparse as int. Therefore compare it as int.
