### PR TITLE
Removed the name and system args

### DIFF
--- a/typesafe_conductr_cli/conduct.py
+++ b/typesafe_conductr_cli/conduct.py
@@ -76,14 +76,6 @@ def build_parser():
                              nargs='?',
                              default=None,
                              help='The optional configuration for the bundle')
-    load_parser.add_argument('--name',
-                             default=None,
-                             dest='bundle_name',
-                             help='The optional name of the bundle. Defaults to the first part of the filename until the digest.')
-    load_parser.add_argument('--system',
-                             default=None,
-                             dest='system',
-                             help='The optional system for the bundle. Defaults to the first part of the filename until the digest.')
     add_default_arguments(load_parser)
     load_parser.set_defaults(func=conduct_load.load)
 

--- a/typesafe_conductr_cli/conduct_load.py
+++ b/typesafe_conductr_cli/conduct_load.py
@@ -1,5 +1,7 @@
-from pyhocon import ConfigFactory
+from pyhocon import ConfigFactory, ConfigTree
+from pyhocon.exceptions import ConfigMissingException
 from typesafe_conductr_cli import bundle_utils, conduct_url, conduct_logging
+from functools import partial
 import json
 import os
 import re
@@ -19,22 +21,20 @@ def load(args):
     if args.configuration is not None and not os.path.isfile(args.configuration):
         raise FileNotFoundError(args.configuration)
 
-    if args.bundle_name is None:
-        args.bundle_name = path_to_bundle_name(args.bundle)
-
-    if args.system is None:
-        args.system = path_to_bundle_name(args.bundle)
-
     bundle_conf = ConfigFactory.parse_string(bundle_utils.conf(args.bundle))
+    overlay_bundle_conf = None if args.configuration is None else \
+         ConfigFactory.parse_string(bundle_utils.conf(args.configuration))
+
+    withBundleConfs = partial(applyToConfs, bundle_conf, overlay_bundle_conf)
 
     url = conduct_url.url('bundles', args)
     files = [
-        ('nrOfCpus', bundle_conf.get_string('nrOfCpus')),
-        ('memory', bundle_conf.get_string('memory')),
-        ('diskSpace', bundle_conf.get_string('diskSpace')),
-        ('roles', ' '.join(bundle_conf.get_list('roles'))),
-        ('bundleName', args.bundle_name),
-        ('system', args.system),
+        ('nrOfCpus', withBundleConfs(ConfigTree.get_string, 'nrOfCpus')),
+        ('memory', withBundleConfs(ConfigTree.get_string, 'memory')),
+        ('diskSpace', withBundleConfs(ConfigTree.get_string, 'diskSpace')),
+        ('roles', ' '.join(withBundleConfs(ConfigTree.get_list, 'roles'))),
+        ('bundleName', withBundleConfs(ConfigTree.get_string, 'name')),
+        ('system', withBundleConfs(ConfigTree.get_string, 'system')),
         ('bundle', open(args.bundle, 'rb'))
     ]
     if args.configuration is not None:
@@ -54,7 +54,11 @@ def load(args):
     print('Unload bundle with: conduct unload{} {}'.format(args.cli_parameters, bundleId))
     print('Print ConductR info with: conduct info{}'.format(args.cli_parameters))
 
-
-def path_to_bundle_name(filename):
-    match = re.match(r'(.*?)(-[a-fA-F0-9]{0,64})?\.zip', os.path.basename(filename))
-    return match.group(1)
+def applyToConfs(base_conf, overlay_conf, method, key):
+    if overlay_conf is None:
+        return method(base_conf, key)
+    else:
+        try:
+            return method(overlay_conf, key)
+        except ConfigMissingException:
+            return method(base_conf, key)

--- a/typesafe_conductr_cli/test/test_conduct.py
+++ b/typesafe_conductr_cli/test/test_conduct.py
@@ -40,14 +40,13 @@ class TestConduct(TestCase):
         self.assertEqual(args.long_ids, False)
 
     def test_parser_load(self):
-        args = self.parser.parse_args('load --name test-bundle path-to-bundle path-to-conf'.split())
+        args = self.parser.parse_args('load path-to-bundle path-to-conf'.split())
 
         self.assertEqual(args.func.__name__, 'load')
         self.assertEqual(args.ip, '127.0.0.1')
         self.assertEqual(args.port, 9005)
         self.assertEqual(args.verbose, False)
         self.assertEqual(args.long_ids, False)
-        self.assertEqual(args.bundle_name, 'test-bundle')
         self.assertEqual(args.bundle, 'path-to-bundle')
         self.assertEqual(args.configuration, 'path-to-conf')
 


### PR DESCRIPTION
No longer required as these can be sourced from args, and overridden by a configuration's overlay bundle.conf

Fixes https://github.com/typesafehub/typesafe-conductr-cli/issues/37
