### PR TITLE
Enable logs and events on the ConductR cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ deb_dist/*
 *.iml
 *.pyc
 .tox
+.eggs

--- a/conductr_cli/conduct.py
+++ b/conductr_cli/conduct.py
@@ -2,7 +2,8 @@ import argcomplete
 import argparse
 from conductr_cli import \
     conduct_info, conduct_load, conduct_run, conduct_services,\
-    conduct_stop, conduct_unload, conduct_version
+    conduct_stop, conduct_unload, conduct_version, conduct_logs,\
+    conduct_events
 import os
 
 
@@ -109,24 +110,38 @@ def build_parser():
     # Sub-parser for `events` sub-command
     events_parser = subparsers.add_parser('events',
                                           help='show bundle events')
-    events_parser.add_argument('--service',
-                               default='http://{}:9210'.format(default_ip),
-                               help='Events service address')
+    add_ip_and_port(events_parser)
+    events_parser.add_argument('-n', '--lines',
+                               type=int,
+                               default=10,
+                               help='The number of events to fetch, defaults to 10')
+    events_parser.add_argument('--date',
+                               action='store_true',
+                               help='Display the date of the events')
+    events_parser.add_argument('--utc',
+                               action='store_true',
+                               help='Convert the date/time of the events to UTC')
     events_parser.add_argument('bundle',
-                               help='The ID of the bundle')
-    # events_parser.set_defaults(func=conduct_events.events) FIXME
-    events_parser.set_defaults(func=lambda x: print('This command is not yet available. Consult ConductR logs.'))
+                               help='The ID or name of the bundle')
+    events_parser.set_defaults(func=conduct_events.events)
 
     # Sub-parser for `logs` sub-command
     logs_parser = subparsers.add_parser('logs',
                                         help='show bundle logs')
-    logs_parser.add_argument('--service',
-                             default='http://{}:9210'.format(default_ip),
-                             help='Logs service address')
+    add_ip_and_port(logs_parser)
+    logs_parser.add_argument('-n', '--lines',
+                             type=int,
+                             default=10,
+                             help='The number of logs to fetch, defaults to 10')
+    logs_parser.add_argument('--date',
+                             action='store_true',
+                             help='Display the date of the log')
+    logs_parser.add_argument('--utc',
+                             action='store_true',
+                             help='Convert the date/time of the log to UTC')
     logs_parser.add_argument('bundle',
-                             help='2The ID of the bundle')
-    # logs_parser.set_defaults(func=conduct_logs.logs) FIXME
-    logs_parser.set_defaults(func=lambda x: print('This command is not yet available. Consult your application logs.'))
+                             help='The ID or name of the bundle')
+    logs_parser.set_defaults(func=conduct_logs.logs)
 
     return parser
 

--- a/conductr_cli/conduct_events.py
+++ b/conductr_cli/conduct_events.py
@@ -1,4 +1,4 @@
-from conductr_cli import conduct_logging, conduct_info
+from conductr_cli import conduct_logging, conduct_info, conduct_url
 import json
 import requests
 
@@ -8,14 +8,15 @@ import requests
 def events(args):
     """`conduct events` command"""
 
-    response = requests.get('{}/events/{}'.format(args.service, args.bundle))
+    request_url = conduct_url.url('bundles/{}/events?count={}'.format(args.bundle, args.lines), args)
+    response = requests.get(request_url)
     conduct_logging.raise_for_status_inc_3xx(response)
 
     data = [
         {
-            'time': event['@cee']['body']['time'],
-            'event': event['@cee']['head']['contentType'],
-            'description': event['@cee']['body']['message']
+            'time': conduct_logging.format_timestamp(event['timestamp'], args),
+            'event': event['event'],
+            'description': event['description']
         } for event in json.loads(response.text)
     ]
     data.insert(0, {'time': 'TIME', 'event': 'EVENT', 'description': 'DESC'})

--- a/conductr_cli/conduct_logging.py
+++ b/conductr_cli/conduct_logging.py
@@ -1,6 +1,7 @@
 import json
 import sys
 import urllib
+import arrow
 
 from pyhocon.exceptions import ConfigException
 from requests import status_codes
@@ -112,3 +113,16 @@ def raise_for_status_inc_3xx(response):
     response.raise_for_status()
     if response.status_code >= 300:
         raise HTTPError(status_codes._codes[response.status_code], response=response)
+
+
+def format_timestamp(timestamp, args):
+    date = arrow.get(timestamp)
+
+    if args.date and args.utc:
+        return date.to('UTC').strftime('%Y-%m-%dT%H:%M:%SZ')
+    elif args.date:
+        return date.to('local').strftime('%c')
+    elif args.utc:
+        return date.to('UTC').strftime('%H:%M:%SZ')
+    else:
+        return date.to('local').strftime('%X')

--- a/conductr_cli/conduct_logs.py
+++ b/conductr_cli/conduct_logs.py
@@ -1,4 +1,4 @@
-from conductr_cli import conduct_logging, conduct_info
+from conductr_cli import conduct_logging, conduct_info, conduct_url
 import json
 import requests
 
@@ -8,14 +8,15 @@ import requests
 def logs(args):
     """`conduct logs` command"""
 
-    response = requests.get('{}/logs/{}'.format(args.service, args.bundle))
+    request_url = conduct_url.url('bundles/{}/logs?count={}'.format(args.bundle, args.lines), args)
+    response = requests.get(request_url)
     conduct_logging.raise_for_status_inc_3xx(response)
 
     data = [
         {
-            'time': event['@cee']['body']['time'],
-            'host': event['@cee']['body']['host'],
-            'log': event['@cee']['body']['log']
+            'time': conduct_logging.format_timestamp(event['timestamp'], args),
+            'host': event['host'],
+            'log': event['message']
         } for event in json.loads(response.text)
     ]
     data.insert(0, {'time': 'TIME', 'host': 'HOST', 'log': 'LOG'})

--- a/conductr_cli/test/test_conduct_events.py
+++ b/conductr_cli/test/test_conduct_events.py
@@ -11,11 +11,15 @@ except ImportError:
 class TestConductEventsCommand(TestCase, CliTestCase):
 
     default_args = {
-        'service': 'http://127.0.0.1:9210',
-        'bundle': 'ab8f513'
+        'ip': '127.0.0.1',
+        'port': '9005',
+        'bundle': 'ab8f513',
+        'lines': 1,
+        'date': True,
+        'utc': True
     }
 
-    default_url = 'http://127.0.0.1:9210/events/ab8f513'
+    default_url = 'http://127.0.0.1:9005/bundles/ab8f513/events?count=1'
 
     def test_no_events(self):
         http_method = self.respond_with(text='{}')
@@ -33,32 +37,14 @@ class TestConductEventsCommand(TestCase, CliTestCase):
     def test_multiple_events(self):
         http_method = self.respond_with(text="""[
             {
-                "@cee": {
-                    "head": {
-                        "contentType": "conductr.loadScheduler.loadBundleRequested"
-                    },
-                    "body": {
-                        "time": "Today 12:54:30",
-                        "requestId": "req123",
-                        "bundleName": "bundle-name",
-                        "message": "Load bundle requested: requestId=req123, bundleName=bundle-name"
-                    },
-                    "tag": "conductr.loadScheduler.loadBundleRequested"
-                }
+                "timestamp":"2015-08-24T01:16:22.327Z",
+                "event":"conductr.loadScheduler.loadBundleRequested",
+                "description":"Load bundle requested: requestId=cba938cd-860e-41a4-9cbe-2c677feaca20, bundleName=visualizer"
             },
             {
-                "@cee": {
-                    "head": {
-                        "contentType": "conductr.loadExecutor.bundleWritten"
-                    },
-                    "body": {
-                        "time": "Today 12:54:36",
-                        "requestId": "req123",
-                        "bundleName": "bundle-name",
-                        "message": "Bundle written: requestId=req123, bundleName=bundle-name"
-                    },
-                    "tag": "conductr.loadExecutor.bundleWritten"
-                }
+                "timestamp":"2015-08-24T01:16:25.327Z",
+                "event":"conductr.loadExecutor.bundleWritten",
+                "description":"Bundle written: requestId=cba938cd-860e-41a4-9cbe-2c677feaca20, bundleName=visualizer"
             }
         ]""")
         stdout = MagicMock()
@@ -68,9 +54,9 @@ class TestConductEventsCommand(TestCase, CliTestCase):
 
         http_method.assert_called_with(self.default_url)
         self.assertEqual(
-            strip_margin("""|TIME            EVENT                                       DESC
-                            |Today 12:54:30  conductr.loadScheduler.loadBundleRequested  Load bundle requested: requestId=req123, bundleName=bundle-name
-                            |Today 12:54:36  conductr.loadExecutor.bundleWritten         Bundle written: requestId=req123, bundleName=bundle-name
+            strip_margin("""|TIME                  EVENT                                       DESC
+                            |2015-08-24T01:16:22Z  conductr.loadScheduler.loadBundleRequested  Load bundle requested: requestId=cba938cd-860e-41a4-9cbe-2c677feaca20, bundleName=visualizer
+                            |2015-08-24T01:16:25Z  conductr.loadExecutor.bundleWritten         Bundle written: requestId=cba938cd-860e-41a4-9cbe-2c677feaca20, bundleName=visualizer
                             |"""),
             self.output(stdout))
 

--- a/conductr_cli/test/test_conduct_logging.py
+++ b/conductr_cli/test/test_conduct_logging.py
@@ -1,0 +1,44 @@
+from unittest import TestCase
+from conductr_cli import conduct_logging
+import arrow
+
+try:
+    from unittest.mock import MagicMock  # 3.3 and beyond
+except ImportError:
+    from mock import MagicMock
+
+
+class TestConductLogsCommand(TestCase):
+    def test_format_date_timestamp_utc(self):
+        input = '2015-08-24T01:16:22.327Z'
+        args = MagicMock()
+        args.date = True
+        args.utc = True
+        result = conduct_logging.format_timestamp(input, args)
+        self.assertEqual('2015-08-24T01:16:22Z', result)
+
+    def test_format_timestamp_utc(self):
+        input = '2015-08-24T01:16:22.327Z'
+        args = MagicMock()
+        args.date = False
+        args.utc = True
+        result = conduct_logging.format_timestamp(input, args)
+        self.assertEqual('01:16:22Z', result)
+
+    def test_format_date_timestamp(self):
+        input = '2015-08-24T01:16:22.327Z'
+        args = MagicMock()
+        args.date = True
+        args.utc = False
+        result = conduct_logging.format_timestamp(input, args)
+        expected_result = arrow.get(input).to('local').datetime.strftime('%c')
+        self.assertEqual(expected_result, result)
+
+    def test_format_timestamp(self):
+        input = '2015-08-24T01:16:22.327Z'
+        args = MagicMock()
+        args.date = False
+        args.utc = False
+        result = conduct_logging.format_timestamp(input, args)
+        expected_result = arrow.get(input).to('local').datetime.strftime('%X')
+        self.assertEqual(expected_result, result)

--- a/conductr_cli/test/test_conduct_logs.py
+++ b/conductr_cli/test/test_conduct_logs.py
@@ -11,11 +11,15 @@ except ImportError:
 class TestConductLogsCommand(TestCase, CliTestCase):
 
     default_args = {
-        'service': 'http://127.0.0.1:9210',
-        'bundle': 'ab8f513'
+        'ip': '127.0.0.1',
+        'port': '9005',
+        'bundle': 'ab8f513',
+        'lines': 1,
+        'date': True,
+        'utc': True
     }
 
-    default_url = 'http://127.0.0.1:9210/logs/ab8f513'
+    default_url = 'http://127.0.0.1:9005/bundles/ab8f513/logs?count=1'
 
     def test_no_logs(self):
         http_method = self.respond_with(text='{}')
@@ -33,22 +37,14 @@ class TestConductLogsCommand(TestCase, CliTestCase):
     def test_multiple_events(self):
         http_method = self.respond_with(text="""[
             {
-                "@cee": {
-                    "body": {
-                        "time": "Today 12:54:36",
-                        "host": "10.0.1.232",
-                        "log": "[WARN] [04/21/2015 12:54:30.079] [doc-renderer-cluster-1-akka.remote.default-remote-dispatcher-22] Association with remote system has failed."
-                    }
-                }
+                "timestamp":"2015-08-24T01:16:22.327Z",
+                "host":"10.0.1.232",
+                "message":"[WARN] [04/21/2015 12:54:30.079] [doc-renderer-cluster-1-akka.remote.default-remote-dispatcher-22] Association with remote system has failed."
             },
             {
-                "@cee": {
-                    "body": {
-                        "time": "Today 12:54:30",
-                        "host": "10.0.1.232",
-                        "log": "[WARN] [04/21/2015 12:54:36.079] [doc-renderer-cluster-1-akka.remote.default-remote-dispatcher-26] Association with remote system has failed."
-                    }
-                }
+                "timestamp":"2015-08-24T01:16:25.327Z",
+                "host":"10.0.1.232",
+                "message":"[WARN] [04/21/2015 12:54:36.079] [doc-renderer-cluster-1-akka.remote.default-remote-dispatcher-26] Association with remote system has failed."
             }
         ]""")
         stdout = MagicMock()
@@ -58,9 +54,9 @@ class TestConductLogsCommand(TestCase, CliTestCase):
 
         http_method.assert_called_with(self.default_url)
         self.assertEqual(
-            strip_margin("""|TIME            HOST        LOG
-                            |Today 12:54:36  10.0.1.232  [WARN] [04/21/2015 12:54:30.079] [doc-renderer-cluster-1-akka.remote.default-remote-dispatcher-22] Association with remote system has failed.
-                            |Today 12:54:30  10.0.1.232  [WARN] [04/21/2015 12:54:36.079] [doc-renderer-cluster-1-akka.remote.default-remote-dispatcher-26] Association with remote system has failed.
+            strip_margin("""|TIME                  HOST        LOG
+                            |2015-08-24T01:16:22Z  10.0.1.232  [WARN] [04/21/2015 12:54:30.079] [doc-renderer-cluster-1-akka.remote.default-remote-dispatcher-22] Association with remote system has failed.
+                            |2015-08-24T01:16:25Z  10.0.1.232  [WARN] [04/21/2015 12:54:36.079] [doc-renderer-cluster-1-akka.remote.default-remote-dispatcher-26] Association with remote system has failed.
                             |"""),
             self.output(stdout))
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 install_requires = [
     'requests>=2.3.0',
     'argcomplete>=0.8.1',
-    'pyhocon==0.2.1'
+    'pyhocon==0.2.1',
+    'arrow>=0.6.0'
 ]
 if sys.version_info[:2] == (3, 2):
     install_requires.extend([


### PR DESCRIPTION
Reinstate `conduct logs` and `conduct events` commands which was
disabled previously.
