### PR TITLE
Add support for bundle name

### DIFF
--- a/typesafe_conductr_cli/__init__.py
+++ b/typesafe_conductr_cli/__init__.py
@@ -1,0 +1,16 @@
+import requests
+
+
+def patch_raise_for_status(original_raise_for_status):
+    """
+    monkey-patching response objects to raise status when status code 3xx
+    """
+
+    def new_raise_for_status(self):
+        original_raise_for_status(self)
+        if self.status_code >= 300:
+            raise requests.exceptions.HTTPError(requests.status_codes._codes[self.status_code], response=self)
+
+    return new_raise_for_status
+
+requests.models.Response.raise_for_status = patch_raise_for_status(requests.models.Response.raise_for_status)

--- a/typesafe_conductr_cli/conduct.py
+++ b/typesafe_conductr_cli/conduct.py
@@ -23,7 +23,7 @@ def add_host_and_port(sub_parser):
 
 def add_verbose(sub_parser):
     sub_parser.add_argument('-v', '--verbose',
-                            help="Print JSON response to the command",
+                            help='Print JSON response to the command',
                             default=False,
                             dest='verbose',
                             action='store_true')
@@ -116,12 +116,12 @@ def build_parser():
 
 
 def get_cli_parameters(args):
-    parameters = [""]
+    parameters = ['']
     if args.host != default_host:
-        parameters.append("--host {}".format(args.host))
+        parameters.append('--host {}'.format(args.host))
     if args.port != int(default_port):
-        parameters.append("--port {}".format(args.port))
-    return " ".join(parameters)
+        parameters.append('--port {}'.format(args.port))
+    return ' '.join(parameters)
 
 
 def run():
@@ -129,7 +129,7 @@ def run():
     parser = build_parser()
     argcomplete.autocomplete(parser)
     args = parser.parse_args()
-    if vars(args).get("func") is None:
+    if vars(args).get('func') is None:
         parser.print_help()
     else:
         args.cli_parameters = get_cli_parameters(args)

--- a/typesafe_conductr_cli/conduct.py
+++ b/typesafe_conductr_cli/conduct.py
@@ -77,6 +77,10 @@ def build_parser():
                              nargs='*',
                              default=[],
                              help='The optional roles of cluster nodes that this bundle can be deployed to, defaults to all roles')
+    load_parser.add_argument('--name',
+                             default=None,
+                             dest='bundle_name',
+                             help='The optional name of the bundle. Defaults to the first part of the filename until the digest.')
     add_default_arguments(load_parser)
     load_parser.set_defaults(func=conduct_load.load)
 
@@ -102,7 +106,7 @@ def build_parser():
 
     # Sub-parser for `unload` sub-command
     unload_parser = subparsers.add_parser('unload',
-                                        help='unload a bundle')
+                                          help='unload a bundle')
     unload_parser.add_argument('bundle',
                                help='The ID of the bundle')
     add_default_arguments(unload_parser)

--- a/typesafe_conductr_cli/conduct_info.py
+++ b/typesafe_conductr_cli/conduct_info.py
@@ -18,12 +18,13 @@ def info(args):
     data = [
         {
             'id': bundle['bundleId'],
+            'name': bundle['attributes']['bundleName'],
             'replications': len(bundle['bundleInstallations']),
             'starting': sum([not execution['isStarted'] for execution in bundle['bundleExecutions']]),
             'executions': sum([execution['isStarted'] for execution in bundle['bundleExecutions']])
         } for bundle in json.loads(response.text)
     ]
-    data.insert(0, {'id': 'ID', 'replications': '#REP', 'starting': "#STR", 'executions': '#RUN'})
+    data.insert(0, {'id': 'ID', 'name': 'NAME', 'replications': '#REP', 'starting': "#STR", 'executions': '#RUN'})
 
     padding = 2
     column_widths = {}
@@ -35,4 +36,4 @@ def info(args):
                 column_widths[width_key] = column_len
 
     for row in data:
-        print("{id: <{id_width}}{replications: <{replications_width}}{starting: <{starting_width}}{executions: <{executions_width}}".format(**dict(row, **column_widths)))
+        print("{id: <{id_width}}{name: <{name_width}}{replications: <{replications_width}}{starting: <{starting_width}}{executions: <{executions_width}}".format(**dict(row, **column_widths)))

--- a/typesafe_conductr_cli/conduct_info.py
+++ b/typesafe_conductr_cli/conduct_info.py
@@ -24,16 +24,16 @@ def info(args):
             'executions': sum([execution['isStarted'] for execution in bundle['bundleExecutions']])
         } for bundle in json.loads(response.text)
     ]
-    data.insert(0, {'id': 'ID', 'name': 'NAME', 'replications': '#REP', 'starting': "#STR", 'executions': '#RUN'})
+    data.insert(0, {'id': 'ID', 'name': 'NAME', 'replications': '#REP', 'starting': '#STR', 'executions': '#RUN'})
 
     padding = 2
     column_widths = {}
     for row in data:
         for column, value in row.items():
             column_len = len(str(value)) + padding
-            width_key = column + "_width"
+            width_key = column + '_width'
             if (column_len > column_widths.get(width_key, 0)):
                 column_widths[width_key] = column_len
 
     for row in data:
-        print("{id: <{id_width}}{name: <{name_width}}{replications: <{replications_width}}{starting: <{starting_width}}{executions: <{executions_width}}".format(**dict(row, **column_widths)))
+        print('{id: <{id_width}}{name: <{name_width}}{replications: <{replications_width}}{starting: <{starting_width}}{executions: <{executions_width}}'.format(**dict(row, **column_widths)))

--- a/typesafe_conductr_cli/conduct_load.py
+++ b/typesafe_conductr_cli/conduct_load.py
@@ -10,7 +10,7 @@ def load(args):
     """`conduct load` command"""
 
     if args.bundle_name is None:
-        args.bundle_name = "-".join(os.path.basename(args.bundle).split("-")[:-1])
+        args.bundle_name = '-'.join(os.path.basename(args.bundle).split('-')[:-1])
 
     url = conduct_url.url('bundles', args)
     files = [
@@ -33,7 +33,7 @@ def load(args):
     response_json = json.loads(response.text)
     bundleId = response_json['bundleId']
 
-    print("Bundle loaded.")
-    print("Start bundle with: conduct run{} {}".format(args.cli_parameters, bundleId))
-    print("Unload bundle with: conduct unload{} {}".format(args.cli_parameters, bundleId))
-    print("Print ConductR info with: conduct info{}".format(args.cli_parameters))
+    print('Bundle loaded.')
+    print('Start bundle with: conduct run{} {}'.format(args.cli_parameters, bundleId))
+    print('Unload bundle with: conduct unload{} {}'.format(args.cli_parameters, bundleId))
+    print('Print ConductR info with: conduct info{}'.format(args.cli_parameters))

--- a/typesafe_conductr_cli/conduct_load.py
+++ b/typesafe_conductr_cli/conduct_load.py
@@ -1,6 +1,7 @@
 from typesafe_conductr_cli import conduct_url, conduct_logging
 import json
 import os
+import re
 import requests
 
 
@@ -10,7 +11,7 @@ def load(args):
     """`conduct load` command"""
 
     if args.bundle_name is None:
-        args.bundle_name = '-'.join(os.path.basename(args.bundle).split('-')[:-1])
+        args.bundle_name = path_to_bundle_name(args.bundle)
 
     url = conduct_url.url('bundles', args)
     files = [
@@ -37,3 +38,8 @@ def load(args):
     print('Start bundle with: conduct run{} {}'.format(args.cli_parameters, bundleId))
     print('Unload bundle with: conduct unload{} {}'.format(args.cli_parameters, bundleId))
     print('Print ConductR info with: conduct info{}'.format(args.cli_parameters))
+
+
+def path_to_bundle_name(filename):
+    match = re.match(r'(.*?)(-[a-fA-F0-9]{0,64})?\.zip', os.path.basename(filename))
+    return match.group(1)

--- a/typesafe_conductr_cli/conduct_load.py
+++ b/typesafe_conductr_cli/conduct_load.py
@@ -1,5 +1,6 @@
 from typesafe_conductr_cli import conduct_url, conduct_logging
 import json
+import os
 import requests
 
 
@@ -8,12 +9,16 @@ import requests
 def load(args):
     """`conduct load` command"""
 
+    if args.bundle_name is None:
+        args.bundle_name = "-".join(os.path.basename(args.bundle).split("-")[:-1])
+
     url = conduct_url.url('bundles', args)
     files = [
         ('nrOfCpus', str(args.nr_of_cpus)),
         ('memory', str(args.memory)),
         ('diskSpace', str(args.disk_space)),
         ('roles', ' '.join(args.roles)),
+        ('bundleName', args.bundle_name),
         ('bundle', open(args.bundle, 'rb'))
     ]
     if args.configuration is not None:

--- a/typesafe_conductr_cli/conduct_logging.py
+++ b/typesafe_conductr_cli/conduct_logging.py
@@ -5,13 +5,13 @@ from requests.exceptions import ConnectionError, HTTPError
 
 # print to stderr
 def error(message, *objs):
-    print("ERROR: {}".format(message.format(*objs)), file=sys.stderr)
+    print('ERROR: {}'.format(message.format(*objs)), file=sys.stderr)
 
 
 def connection_error(err, args):
-    error("Unable to contact Typesafe ConductR.")
-    error("Reason: {}".format(err.args[0]))
-    error("Make sure it can be accessed at {}:{}.".format(args[0].host, args[0].port))
+    error('Unable to contact Typesafe ConductR.')
+    error('Reason: {}'.format(err.args[0]))
+    error('Make sure it can be accessed at {}:{}.'.format(args[0].host, args[0].port))
 
 
 def handle_connection_error(func):
@@ -33,8 +33,8 @@ def handle_http_error(func):
         try:
             return func(*args, **kwargs)
         except HTTPError as err:
-            error("{} {}", err.response.status_code, err.response.reason)
-            if err.response.text != "":
+            error('{} {}', err.response.status_code, err.response.reason)
+            if err.response.text != '':
                 error(err.response.text)
 
     # Do not change the wrapped function name,

--- a/typesafe_conductr_cli/conduct_logging.py
+++ b/typesafe_conductr_cli/conduct_logging.py
@@ -34,6 +34,8 @@ def handle_http_error(func):
             return func(*args, **kwargs)
         except HTTPError as err:
             error("{} {}", err.response.status_code, err.response.reason)
+            if err.response.text != "":
+                error(err.response.text)
 
     # Do not change the wrapped function name,
     # so argparse configuration can be tested.

--- a/typesafe_conductr_cli/conduct_run.py
+++ b/typesafe_conductr_cli/conduct_run.py
@@ -19,6 +19,6 @@ def run(args):
     response_json = json.loads(response.text)
     bundleId = response_json['bundleId']
 
-    print("Bundle run request sent.")
-    print("Stop bundle with: conduct stop{} {}".format(args.cli_parameters, bundleId))
-    print("Print ConductR info with: conduct info{}".format(args.cli_parameters))
+    print('Bundle run request sent.')
+    print('Stop bundle with: conduct stop{} {}'.format(args.cli_parameters, bundleId))
+    print('Print ConductR info with: conduct info{}'.format(args.cli_parameters))

--- a/typesafe_conductr_cli/conduct_stop.py
+++ b/typesafe_conductr_cli/conduct_stop.py
@@ -19,6 +19,6 @@ def stop(args):
     response_json = json.loads(response.text)
     bundleId = response_json['bundleId']
 
-    print("Bundle stop request sent.")
-    print("Unload bundle with: conduct unload{} {}".format(args.cli_parameters, bundleId))
-    print("Print ConductR info with: conduct info{}".format(args.cli_parameters))
+    print('Bundle stop request sent.')
+    print('Unload bundle with: conduct unload{} {}'.format(args.cli_parameters, bundleId))
+    print('Print ConductR info with: conduct info{}'.format(args.cli_parameters))

--- a/typesafe_conductr_cli/conduct_unload.py
+++ b/typesafe_conductr_cli/conduct_unload.py
@@ -15,5 +15,5 @@ def unload(args):
     if (args.verbose):
         conduct_logging.pretty_json(response.text)
 
-    print("Bundle unload request sent.")
-    print("Print ConductR info with: conduct info{}".format(args.cli_parameters))
+    print('Bundle unload request sent.')
+    print('Print ConductR info with: conduct info{}'.format(args.cli_parameters))

--- a/typesafe_conductr_cli/shazar.py
+++ b/typesafe_conductr_cli/shazar.py
@@ -20,19 +20,19 @@ def run():
 
 def build_parser():
     parser = argparse.ArgumentParser(
-        description="Package a bundle directory or bundle configuration file"
+        description='Package a bundle directory or bundle configuration file'
     )
     parser.add_argument('--output-dir',
                         default='.',
                         help="The optional output directory, defaults to '.'")
     parser.add_argument('source',
-                        help="Path to a bundle directory or bundle configuration file")
+                        help='Path to a bundle directory or bundle configuration file')
     parser.set_defaults(func=shazar)
     return parser
 
 
 def shazar(args):
-    source_base_name = os.path.basename(args.source.rstrip("\\/"))
+    source_base_name = os.path.basename(args.source.rstrip('\\/'))
     temp_file = tempfile.NamedTemporaryFile(suffix='.zip', delete=False).name
 
     with zipfile.ZipFile(temp_file, 'w') as zip_file:
@@ -47,7 +47,7 @@ def shazar(args):
 
     dest = shutil.move(
         temp_file,
-        os.path.join(args.output_dir, "{}-{}.zip".format(source_base_name, create_digest(temp_file)))
+        os.path.join(args.output_dir, '{}-{}.zip'.format(source_base_name, create_digest(temp_file)))
     )
     print('Created digested ZIP archive at {}'.format(dest))
 

--- a/typesafe_conductr_cli/test/cli_test_case.py
+++ b/typesafe_conductr_cli/test/cli_test_case.py
@@ -14,8 +14,8 @@ class CliTestCase():
 
     def respond_with(self, status_code=200, text=""):
         reasons = {
-            200: "OK",
-            404: "Not Found"
+            200: 'OK',
+            404: 'Not Found'
         }
 
         response_mock = MagicMock(
@@ -36,7 +36,7 @@ class CliTestCase():
         return MagicMock(side_effect=ConnectionError(reason))
 
     def output(self, logger):
-        return "".join([args[0].rstrip(" ") for name, args, kwargs in logger.method_calls])
+        return ''.join([args[0].rstrip(' ') for name, args, kwargs in logger.method_calls])
 
     def strip_margin(self, string, marginChar='|'):
-        return "\n".join([line[line.index(marginChar) + 1:] for line in string.split("\n")])
+        return '\n'.join([line[line.index(marginChar) + 1:] for line in string.split('\n')])

--- a/typesafe_conductr_cli/test/cli_test_case.py
+++ b/typesafe_conductr_cli/test/cli_test_case.py
@@ -39,4 +39,4 @@ class CliTestCase():
         return "".join([args[0].rstrip(" ") for name, args, kwargs in logger.method_calls])
 
     def strip_margin(self, string, marginChar='|'):
-        return "\n".join([line[line.index(marginChar)+1:] for line in string.split("\n")])
+        return "\n".join([line[line.index(marginChar) + 1:] for line in string.split("\n")])

--- a/typesafe_conductr_cli/test/test_conduct.py
+++ b/typesafe_conductr_cli/test/test_conduct.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
-from unittest.mock import patch, MagicMock
 from typesafe_conductr_cli.conduct import build_parser, get_cli_parameters
 from argparse import Namespace
+
 
 class TestConduct(TestCase):
 
@@ -21,7 +21,7 @@ class TestConduct(TestCase):
         self.assertEqual(args.verbose, False)
 
     def test_parser_load(self):
-        args = self.parser.parse_args("load --host 127.0.1.1 --port 9999 -v --nr-of-cpus 2 --memory 100 --disk-space 200 --roles role1 role2 -- path-to-bundle path-to-conf".split())
+        args = self.parser.parse_args("load --host 127.0.1.1 --port 9999 -v --nr-of-cpus 2 --memory 100 --disk-space 200 --name test-bundle --roles role1 role2 -- path-to-bundle path-to-conf".split())
 
         self.assertEqual(args.func.__name__, "load")
         self.assertEqual(args.host, "127.0.1.1")
@@ -31,6 +31,7 @@ class TestConduct(TestCase):
         self.assertEqual(args.memory, 100)
         self.assertEqual(args.disk_space, 200)
         self.assertEqual(args.roles, ["role1", "role2"])
+        self.assertEqual(args.bundle_name, "test-bundle")
         self.assertEqual(args.bundle, "path-to-bundle")
         self.assertEqual(args.configuration, "path-to-conf")
 

--- a/typesafe_conductr_cli/test/test_conduct.py
+++ b/typesafe_conductr_cli/test/test_conduct.py
@@ -8,70 +8,70 @@ class TestConduct(TestCase):
     parser = build_parser()
 
     def test_parser_version(self):
-        args = self.parser.parse_args("version".split())
+        args = self.parser.parse_args('version'.split())
 
-        self.assertEqual(args.func.__name__, "version")
+        self.assertEqual(args.func.__name__, 'version')
 
     def test_parser_info(self):
-        args = self.parser.parse_args("info --host 127.0.1.1 --port 9999".split())
+        args = self.parser.parse_args('info --host 127.0.1.1 --port 9999'.split())
 
-        self.assertEqual(args.func.__name__, "info")
-        self.assertEqual(args.host, "127.0.1.1")
+        self.assertEqual(args.func.__name__, 'info')
+        self.assertEqual(args.host, '127.0.1.1')
         self.assertEqual(args.port, 9999)
         self.assertEqual(args.verbose, False)
 
     def test_parser_load(self):
-        args = self.parser.parse_args("load --host 127.0.1.1 --port 9999 -v --nr-of-cpus 2 --memory 100 --disk-space 200 --name test-bundle --roles role1 role2 -- path-to-bundle path-to-conf".split())
+        args = self.parser.parse_args('load --host 127.0.1.1 --port 9999 -v --nr-of-cpus 2 --memory 100 --disk-space 200 --name test-bundle --roles role1 role2 -- path-to-bundle path-to-conf'.split())
 
-        self.assertEqual(args.func.__name__, "load")
-        self.assertEqual(args.host, "127.0.1.1")
+        self.assertEqual(args.func.__name__, 'load')
+        self.assertEqual(args.host, '127.0.1.1')
         self.assertEqual(args.port, 9999)
         self.assertEqual(args.verbose, True)
         self.assertEqual(args.nr_of_cpus, 2)
         self.assertEqual(args.memory, 100)
         self.assertEqual(args.disk_space, 200)
-        self.assertEqual(args.roles, ["role1", "role2"])
-        self.assertEqual(args.bundle_name, "test-bundle")
-        self.assertEqual(args.bundle, "path-to-bundle")
-        self.assertEqual(args.configuration, "path-to-conf")
+        self.assertEqual(args.roles, ['role1', 'role2'])
+        self.assertEqual(args.bundle_name, 'test-bundle')
+        self.assertEqual(args.bundle, 'path-to-bundle')
+        self.assertEqual(args.configuration, 'path-to-conf')
 
     def test_parser_run(self):
-        args = self.parser.parse_args("run --host 127.0.1.1 --port 9999 --scale 5 path-to-bundle".split())
+        args = self.parser.parse_args('run --host 127.0.1.1 --port 9999 --scale 5 path-to-bundle'.split())
 
-        self.assertEqual(args.func.__name__, "run")
-        self.assertEqual(args.host, "127.0.1.1")
+        self.assertEqual(args.func.__name__, 'run')
+        self.assertEqual(args.host, '127.0.1.1')
         self.assertEqual(args.port, 9999)
         self.assertEqual(args.verbose, False)
         self.assertEqual(args.scale, 5)
-        self.assertEqual(args.bundle, "path-to-bundle")
+        self.assertEqual(args.bundle, 'path-to-bundle')
 
     def test_parser_stop(self):
-        args = self.parser.parse_args("stop --host 127.0.1.1 --port 9999 path-to-bundle".split())
+        args = self.parser.parse_args('stop --host 127.0.1.1 --port 9999 path-to-bundle'.split())
 
-        self.assertEqual(args.func.__name__, "stop")
-        self.assertEqual(args.host, "127.0.1.1")
+        self.assertEqual(args.func.__name__, 'stop')
+        self.assertEqual(args.host, '127.0.1.1')
         self.assertEqual(args.port, 9999)
         self.assertEqual(args.verbose, False)
-        self.assertEqual(args.bundle, "path-to-bundle")
+        self.assertEqual(args.bundle, 'path-to-bundle')
 
     def test_parser_unload(self):
-        args = self.parser.parse_args("unload --host 127.0.1.1 --port 9999 path-to-bundle".split())
+        args = self.parser.parse_args('unload --host 127.0.1.1 --port 9999 path-to-bundle'.split())
 
-        self.assertEqual(args.func.__name__, "unload")
-        self.assertEqual(args.host, "127.0.1.1")
+        self.assertEqual(args.func.__name__, 'unload')
+        self.assertEqual(args.host, '127.0.1.1')
         self.assertEqual(args.port, 9999)
         self.assertEqual(args.verbose, False)
-        self.assertEqual(args.bundle, "path-to-bundle")
+        self.assertEqual(args.bundle, 'path-to-bundle')
 
     def test_get_cli_parameters(self):
-        args = Namespace(host="127.0.0.1", port=9005)
-        self.assertEqual(get_cli_parameters(args), "")
+        args = Namespace(host='127.0.0.1', port=9005)
+        self.assertEqual(get_cli_parameters(args), '')
 
-        args = Namespace(host="127.0.1.1", port=9005)
-        self.assertEqual(get_cli_parameters(args), " --host 127.0.1.1")
+        args = Namespace(host='127.0.1.1', port=9005)
+        self.assertEqual(get_cli_parameters(args), ' --host 127.0.1.1')
 
-        args = Namespace(host="127.0.0.1", port=9006)
-        self.assertEqual(get_cli_parameters(args), " --port 9006")
+        args = Namespace(host='127.0.0.1', port=9006)
+        self.assertEqual(get_cli_parameters(args), ' --port 9006')
 
-        args = Namespace(host="127.0.1.1", port=9006)
-        self.assertEqual(get_cli_parameters(args), " --host 127.0.1.1 --port 9006")
+        args = Namespace(host='127.0.1.1', port=9006)
+        self.assertEqual(get_cli_parameters(args), ' --host 127.0.1.1 --port 9006')

--- a/typesafe_conductr_cli/test/test_conduct_info.py
+++ b/typesafe_conductr_cli/test/test_conduct_info.py
@@ -7,15 +7,15 @@ from typesafe_conductr_cli import conduct_info
 class TestConductInfoCommand(TestCase, CliTestCase):
 
     default_args = {
-        "host": "127.0.0.1",
-        "port": 9005,
-        "verbose": False
+        'host': '127.0.0.1',
+        'port': 9005,
+        'verbose': False
     }
 
-    default_url = "http://127.0.0.1:9005/bundles"
+    default_url = 'http://127.0.0.1:9005/bundles'
 
     def test_no_bundles(self):
-        http_method = self.respond_with(text="[]")
+        http_method = self.respond_with(text='[]')
         stdout = MagicMock()
 
         with patch('requests.get', http_method), patch('sys.stdout', stdout):
@@ -102,7 +102,7 @@ class TestConductInfoCommand(TestCase, CliTestCase):
 
         with patch('requests.get', http_method), patch('sys.stdout', stdout):
             args = self.default_args.copy()
-            args.update({"verbose": True})
+            args.update({'verbose': True})
             conduct_info.info(MagicMock(**args))
 
         http_method.assert_called_with(self.default_url)
@@ -150,7 +150,7 @@ class TestConductInfoCommand(TestCase, CliTestCase):
             self.output(stdout))
 
     def test_failure_invalid_address(self):
-        http_method = self.raise_connection_error("test reason")
+        http_method = self.raise_connection_error('test reason')
         stderr = MagicMock()
 
         with patch('requests.get', http_method), patch('sys.stderr', stderr):
@@ -158,5 +158,5 @@ class TestConductInfoCommand(TestCase, CliTestCase):
 
         http_method.assert_called_with(self.default_url)
         self.assertEqual(
-            self.default_connection_error.format(self.default_args["host"], self.default_args["port"]),
+            self.default_connection_error.format(self.default_args['host'], self.default_args['port']),
             self.output(stderr))

--- a/typesafe_conductr_cli/test/test_conduct_info.py
+++ b/typesafe_conductr_cli/test/test_conduct_info.py
@@ -1,4 +1,3 @@
-import unittest
 from unittest import TestCase
 from unittest.mock import patch, MagicMock
 from typesafe_conductr_cli.test.cli_test_case import CliTestCase
@@ -24,13 +23,14 @@ class TestConductInfoCommand(TestCase, CliTestCase):
 
         http_method.assert_called_with(self.default_url)
         self.assertEqual(
-            self.strip_margin("""|ID  #REP  #STR  #RUN
+            self.strip_margin("""|ID  NAME  #REP  #STR  #RUN
                                  |"""),
             self.output(stdout))
 
     def test_stopped_bundle(self):
         http_method = self.respond_with(text="""[
             {
+                "attributes": { "bundleName": "test-bundle" },
                 "bundleId": "45e0c477d3e5ea92aa8d85c0d8f3e25c",
                 "bundleExecutions": [],
                 "bundleInstallations": [1]
@@ -43,24 +43,27 @@ class TestConductInfoCommand(TestCase, CliTestCase):
 
         http_method.assert_called_with(self.default_url)
         self.assertEqual(
-            self.strip_margin("""|ID                                #REP  #STR  #RUN
-                                 |45e0c477d3e5ea92aa8d85c0d8f3e25c  1     0     0
+            self.strip_margin("""|ID                                NAME         #REP  #STR  #RUN
+                                 |45e0c477d3e5ea92aa8d85c0d8f3e25c  test-bundle  1     0     0
                                  |"""),
             self.output(stdout))
 
     def test_one_running_one_starting_one_stopped(self):
         http_method = self.respond_with(text="""[
             {
+                "attributes": { "bundleName": "test-bundle-1" },
                 "bundleId": "running",
                 "bundleExecutions": [{"isStarted": true}],
                 "bundleInstallations": [1]
             },
             {
+                "attributes": { "bundleName": "test-bundle-2" },
                 "bundleId": "starting",
                 "bundleExecutions": [{"isStarted": false}],
                 "bundleInstallations": [1]
             },
             {
+                "attributes": { "bundleName": "test-bundle-3" },
                 "bundleId": "stopped",
                 "bundleExecutions": [],
                 "bundleInstallations": [1]
@@ -73,21 +76,23 @@ class TestConductInfoCommand(TestCase, CliTestCase):
 
         http_method.assert_called_with(self.default_url)
         self.assertEqual(
-            self.strip_margin("""|ID        #REP  #STR  #RUN
-                                 |running   1     0     1
-                                 |starting  1     1     0
-                                 |stopped   1     0     0
+            self.strip_margin("""|ID        NAME           #REP  #STR  #RUN
+                                 |running   test-bundle-1  1     0     1
+                                 |starting  test-bundle-2  1     1     0
+                                 |stopped   test-bundle-3  1     0     0
                                  |"""),
             self.output(stdout))
 
     def test_one_running_one_stopped_verbose(self):
         http_method = self.respond_with(text="""[
             {
+                "attributes": { "bundleName": "test-bundle-1" },
                 "bundleId": "45e0c477d3e5ea92aa8d85c0d8f3e25c",
                 "bundleExecutions": [{"isStarted": true},{"isStarted": true},{"isStarted": true}],
                 "bundleInstallations": [1,2,3]
             },
             {
+                "attributes": { "bundleName": "test-bundle-2" },
                 "bundleId": "c52e3f8d0c58d8aa29ae5e3d774c0e54",
                 "bundleExecutions": [],
                 "bundleInstallations": [1,2,3]
@@ -104,6 +109,9 @@ class TestConductInfoCommand(TestCase, CliTestCase):
         self.assertEqual(
             self.strip_margin("""|[
                                  |  {
+                                 |    "attributes": {
+                                 |      "bundleName": "test-bundle-1"
+                                 |    },
                                  |    "bundleExecutions": [
                                  |      {
                                  |        "isStarted": true
@@ -123,6 +131,9 @@ class TestConductInfoCommand(TestCase, CliTestCase):
                                  |    ]
                                  |  },
                                  |  {
+                                 |    "attributes": {
+                                 |      "bundleName": "test-bundle-2"
+                                 |    },
                                  |    "bundleExecutions": [],
                                  |    "bundleId": "c52e3f8d0c58d8aa29ae5e3d774c0e54",
                                  |    "bundleInstallations": [
@@ -132,9 +143,9 @@ class TestConductInfoCommand(TestCase, CliTestCase):
                                  |    ]
                                  |  }
                                  |]
-                                 |ID                                #REP  #STR  #RUN
-                                 |45e0c477d3e5ea92aa8d85c0d8f3e25c  3     0     3
-                                 |c52e3f8d0c58d8aa29ae5e3d774c0e54  3     0     0
+                                 |ID                                NAME           #REP  #STR  #RUN
+                                 |45e0c477d3e5ea92aa8d85c0d8f3e25c  test-bundle-1  3     0     3
+                                 |c52e3f8d0c58d8aa29ae5e3d774c0e54  test-bundle-2  3     0     0
                                  |"""),
             self.output(stdout))
 
@@ -149,6 +160,3 @@ class TestConductInfoCommand(TestCase, CliTestCase):
         self.assertEqual(
             self.default_connection_error.format(self.default_args["host"], self.default_args["port"]),
             self.output(stderr))
-
-if __name__ == '__main__':
-    unittest.main()

--- a/typesafe_conductr_cli/test/test_conduct_load.py
+++ b/typesafe_conductr_cli/test/test_conduct_load.py
@@ -14,20 +14,20 @@ class TestConductLoadCommand(TestCase, CliTestCase):
                                     |""")
 
     default_args = {
-        "host": "127.0.0.1",
-        "port": 9005,
-        "verbose": False,
-        "cli_parameters": "",
-        "nr_of_cpus": 1,
-        "memory": 200,
-        "disk_space": False,
-        "roles": ["role1, role2"],
-        "bundle_name": None,
-        "bundle": "bundle-abc123.tgz",
-        "configuration": None
+        'host': '127.0.0.1',
+        'port': 9005,
+        'verbose': False,
+        'cli_parameters': '',
+        'nr_of_cpus': 1,
+        'memory': 200,
+        'disk_space': False,
+        'roles': ['role1, role2'],
+        'bundle_name': None,
+        'bundle': 'bundle-abc123.tgz',
+        'configuration': None
     }
 
-    default_url = "http://127.0.0.1:9005/bundles"
+    default_url = 'http://127.0.0.1:9005/bundles'
 
     default_files = [
         ('nrOfCpus', '1'),
@@ -46,7 +46,7 @@ class TestConductLoadCommand(TestCase, CliTestCase):
 
     @property
     def default_output(self):
-        return self.strip_margin(self.output_template.format(*[""] * 3))
+        return self.strip_margin(self.output_template.format(*[''] * 3))
 
     def test_success(self):
         http_method = self.respond_with(200, self.default_response)
@@ -56,7 +56,7 @@ class TestConductLoadCommand(TestCase, CliTestCase):
         with patch('requests.post', http_method), patch('sys.stdout', stdout), patch('builtins.open', openMock):
             conduct_load.load(MagicMock(**self.default_args))
 
-        openMock.assert_called_with("bundle-abc123.tgz", "rb")
+        openMock.assert_called_with('bundle-abc123.tgz', 'rb')
         http_method.assert_called_with(self.default_url, files=self.default_files)
 
         self.assertEqual(self.default_output, self.output(stdout))
@@ -68,10 +68,10 @@ class TestConductLoadCommand(TestCase, CliTestCase):
 
         with patch('requests.post', http_method), patch('sys.stdout', stdout), patch('builtins.open', openMock):
             args = self.default_args.copy()
-            args.update({"verbose": True})
+            args.update({'verbose': True})
             conduct_load.load(MagicMock(**args))
 
-        openMock.assert_called_with("bundle-abc123.tgz", "rb")
+        openMock.assert_called_with('bundle-abc123.tgz', 'rb')
         http_method.assert_called_with(self.default_url, files=self.default_files)
 
         self.assertEqual(self.default_response + self.default_output, self.output(stdout))
@@ -81,13 +81,13 @@ class TestConductLoadCommand(TestCase, CliTestCase):
         stdout = MagicMock()
         openMock = MagicMock(return_value=1)
 
-        cli_parameters = " --host 127.0.1.1 --port 9006"
+        cli_parameters = ' --host 127.0.1.1 --port 9006'
         with patch('requests.post', http_method), patch('sys.stdout', stdout), patch('builtins.open', openMock):
             args = self.default_args.copy()
-            args.update({"cli_parameters": cli_parameters})
+            args.update({'cli_parameters': cli_parameters})
             conduct_load.load(MagicMock(**args))
 
-        openMock.assert_called_with("bundle-abc123.tgz", "rb")
+        openMock.assert_called_with('bundle-abc123.tgz', 'rb')
         http_method.assert_called_with(self.default_url, files=self.default_files)
 
         self.assertEqual(
@@ -101,12 +101,12 @@ class TestConductLoadCommand(TestCase, CliTestCase):
 
         with patch('requests.post', http_method), patch('sys.stdout', stdout), patch('builtins.open', openMock):
             args = self.default_args.copy()
-            args.update({"configuration": "configuration.tgz"})
+            args.update({'configuration': 'configuration.tgz'})
             conduct_load.load(MagicMock(**args))
 
         self.assertEqual(
             openMock.call_args_list,
-            [call("bundle-abc123.tgz", "rb"), call("configuration.tgz", "rb")]
+            [call('bundle-abc123.tgz', 'rb'), call('configuration.tgz', 'rb')]
         )
 
         http_method.assert_called_with(self.default_url, files=self.default_files + [('configuration', 1)])
@@ -120,10 +120,10 @@ class TestConductLoadCommand(TestCase, CliTestCase):
 
         with patch('requests.post', http_method), patch('sys.stdout', stdout), patch('builtins.open', openMock):
             args = self.default_args.copy()
-            args.update({"bundle_name": "test-name"})
+            args.update({'bundle_name': 'test-name'})
             conduct_load.load(MagicMock(**args))
 
-        openMock.assert_called_with("bundle-abc123.tgz", "rb")
+        openMock.assert_called_with('bundle-abc123.tgz', 'rb')
         http_method.assert_called_with(self.default_url, files=[(file, value if file != 'bundleName' else 'test-name') for file, value in self.default_files])
 
         self.assertEqual(self.default_output, self.output(stdout))
@@ -136,7 +136,7 @@ class TestConductLoadCommand(TestCase, CliTestCase):
         with patch('requests.post', http_method), patch('sys.stderr', stderr), patch('builtins.open', openMock):
             conduct_load.load(MagicMock(**self.default_args))
 
-        openMock.assert_called_with("bundle-abc123.tgz", "rb")
+        openMock.assert_called_with('bundle-abc123.tgz', 'rb')
         http_method.assert_called_with(self.default_url, files=self.default_files)
 
         self.assertEqual(
@@ -145,16 +145,16 @@ class TestConductLoadCommand(TestCase, CliTestCase):
             self.output(stderr))
 
     def test_failure_invalid_address(self):
-        http_method = self.raise_connection_error("test reason")
+        http_method = self.raise_connection_error('test reason')
         stderr = MagicMock()
         openMock = MagicMock(return_value=1)
 
         with patch('requests.post', http_method), patch('sys.stderr', stderr), patch('builtins.open', openMock):
             conduct_load.load(MagicMock(**self.default_args))
 
-        openMock.assert_called_with("bundle-abc123.tgz", "rb")
+        openMock.assert_called_with('bundle-abc123.tgz', 'rb')
         http_method.assert_called_with(self.default_url, files=self.default_files)
 
         self.assertEqual(
-            self.default_connection_error.format(self.default_args["host"], self.default_args["port"]),
+            self.default_connection_error.format(self.default_args['host'], self.default_args['port']),
             self.output(stderr))

--- a/typesafe_conductr_cli/test/test_conduct_load.py
+++ b/typesafe_conductr_cli/test/test_conduct_load.py
@@ -13,6 +13,8 @@ class TestConductLoadCommand(TestCase, CliTestCase):
                                     |}
                                     |""")
 
+    bundle_file = 'bundle-abc123.zip'
+
     default_args = {
         'host': '127.0.0.1',
         'port': 9005,
@@ -23,7 +25,7 @@ class TestConductLoadCommand(TestCase, CliTestCase):
         'disk_space': False,
         'roles': ['role1, role2'],
         'bundle_name': None,
-        'bundle': 'bundle-abc123.tgz',
+        'bundle': bundle_file,
         'configuration': None
     }
 
@@ -56,7 +58,7 @@ class TestConductLoadCommand(TestCase, CliTestCase):
         with patch('requests.post', http_method), patch('sys.stdout', stdout), patch('builtins.open', openMock):
             conduct_load.load(MagicMock(**self.default_args))
 
-        openMock.assert_called_with('bundle-abc123.tgz', 'rb')
+        openMock.assert_called_with(self.bundle_file, 'rb')
         http_method.assert_called_with(self.default_url, files=self.default_files)
 
         self.assertEqual(self.default_output, self.output(stdout))
@@ -71,7 +73,7 @@ class TestConductLoadCommand(TestCase, CliTestCase):
             args.update({'verbose': True})
             conduct_load.load(MagicMock(**args))
 
-        openMock.assert_called_with('bundle-abc123.tgz', 'rb')
+        openMock.assert_called_with(self.bundle_file, 'rb')
         http_method.assert_called_with(self.default_url, files=self.default_files)
 
         self.assertEqual(self.default_response + self.default_output, self.output(stdout))
@@ -87,7 +89,7 @@ class TestConductLoadCommand(TestCase, CliTestCase):
             args.update({'cli_parameters': cli_parameters})
             conduct_load.load(MagicMock(**args))
 
-        openMock.assert_called_with('bundle-abc123.tgz', 'rb')
+        openMock.assert_called_with(self.bundle_file, 'rb')
         http_method.assert_called_with(self.default_url, files=self.default_files)
 
         self.assertEqual(
@@ -106,7 +108,7 @@ class TestConductLoadCommand(TestCase, CliTestCase):
 
         self.assertEqual(
             openMock.call_args_list,
-            [call('bundle-abc123.tgz', 'rb'), call('configuration.tgz', 'rb')]
+            [call(self.bundle_file, 'rb'), call('configuration.tgz', 'rb')]
         )
 
         http_method.assert_called_with(self.default_url, files=self.default_files + [('configuration', 1)])
@@ -123,7 +125,7 @@ class TestConductLoadCommand(TestCase, CliTestCase):
             args.update({'bundle_name': 'test-name'})
             conduct_load.load(MagicMock(**args))
 
-        openMock.assert_called_with('bundle-abc123.tgz', 'rb')
+        openMock.assert_called_with(self.bundle_file, 'rb')
         http_method.assert_called_with(self.default_url, files=[(file, value if file != 'bundleName' else 'test-name') for file, value in self.default_files])
 
         self.assertEqual(self.default_output, self.output(stdout))
@@ -136,7 +138,7 @@ class TestConductLoadCommand(TestCase, CliTestCase):
         with patch('requests.post', http_method), patch('sys.stderr', stderr), patch('builtins.open', openMock):
             conduct_load.load(MagicMock(**self.default_args))
 
-        openMock.assert_called_with('bundle-abc123.tgz', 'rb')
+        openMock.assert_called_with(self.bundle_file, 'rb')
         http_method.assert_called_with(self.default_url, files=self.default_files)
 
         self.assertEqual(
@@ -152,9 +154,14 @@ class TestConductLoadCommand(TestCase, CliTestCase):
         with patch('requests.post', http_method), patch('sys.stderr', stderr), patch('builtins.open', openMock):
             conduct_load.load(MagicMock(**self.default_args))
 
-        openMock.assert_called_with('bundle-abc123.tgz', 'rb')
+        openMock.assert_called_with(self.bundle_file, 'rb')
         http_method.assert_called_with(self.default_url, files=self.default_files)
 
         self.assertEqual(
             self.default_connection_error.format(self.default_args['host'], self.default_args['port']),
             self.output(stderr))
+
+    def test_path_to_bundle_name(self):
+        self.assertEqual(conduct_load.path_to_bundle_name('path/to/bundle-5ca1ab1e.zip'), 'bundle')
+        self.assertEqual(conduct_load.path_to_bundle_name('path/to/bundle.zip'), 'bundle')
+        self.assertEqual(conduct_load.path_to_bundle_name('path/to/bundle-1.0.0-M2.zip'), 'bundle-1.0.0-M2')

--- a/typesafe_conductr_cli/test/test_conduct_run.py
+++ b/typesafe_conductr_cli/test/test_conduct_run.py
@@ -14,15 +14,15 @@ class TestConductRunCommand(TestCase, CliTestCase):
                                     |""")
 
     default_args = {
-        "host": "127.0.0.1",
-        "port": 9005,
-        "verbose": False,
-        "cli_parameters": "",
-        "bundle": "45e0c477d3e5ea92aa8d85c0d8f3e25c",
-        "scale": 3
+        'host': '127.0.0.1',
+        'port': 9005,
+        'verbose': False,
+        'cli_parameters': '',
+        'bundle': '45e0c477d3e5ea92aa8d85c0d8f3e25c',
+        'scale': 3
     }
 
-    default_url = "http://127.0.0.1:9005/bundles/45e0c477d3e5ea92aa8d85c0d8f3e25c?scale=3"
+    default_url = 'http://127.0.0.1:9005/bundles/45e0c477d3e5ea92aa8d85c0d8f3e25c?scale=3'
 
     output_template = """|Bundle run request sent.
                          |Stop bundle with: conduct stop{} 45e0c477d3e5ea92aa8d85c0d8f3e25c
@@ -31,7 +31,7 @@ class TestConductRunCommand(TestCase, CliTestCase):
 
     @property
     def default_output(self):
-        return self.strip_margin(self.output_template.format(*[""] * 2))
+        return self.strip_margin(self.output_template.format(*[''] * 2))
 
     def test_success(self):
         http_method = self.respond_with(200, self.default_response)
@@ -50,7 +50,7 @@ class TestConductRunCommand(TestCase, CliTestCase):
 
         with patch('requests.put', http_method), patch('sys.stdout', stdout):
             args = self.default_args.copy()
-            args.update({"verbose": True})
+            args.update({'verbose': True})
             conduct_run.run(MagicMock(**args))
 
         http_method.assert_called_with(self.default_url)
@@ -61,10 +61,10 @@ class TestConductRunCommand(TestCase, CliTestCase):
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
 
-        cli_parameters = " --host 127.0.1.1 --port 9006"
+        cli_parameters = ' --host 127.0.1.1 --port 9006'
         with patch('requests.put', http_method), patch('sys.stdout', stdout):
             args = self.default_args.copy()
-            args.update({"cli_parameters": cli_parameters})
+            args.update({'cli_parameters': cli_parameters})
             conduct_run.run(MagicMock(**args))
 
         http_method.assert_called_with(self.default_url)
@@ -88,7 +88,7 @@ class TestConductRunCommand(TestCase, CliTestCase):
             self.output(stderr))
 
     def test_failure_invalid_address(self):
-        http_method = self.raise_connection_error("test reason")
+        http_method = self.raise_connection_error('test reason')
         stderr = MagicMock()
 
         with patch('requests.put', http_method), patch('sys.stderr', stderr):
@@ -97,5 +97,5 @@ class TestConductRunCommand(TestCase, CliTestCase):
         http_method.assert_called_with(self.default_url)
 
         self.assertEqual(
-            self.default_connection_error.format(self.default_args["host"], self.default_args["port"]),
+            self.default_connection_error.format(self.default_args['host'], self.default_args['port']),
             self.output(stderr))

--- a/typesafe_conductr_cli/test/test_conduct_run.py
+++ b/typesafe_conductr_cli/test/test_conduct_run.py
@@ -31,7 +31,7 @@ class TestConductRunCommand(TestCase, CliTestCase):
 
     @property
     def default_output(self):
-        return self.strip_margin(self.output_template.format(*[""]*2))
+        return self.strip_margin(self.output_template.format(*[""] * 2))
 
     def test_success(self):
         http_method = self.respond_with(200, self.default_response)
@@ -70,7 +70,7 @@ class TestConductRunCommand(TestCase, CliTestCase):
         http_method.assert_called_with(self.default_url)
 
         self.assertEqual(
-            self.strip_margin(self.output_template.format(*[cli_parameters]*2)),
+            self.strip_margin(self.output_template.format(*[cli_parameters] * 2)),
             self.output(stdout))
 
     def test_failure(self):
@@ -99,6 +99,3 @@ class TestConductRunCommand(TestCase, CliTestCase):
         self.assertEqual(
             self.default_connection_error.format(self.default_args["host"], self.default_args["port"]),
             self.output(stderr))
-
-if __name__ == '__main__':
-    unittest.main()

--- a/typesafe_conductr_cli/test/test_conduct_stop.py
+++ b/typesafe_conductr_cli/test/test_conduct_stop.py
@@ -30,7 +30,7 @@ class TestConductStopCommand(TestCase, CliTestCase):
 
     @property
     def default_output(self):
-        return self.strip_margin(self.output_template.format(*[""]*2))
+        return self.strip_margin(self.output_template.format(*[""] * 2))
 
     def test_success(self):
         http_method = self.respond_with(200, self.default_response)
@@ -69,7 +69,7 @@ class TestConductStopCommand(TestCase, CliTestCase):
         http_method.assert_called_with(self.default_url)
 
         self.assertEqual(
-            self.strip_margin(self.output_template.format(*[cli_parameters]*2)),
+            self.strip_margin(self.output_template.format(*[cli_parameters] * 2)),
             self.output(stdout))
 
     def test_failure(self):
@@ -98,6 +98,3 @@ class TestConductStopCommand(TestCase, CliTestCase):
         self.assertEqual(
             self.default_connection_error.format(self.default_args["host"], self.default_args["port"]),
             self.output(stderr))
-
-if __name__ == '__main__':
-    unittest.main()

--- a/typesafe_conductr_cli/test/test_conduct_stop.py
+++ b/typesafe_conductr_cli/test/test_conduct_stop.py
@@ -14,14 +14,14 @@ class TestConductStopCommand(TestCase, CliTestCase):
                                     |""")
 
     default_args = {
-        "host": "127.0.0.1",
-        "port": 9005,
-        "verbose": False,
-        "cli_parameters": "",
-        "bundle": "45e0c477d3e5ea92aa8d85c0d8f3e25c"
+        'host': '127.0.0.1',
+        'port': 9005,
+        'verbose': False,
+        'cli_parameters': '',
+        'bundle': '45e0c477d3e5ea92aa8d85c0d8f3e25c'
     }
 
-    default_url = "http://127.0.0.1:9005/bundles/45e0c477d3e5ea92aa8d85c0d8f3e25c?scale=0"
+    default_url = 'http://127.0.0.1:9005/bundles/45e0c477d3e5ea92aa8d85c0d8f3e25c?scale=0'
 
     output_template = """|Bundle stop request sent.
                          |Unload bundle with: conduct unload{} 45e0c477d3e5ea92aa8d85c0d8f3e25c
@@ -30,7 +30,7 @@ class TestConductStopCommand(TestCase, CliTestCase):
 
     @property
     def default_output(self):
-        return self.strip_margin(self.output_template.format(*[""] * 2))
+        return self.strip_margin(self.output_template.format(*[''] * 2))
 
     def test_success(self):
         http_method = self.respond_with(200, self.default_response)
@@ -49,7 +49,7 @@ class TestConductStopCommand(TestCase, CliTestCase):
 
         with patch('requests.put', http_method), patch('sys.stdout', stdout):
             args = self.default_args.copy()
-            args.update({"verbose": True})
+            args.update({'verbose': True})
             conduct_stop.stop(MagicMock(**args))
 
         http_method.assert_called_with(self.default_url)
@@ -60,10 +60,10 @@ class TestConductStopCommand(TestCase, CliTestCase):
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
 
-        cli_parameters = " --host 127.0.1.1 --port 9006"
+        cli_parameters = ' --host 127.0.1.1 --port 9006'
         with patch('requests.put', http_method), patch('sys.stdout', stdout):
             args = self.default_args.copy()
-            args.update({"cli_parameters": cli_parameters})
+            args.update({'cli_parameters': cli_parameters})
             conduct_stop.stop(MagicMock(**args))
 
         http_method.assert_called_with(self.default_url)
@@ -87,7 +87,7 @@ class TestConductStopCommand(TestCase, CliTestCase):
             self.output(stderr))
 
     def test_failure_invalid_address(self):
-        http_method = self.raise_connection_error("test reason")
+        http_method = self.raise_connection_error('test reason')
         stderr = MagicMock()
 
         with patch('requests.put', http_method), patch('sys.stderr', stderr):
@@ -96,5 +96,5 @@ class TestConductStopCommand(TestCase, CliTestCase):
         http_method.assert_called_with(self.default_url)
 
         self.assertEqual(
-            self.default_connection_error.format(self.default_args["host"], self.default_args["port"]),
+            self.default_connection_error.format(self.default_args['host'], self.default_args['port']),
             self.output(stderr))

--- a/typesafe_conductr_cli/test/test_conduct_unload.py
+++ b/typesafe_conductr_cli/test/test_conduct_unload.py
@@ -14,14 +14,14 @@ class TestConductUnloadCommand(TestCase, CliTestCase):
                                     |""")
 
     default_args = {
-        "host": "127.0.0.1",
-        "port": 9005,
-        "verbose": False,
-        "cli_parameters": "",
-        "bundle": "45e0c477d3e5ea92aa8d85c0d8f3e25c"
+        'host': '127.0.0.1',
+        'port': 9005,
+        'verbose': False,
+        'cli_parameters': '',
+        'bundle': '45e0c477d3e5ea92aa8d85c0d8f3e25c'
     }
 
-    default_url = "http://127.0.0.1:9005/bundles/45e0c477d3e5ea92aa8d85c0d8f3e25c"
+    default_url = 'http://127.0.0.1:9005/bundles/45e0c477d3e5ea92aa8d85c0d8f3e25c'
 
     output_template = """|Bundle unload request sent.
                          |Print ConductR info with: conduct info{}
@@ -29,7 +29,7 @@ class TestConductUnloadCommand(TestCase, CliTestCase):
 
     @property
     def default_output(self):
-        return self.strip_margin(self.output_template.format(""))
+        return self.strip_margin(self.output_template.format(''))
 
     def test_success(self):
         http_method = self.respond_with(200, self.default_response)
@@ -48,7 +48,7 @@ class TestConductUnloadCommand(TestCase, CliTestCase):
 
         with patch('requests.delete', http_method), patch('sys.stdout', stdout):
             args = self.default_args.copy()
-            args.update({"verbose": True})
+            args.update({'verbose': True})
             conduct_unload.unload(MagicMock(**args))
 
         http_method.assert_called_with(self.default_url)
@@ -59,10 +59,10 @@ class TestConductUnloadCommand(TestCase, CliTestCase):
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
 
-        cli_parameters = " --host 127.0.1.1 --port 9006"
+        cli_parameters = ' --host 127.0.1.1 --port 9006'
         with patch('requests.delete', http_method), patch('sys.stdout', stdout):
             args = self.default_args.copy()
-            args.update({"cli_parameters": cli_parameters})
+            args.update({'cli_parameters': cli_parameters})
             conduct_unload.unload(MagicMock(**args))
 
         http_method.assert_called_with(self.default_url)
@@ -86,7 +86,7 @@ class TestConductUnloadCommand(TestCase, CliTestCase):
             self.output(stderr))
 
     def test_failure_invalid_address(self):
-        http_method = self.raise_connection_error("test reason")
+        http_method = self.raise_connection_error('test reason')
         stderr = MagicMock()
 
         with patch('requests.delete', http_method), patch('sys.stderr', stderr):
@@ -95,5 +95,5 @@ class TestConductUnloadCommand(TestCase, CliTestCase):
         http_method.assert_called_with(self.default_url)
 
         self.assertEqual(
-            self.default_connection_error.format(self.default_args["host"], self.default_args["port"]),
+            self.default_connection_error.format(self.default_args['host'], self.default_args['port']),
             self.output(stderr))

--- a/typesafe_conductr_cli/test/test_conduct_unload.py
+++ b/typesafe_conductr_cli/test/test_conduct_unload.py
@@ -97,6 +97,3 @@ class TestConductUnloadCommand(TestCase, CliTestCase):
         self.assertEqual(
             self.default_connection_error.format(self.default_args["host"], self.default_args["port"]),
             self.output(stderr))
-
-if __name__ == '__main__':
-    unittest.main()

--- a/typesafe_conductr_cli/test/test_shazar.py
+++ b/typesafe_conductr_cli/test/test_shazar.py
@@ -8,18 +8,18 @@ class TestShazar(TestCase):
 
     def test_create_digest(self):
         temp = tempfile.NamedTemporaryFile(mode='w+b', delete=False)
-        temp.write(b"test file data")
+        temp.write(b'test file data')
         temp_name = temp.name
         temp.close()
         self.assertEqual(
             create_digest(temp_name),
-            "1be7aaf1938cc19af7d2fdeb48a11c381dff8a98d4c4b47b3b0a5044a5255c04"
+            '1be7aaf1938cc19af7d2fdeb48a11c381dff8a98d4c4b47b3b0a5044a5255c04'
         )
         remove(temp_name)
 
     def test_parser_success(self):
         parser = build_parser()
-        args = parser.parse_args("--output-dir output-dir source".split())
+        args = parser.parse_args('--output-dir output-dir source'.split())
 
-        self.assertEqual(args.output_dir, "output-dir")
-        self.assertEqual(args.source, "source")
+        self.assertEqual(args.output_dir, 'output-dir')
+        self.assertEqual(args.source, 'source')


### PR DESCRIPTION
- Send bundle name when loading a bundle
- Add bundle name to the output of conduct info

Showcase:

```
➜  typesafe-conductr-cli git:(wip-bundle-name) ✗ conduct info 
ID                                NAME                            #REP  #STR  #RUN  
4e7b9a884fec7163aa5c097c2a580a49  filesystem-server-1.0.0         1     0     0     
2007beb6c00f8ee70f4bf7c2bb1e6c36  filesystem-server-docker-1.0.0  1     0     0     
➜  typesafe-conductr-cli git:(wip-bundle-name) ✗ conduct run file
ERROR: 300 Multiple Choices
ERROR: Specified Bundle ID/name: 'file' resulted in multiple Bundle IDs: '4e7b9a884fec7163aa5c097c2a580a49, 2007beb6c00f8ee70f4bf7c2bb1e6c36'
➜  typesafe-conductr-cli git:(wip-bundle-name) ✗ conduct run filez
ERROR: 404 Not Found
ERROR: No bundle found by the specified Bundle ID/name: 'filez'
```
