### PR TITLE
URLs for bundle and config

### DIFF
--- a/conductr_cli/bundle_utils.py
+++ b/conductr_cli/bundle_utils.py
@@ -7,5 +7,5 @@ def short_id(bundle_id):
 
 def conf(bundle_path):
     bundle_zip = ZipFile(bundle_path)
-    bundleConf = [bundle_zip.read(name) for name in bundle_zip.namelist() if name.endswith('bundle.conf')]
-    return bundleConf[0].decode('utf-8') if len(bundleConf) == 1 else ''
+    bundle_configuration = [bundle_zip.read(name) for name in bundle_zip.namelist() if name.endswith('bundle.conf')]
+    return bundle_configuration[0].decode('utf-8') if len(bundle_configuration) == 1 else ''

--- a/conductr_cli/conduct.py
+++ b/conductr_cli/conduct.py
@@ -3,7 +3,8 @@
 
 import argcomplete
 import argparse
-from conductr_cli import conduct_info, conduct_load, conduct_run, conduct_services, conduct_stop, conduct_unload, conduct_version
+from conductr_cli \
+    import conduct_info, conduct_load, conduct_run, conduct_services, conduct_stop, conduct_unload, conduct_version
 import os
 
 

--- a/conductr_cli/conduct_info.py
+++ b/conductr_cli/conduct_info.py
@@ -12,7 +12,7 @@ def info(args):
     response = requests.get(url)
     conduct_logging.raise_for_status_inc_3xx(response)
 
-    if (args.verbose):
+    if args.verbose:
         conduct_logging.pretty_json(response.text)
 
     data = [
@@ -38,6 +38,6 @@ def calc_column_widths(data):
         for column, value in row.items():
             column_len = len(str(value))
             width_key = column + '_width'
-            if (column_len > column_widths.get(width_key, 0)):
+            if column_len > column_widths.get(width_key, 0):
                 column_widths[width_key] = column_len
     return column_widths

--- a/conductr_cli/conduct_load.py
+++ b/conductr_cli/conduct_load.py
@@ -4,7 +4,6 @@ from conductr_cli import bundle_utils, conduct_url, conduct_logging
 from functools import partial
 import json
 import os
-import re
 import requests
 
 
@@ -23,18 +22,18 @@ def load(args):
 
     bundle_conf = ConfigFactory.parse_string(bundle_utils.conf(args.bundle))
     overlay_bundle_conf = None if args.configuration is None else \
-         ConfigFactory.parse_string(bundle_utils.conf(args.configuration))
+        ConfigFactory.parse_string(bundle_utils.conf(args.configuration))
 
-    withBundleConfs = partial(applyToConfs, bundle_conf, overlay_bundle_conf)
+    with_bundle_configurations = partial(apply_to_configurations, bundle_conf, overlay_bundle_conf)
 
     url = conduct_url.url('bundles', args)
     files = [
-        ('nrOfCpus', withBundleConfs(ConfigTree.get_string, 'nrOfCpus')),
-        ('memory', withBundleConfs(ConfigTree.get_string, 'memory')),
-        ('diskSpace', withBundleConfs(ConfigTree.get_string, 'diskSpace')),
-        ('roles', ' '.join(withBundleConfs(ConfigTree.get_list, 'roles'))),
-        ('bundleName', withBundleConfs(ConfigTree.get_string, 'name')),
-        ('system', withBundleConfs(ConfigTree.get_string, 'system')),
+        ('nrOfCpus', with_bundle_configurations(ConfigTree.get_string, 'nrOfCpus')),
+        ('memory', with_bundle_configurations(ConfigTree.get_string, 'memory')),
+        ('diskSpace', with_bundle_configurations(ConfigTree.get_string, 'diskSpace')),
+        ('roles', ' '.join(with_bundle_configurations(ConfigTree.get_list, 'roles'))),
+        ('bundleName', with_bundle_configurations(ConfigTree.get_string, 'name')),
+        ('system', with_bundle_configurations(ConfigTree.get_string, 'system')),
         ('bundle', open(args.bundle, 'rb'))
     ]
     if args.configuration is not None:
@@ -43,18 +42,19 @@ def load(args):
     response = requests.post(url, files=files)
     conduct_logging.raise_for_status_inc_3xx(response)
 
-    if (args.verbose):
+    if args.verbose:
         conduct_logging.pretty_json(response.text)
 
     response_json = json.loads(response.text)
-    bundleId = response_json['bundleId'] if args.long_ids else bundle_utils.short_id(response_json['bundleId'])
+    bundle_id = response_json['bundleId'] if args.long_ids else bundle_utils.short_id(response_json['bundleId'])
 
     print('Bundle loaded.')
-    print('Start bundle with: conduct run{} {}'.format(args.cli_parameters, bundleId))
-    print('Unload bundle with: conduct unload{} {}'.format(args.cli_parameters, bundleId))
+    print('Start bundle with: conduct run{} {}'.format(args.cli_parameters, bundle_id))
+    print('Unload bundle with: conduct unload{} {}'.format(args.cli_parameters, bundle_id))
     print('Print ConductR info with: conduct info{}'.format(args.cli_parameters))
 
-def applyToConfs(base_conf, overlay_conf, method, key):
+
+def apply_to_configurations(base_conf, overlay_conf, method, key):
     if overlay_conf is None:
         return method(base_conf, key)
     else:

--- a/conductr_cli/conduct_logging.py
+++ b/conductr_cli/conduct_logging.py
@@ -15,7 +15,7 @@ def warning(message, *objs):
 
 
 def connection_error(err, args):
-    error('Unable to contact Typesafe ConductR.')
+    error('Unable to contact ConductR.')
     error('Reason: {}'.format(err.args[0]))
     error('Make sure it can be accessed at {}:{}.'.format(args[0].ip, args[0].port))
 

--- a/conductr_cli/conduct_run.py
+++ b/conductr_cli/conduct_run.py
@@ -13,12 +13,12 @@ def run(args):
     response = requests.put(url)
     conduct_logging.raise_for_status_inc_3xx(response)
 
-    if (args.verbose):
+    if args.verbose:
         conduct_logging.pretty_json(response.text)
 
     response_json = json.loads(response.text)
-    bundleId = response_json['bundleId'] if args.long_ids else bundle_utils.short_id(response_json['bundleId'])
+    bundle_id = response_json['bundleId'] if args.long_ids else bundle_utils.short_id(response_json['bundleId'])
 
     print('Bundle run request sent.')
-    print('Stop bundle with: conduct stop{} {}'.format(args.cli_parameters, bundleId))
+    print('Stop bundle with: conduct stop{} {}'.format(args.cli_parameters, bundle_id))
     print('Print ConductR info with: conduct info{}'.format(args.cli_parameters))

--- a/conductr_cli/conduct_services.py
+++ b/conductr_cli/conduct_services.py
@@ -13,7 +13,7 @@ def services(args):
     response = requests.get(url)
     conduct_logging.raise_for_status_inc_3xx(response)
 
-    if (args.verbose):
+    if args.verbose:
         conduct_logging.pretty_json(response.text)
 
     data = sorted([
@@ -39,7 +39,8 @@ def services(args):
                 service_endpoints[url.path] |= {service['service']}
             except KeyError:
                 service_endpoints[url.path] = {service['service']}
-    duplicate_endpoints = [service for (service, endpoint) in service_endpoints.items() if len(endpoint) > 1] if len(service_endpoints) > 0 else []
+    duplicate_endpoints = [service for (service, endpoint) in service_endpoints.items() if len(endpoint) > 1] \
+        if len(service_endpoints) > 0 else []
 
     data.insert(0, {'service': 'SERVICE', 'bundle_id': 'BUNDLE ID', 'bundle_name': 'BUNDLE NAME', 'status': 'STATUS'})
 

--- a/conductr_cli/conduct_stop.py
+++ b/conductr_cli/conduct_stop.py
@@ -13,12 +13,12 @@ def stop(args):
     response = requests.put(url)
     conduct_logging.raise_for_status_inc_3xx(response)
 
-    if (args.verbose):
+    if args.verbose:
         conduct_logging.pretty_json(response.text)
 
     response_json = json.loads(response.text)
-    bundleId = response_json['bundleId'] if args.long_ids else bundle_utils.short_id(response_json['bundleId'])
+    bundle_id = response_json['bundleId'] if args.long_ids else bundle_utils.short_id(response_json['bundleId'])
 
     print('Bundle stop request sent.')
-    print('Unload bundle with: conduct unload{} {}'.format(args.cli_parameters, bundleId))
+    print('Unload bundle with: conduct unload{} {}'.format(args.cli_parameters, bundle_id))
     print('Print ConductR info with: conduct info{}'.format(args.cli_parameters))

--- a/conductr_cli/conduct_unload.py
+++ b/conductr_cli/conduct_unload.py
@@ -12,7 +12,7 @@ def unload(args):
     response = requests.delete(url)
     conduct_logging.raise_for_status_inc_3xx(response)
 
-    if (args.verbose):
+    if args.verbose:
         conduct_logging.pretty_json(response.text)
 
     print('Bundle unload request sent.')

--- a/conductr_cli/conduct_version.py
+++ b/conductr_cli/conduct_version.py
@@ -2,5 +2,5 @@ from conductr_cli import __version__
 
 
 # `conduct version` command
-def version(args):
+def version():
     print(__version__)

--- a/conductr_cli/test/cli_test_case.py
+++ b/conductr_cli/test/cli_test_case.py
@@ -47,7 +47,7 @@ class CliTestCase():
 
 
 def strip_margin(string, marginChar='|'):
-    return '\n'.join([line[line.index(marginChar) + 1:] for line in string.split('\n')])
+    return '\n'.join([line[line.find(marginChar) + 1:] for line in string.split('\n')])
 
 
 def create_temp_bundle_with_contents(contents):

--- a/conductr_cli/test/cli_test_case.py
+++ b/conductr_cli/test/cli_test_case.py
@@ -10,7 +10,7 @@ class CliTestCase():
 
     @property
     def default_connection_error(self):
-        return strip_margin("""|ERROR: Unable to contact Typesafe ConductR.
+        return strip_margin("""|ERROR: Unable to contact ConductR.
                                |ERROR: Reason: test reason
                                |ERROR: Make sure it can be accessed at {}:{}.
                                |""")


### PR DESCRIPTION
The load command may now download a bundle and/or from an external resource, as well as the previous behaviour of loading from a file system.

Fixes #49 
