### PR TITLE
Enable support for both v1.0 and v1.1 of the ConductR API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -131,6 +131,8 @@ e.g.
 
 Most sub-commands connect to a ConductR instance and therefore you have to specify its IP and port; if not given, ``CONDUCTR_IP`` environment variable or ``127.0.0.1`` will be used for the IP and ``CONDUCTR_PORT`` or ``9005`` for the port. Alternatively you can specify the IP via the ``--ip`` option and the port via the ``--port`` option.
 
+The commands provided via CLI uses version 1.0 of the ConductR API by default. When working with version 1.1 of ConductR, set the ``CONDUCTR_API_VERSION`` environment variable to ``1.1``. Alternatively you can specify the API version via the ``--api-version`` option.
+
 Here’s an example for loading a bundle:
 
 .. code:: bash
@@ -141,8 +143,8 @@ Note that when specifying IPV6 addresses then you must surround them with square
 
 .. code:: bash
 
-    conduct info --ip [fe80:0000:0000:0000:0cb3:e2ff:fe74:902d] 
-    
+    conduct info --ip [fe80:0000:0000:0000:0cb3:e2ff:fe74:902d]
+
 shazar
 ^^^^^^
 

--- a/conductr_cli/conduct.py
+++ b/conductr_cli/conduct.py
@@ -9,6 +9,7 @@ import os
 
 default_ip = os.getenv('CONDUCTR_IP', '127.0.0.1')
 default_port = os.getenv('CONDUCTR_PORT', '9005')
+default_api_version = os.getenv('CONDUCTR_API_VERSION', '1.0')
 
 
 def add_ip_and_port(sub_parser):
@@ -37,10 +38,19 @@ def add_long_ids(sub_parser):
                             action='store_true')
 
 
+def add_api_version(sub_parser):
+    sub_parser.add_argument('--api-version',
+                            help='Sets which ConductR api version to be used',
+                            default=default_api_version,
+                            dest='api_version',
+                            choices=conduct_version.supported_api_versions())
+
+
 def add_default_arguments(sub_parser):
     add_ip_and_port(sub_parser)
     add_verbose(sub_parser)
     add_long_ids(sub_parser)
+    add_api_version(sub_parser)
 
 
 def build_parser():
@@ -152,6 +162,8 @@ def get_cli_parameters(args):
         parameters.append('--ip {}'.format(args.ip))
     if getattr(args, 'port', int(default_port)) != int(default_port):
         parameters.append('--port {}'.format(args.port))
+    if getattr(args, 'api_version', default_api_version) != default_api_version:
+        parameters.append('--api-version {}'.format(args.api_version))
     return ' '.join(parameters)
 
 

--- a/conductr_cli/conduct_url.py
+++ b/conductr_cli/conduct_url.py
@@ -1,4 +1,11 @@
 # build url from ConductR base url and given path
 def url(path, args):
-    base_url = 'http://{}:{}'.format(args.ip, args.port)
+    base_url = 'http://{}:{}{}'.format(args.ip, args.port, api_version_path(args.api_version))
     return '{}/{}'.format(base_url, path)
+
+
+def api_version_path(api_version):
+    if api_version == '1.0':
+        return ''
+    else:
+        return '/v{}'.format(api_version)

--- a/conductr_cli/conduct_version.py
+++ b/conductr_cli/conduct_version.py
@@ -1,6 +1,11 @@
 from conductr_cli import __version__
 
 
+def supported_api_versions():
+    return ['1.0', '1.1']
+
+
 def version(args):
     '''`conduct version` command'''
     print(__version__)
+    print('Supported API version(s): {}'.format(', '.join(supported_api_versions())))

--- a/conductr_cli/test/conduct_load_test_base.py
+++ b/conductr_cli/test/conduct_load_test_base.py
@@ -1,8 +1,6 @@
-from unittest import TestCase
 from conductr_cli.test.cli_test_case import CliTestCase, create_temp_bundle, create_temp_bundle_with_contents, strip_margin
 from conductr_cli import conduct_load
 from urllib.error import URLError
-import os
 import shutil
 
 try:
@@ -11,52 +9,7 @@ except ImportError:
     from mock import call, patch, MagicMock
 
 
-class TestConductLoadCommand(TestCase, CliTestCase):
-
-    @property
-    def default_response(self):
-        return strip_margin("""|{
-                               |  "bundleId": "45e0c477d3e5ea92aa8d85c0d8f3e25c"
-                               |}
-                               |""")
-
-    nr_of_cpus = 1.0
-    memory = 200
-    disk_space = 100
-    roles = ['web-server']
-    bundleName = 'bundle'
-    system = 'bundle'
-
-    tmpdir, bundle_file = create_temp_bundle(
-        strip_margin("""|nrOfCpus   = {}
-                        |memory     = {}
-                        |diskSpace  = {}
-                        |roles      = [{}]
-                        |name       = {}
-                        |system     = {}
-                        |""").format(nr_of_cpus, memory, disk_space, ', '.join(roles), bundleName, system))
-
-    default_args = {
-        'ip': '127.0.0.1',
-        'port': 9005,
-        'verbose': False,
-        'long_ids': False,
-        'cli_parameters': '',
-        'bundle': bundle_file,
-        'configuration': None
-    }
-
-    default_url = 'http://127.0.0.1:9005/bundles'
-
-    default_files = [
-        ('nrOfCpus', str(nr_of_cpus)),
-        ('memory', str(memory)),
-        ('diskSpace', str(disk_space)),
-        ('roles', ' '.join(roles)),
-        ('bundleName', bundleName),
-        ('system', system),
-        ('bundle', ('bundle.zip', 1))
-    ]
+class ConductLoadTestBase(CliTestCase):
 
     output_template = """|Retrieving bundle...
                          |{downloading_configuration}Loading bundle to ConductR...
@@ -66,9 +19,12 @@ class TestConductLoadCommand(TestCase, CliTestCase):
                          |Print ConductR info with: conduct info{params}
                          |"""
 
-    @classmethod
-    def tearDownClass(cls):  # noqa
-        shutil.rmtree(cls.tmpdir)
+    @property
+    def default_response(self):
+        return strip_margin("""|{
+                               |  "bundleId": "45e0c477d3e5ea92aa8d85c0d8f3e25c"
+                               |}
+                               |""")
 
     def default_output(self, params='', bundle_id='45e0c47', downloading_configuration='', verbose=''):
         return strip_margin(self.output_template.format(**{
@@ -362,16 +318,3 @@ class TestConductLoadCommand(TestCase, CliTestCase):
             strip_margin("""|ERROR: File not found: no_such.conf
                             |"""),
             self.output(stderr))
-
-
-class TestGetUrl(TestCase):
-
-    def test_url(self):
-        filename, url = conduct_load.get_url('https://site.com/bundle-1.0-e78ed07d4a895e14595a21aef1bf616b1b0e4d886f3265bc7b152acf93d259b5.zip')
-        self.assertEqual('bundle-1.0-e78ed07d4a895e14595a21aef1bf616b1b0e4d886f3265bc7b152acf93d259b5.zip', filename)
-        self.assertEqual('https://site.com/bundle-1.0-e78ed07d4a895e14595a21aef1bf616b1b0e4d886f3265bc7b152acf93d259b5.zip', url)
-
-    def test_file(self):
-        filename, url = conduct_load.get_url('bundle-1.0-e78ed07d4a895e14595a21aef1bf616b1b0e4d886f3265bc7b152acf93d259b5.zip')
-        self.assertEqual('bundle-1.0-e78ed07d4a895e14595a21aef1bf616b1b0e4d886f3265bc7b152acf93d259b5.zip', filename)
-        self.assertEqual('file://' + os.getcwd() + '/bundle-1.0-e78ed07d4a895e14595a21aef1bf616b1b0e4d886f3265bc7b152acf93d259b5.zip', url)

--- a/conductr_cli/test/test_conduct.py
+++ b/conductr_cli/test/test_conduct.py
@@ -13,11 +13,12 @@ class TestConduct(TestCase):
         self.assertEqual(args.func.__name__, 'version')
 
     def test_default(self):
-        args = self.parser.parse_args('info --ip 127.0.1.1 --port 9999 -v --long-ids'.split())
+        args = self.parser.parse_args('info --ip 127.0.1.1 --port 9999 -v --long-ids --api-version 1.1'.split())
 
         self.assertEqual(args.func.__name__, 'info')
         self.assertEqual(args.ip, '127.0.1.1')
         self.assertEqual(args.port, 9999)
+        self.assertEqual(args.api_version, '1.1')
         self.assertEqual(args.verbose, True)
         self.assertEqual(args.long_ids, True)
 
@@ -27,6 +28,7 @@ class TestConduct(TestCase):
         self.assertEqual(args.func.__name__, 'info')
         self.assertEqual(args.ip, '127.0.0.1')
         self.assertEqual(args.port, 9005)
+        self.assertEqual(args.api_version, '1.0')
         self.assertEqual(args.verbose, False)
         self.assertEqual(args.long_ids, False)
 
@@ -36,6 +38,7 @@ class TestConduct(TestCase):
         self.assertEqual(args.func.__name__, 'services')
         self.assertEqual(args.ip, '127.0.0.1')
         self.assertEqual(args.port, 9005)
+        self.assertEqual(args.api_version, '1.0')
         self.assertEqual(args.verbose, False)
         self.assertEqual(args.long_ids, False)
 
@@ -45,6 +48,7 @@ class TestConduct(TestCase):
         self.assertEqual(args.func.__name__, 'load')
         self.assertEqual(args.ip, '127.0.0.1')
         self.assertEqual(args.port, 9005)
+        self.assertEqual(args.api_version, '1.0')
         self.assertEqual(args.verbose, False)
         self.assertEqual(args.long_ids, False)
         self.assertEqual(args.bundle, 'path-to-bundle')
@@ -56,6 +60,7 @@ class TestConduct(TestCase):
         self.assertEqual(args.func.__name__, 'run')
         self.assertEqual(args.ip, '127.0.0.1')
         self.assertEqual(args.port, 9005)
+        self.assertEqual(args.api_version, '1.0')
         self.assertEqual(args.verbose, False)
         self.assertEqual(args.long_ids, False)
         self.assertEqual(args.scale, 5)
@@ -67,6 +72,7 @@ class TestConduct(TestCase):
         self.assertEqual(args.func.__name__, 'stop')
         self.assertEqual(args.ip, '127.0.0.1')
         self.assertEqual(args.port, 9005)
+        self.assertEqual(args.api_version, '1.0')
         self.assertEqual(args.verbose, False)
         self.assertEqual(args.long_ids, False)
         self.assertEqual(args.bundle, 'path-to-bundle')
@@ -77,12 +83,13 @@ class TestConduct(TestCase):
         self.assertEqual(args.func.__name__, 'unload')
         self.assertEqual(args.ip, '127.0.0.1')
         self.assertEqual(args.port, 9005)
+        self.assertEqual(args.api_version, '1.0')
         self.assertEqual(args.verbose, False)
         self.assertEqual(args.long_ids, False)
         self.assertEqual(args.bundle, 'path-to-bundle')
 
     def test_get_cli_parameters(self):
-        args = Namespace(ip='127.0.0.1', port=9005)
+        args = Namespace(ip='127.0.0.1', port=9005, api_version='1.0')
         self.assertEqual(get_cli_parameters(args), '')
 
         args = Namespace(ip='127.0.1.1', port=9005)
@@ -91,5 +98,8 @@ class TestConduct(TestCase):
         args = Namespace(ip='127.0.0.1', port=9006)
         self.assertEqual(get_cli_parameters(args), ' --port 9006')
 
-        args = Namespace(ip='127.0.1.1', port=9006)
-        self.assertEqual(get_cli_parameters(args), ' --ip 127.0.1.1 --port 9006')
+        args = Namespace(ip='127.0.0.1', port=9005, api_version='1.1')
+        self.assertEqual(get_cli_parameters(args), ' --api-version 1.1')
+
+        args = Namespace(ip='127.0.1.1', port=9006, api_version='1.1')
+        self.assertEqual(get_cli_parameters(args), ' --ip 127.0.1.1 --port 9006 --api-version 1.1')

--- a/conductr_cli/test/test_conduct_events.py
+++ b/conductr_cli/test/test_conduct_events.py
@@ -13,6 +13,7 @@ class TestConductEventsCommand(TestCase, CliTestCase):
     default_args = {
         'ip': '127.0.0.1',
         'port': '9005',
+        'api_version': '1.0',
         'bundle': 'ab8f513',
         'lines': 1,
         'date': True,

--- a/conductr_cli/test/test_conduct_info.py
+++ b/conductr_cli/test/test_conduct_info.py
@@ -13,6 +13,7 @@ class TestConductInfoCommand(TestCase, CliTestCase):
     default_args = {
         'ip': '127.0.0.1',
         'port': 9005,
+        'api_version': '1.0',
         'verbose': False,
         'long_ids': False
     }

--- a/conductr_cli/test/test_conduct_load_v1_0.py
+++ b/conductr_cli/test/test_conduct_load_v1_0.py
@@ -1,0 +1,65 @@
+from unittest import TestCase
+from conductr_cli.test.cli_test_case import CliTestCase, create_temp_bundle, strip_margin
+from conductr_cli.test.conduct_load_test_base import ConductLoadTestBase
+from conductr_cli import conduct_load
+import os
+import shutil
+
+
+class TestConductLoadCommand(TestCase, ConductLoadTestBase, CliTestCase):
+
+    nr_of_cpus = 1.0
+    memory = 200
+    disk_space = 100
+    roles = ['web-server']
+    bundleName = 'bundle'
+    system = 'bundle'
+
+    tmpdir, bundle_file = create_temp_bundle(
+        strip_margin("""|nrOfCpus   = {}
+                        |memory     = {}
+                        |diskSpace  = {}
+                        |roles      = [{}]
+                        |name       = {}
+                        |system     = {}
+                        |""").format(nr_of_cpus, memory, disk_space, ', '.join(roles), bundleName, system))
+
+    default_args = {
+        'ip': '127.0.0.1',
+        'port': 9005,
+        'api_version': '1.0',
+        'verbose': False,
+        'long_ids': False,
+        'cli_parameters': '',
+        'bundle': bundle_file,
+        'configuration': None
+    }
+
+    default_url = 'http://127.0.0.1:9005/bundles'
+
+    default_files = [
+        ('nrOfCpus', str(nr_of_cpus)),
+        ('memory', str(memory)),
+        ('diskSpace', str(disk_space)),
+        ('roles', ' '.join(roles)),
+        ('bundleName', bundleName),
+        ('system', system),
+        ('bundle', ('bundle.zip', 1))
+    ]
+
+    @classmethod
+    def tearDownClass(cls):  # noqa
+        shutil.rmtree(cls.tmpdir)
+
+
+class TestGetUrl(TestCase):
+
+    def test_url(self):
+        filename, url = conduct_load.get_url('https://site.com/bundle-1.0-e78ed07d4a895e14595a21aef1bf616b1b0e4d886f3265bc7b152acf93d259b5.zip')
+        self.assertEqual('bundle-1.0-e78ed07d4a895e14595a21aef1bf616b1b0e4d886f3265bc7b152acf93d259b5.zip', filename)
+        self.assertEqual('https://site.com/bundle-1.0-e78ed07d4a895e14595a21aef1bf616b1b0e4d886f3265bc7b152acf93d259b5.zip', url)
+
+    def test_file(self):
+        filename, url = conduct_load.get_url('bundle-1.0-e78ed07d4a895e14595a21aef1bf616b1b0e4d886f3265bc7b152acf93d259b5.zip')
+        self.assertEqual('bundle-1.0-e78ed07d4a895e14595a21aef1bf616b1b0e4d886f3265bc7b152acf93d259b5.zip', filename)
+        self.assertEqual('file://' + os.getcwd() + '/bundle-1.0-e78ed07d4a895e14595a21aef1bf616b1b0e4d886f3265bc7b152acf93d259b5.zip', url)

--- a/conductr_cli/test/test_conduct_load_v1_1.py
+++ b/conductr_cli/test/test_conduct_load_v1_1.py
@@ -1,0 +1,56 @@
+from unittest import TestCase
+from conductr_cli.test.cli_test_case import CliTestCase, create_temp_bundle, strip_margin
+from conductr_cli.test.conduct_load_test_base import ConductLoadTestBase
+import shutil
+
+
+class TestConductLoadCommand(TestCase, ConductLoadTestBase, CliTestCase):
+
+    nr_of_cpus = 1.0
+    memory = 200
+    disk_space = 100
+    roles = ['web-server']
+    bundleName = 'bundle'
+    system = 'bundle'
+    systemVersion = '2.3'
+    compatibilityVersion = '2.0'
+
+    tmpdir, bundle_file = create_temp_bundle(
+        strip_margin("""|nrOfCpus               = {}
+                        |memory                 = {}
+                        |diskSpace              = {}
+                        |roles                  = [{}]
+                        |name                   = {}
+                        |system                 = {}
+                        |systemVersion          = {}
+                        |compatibilityVersion   = {}
+                        |""").format(nr_of_cpus, memory, disk_space, ', '.join(roles), bundleName, system, systemVersion, compatibilityVersion))
+
+    default_args = {
+        'ip': '127.0.0.1',
+        'port': 9005,
+        'api_version': '1.1',
+        'verbose': False,
+        'long_ids': False,
+        'cli_parameters': '',
+        'bundle': bundle_file,
+        'configuration': None
+    }
+
+    default_url = 'http://127.0.0.1:9005/v1.1/bundles'
+
+    default_files = [
+        ('nrOfCpus', str(nr_of_cpus)),
+        ('memory', str(memory)),
+        ('diskSpace', str(disk_space)),
+        ('roles', ' '.join(roles)),
+        ('bundleName', bundleName),
+        ('system', system),
+        ('systemVersion', systemVersion),
+        ('compatibilityVersion', compatibilityVersion),
+        ('bundle', ('bundle.zip', 1))
+    ]
+
+    @classmethod
+    def tearDownClass(cls):  # noqa
+        shutil.rmtree(cls.tmpdir)

--- a/conductr_cli/test/test_conduct_logs.py
+++ b/conductr_cli/test/test_conduct_logs.py
@@ -13,6 +13,7 @@ class TestConductLogsCommand(TestCase, CliTestCase):
     default_args = {
         'ip': '127.0.0.1',
         'port': '9005',
+        'api_version': '1.0',
         'bundle': 'ab8f513',
         'lines': 1,
         'date': True,

--- a/conductr_cli/test/test_conduct_run.py
+++ b/conductr_cli/test/test_conduct_run.py
@@ -20,6 +20,7 @@ class TestConductRunCommand(TestCase, CliTestCase):
     default_args = {
         'ip': '127.0.0.1',
         'port': 9005,
+        'api_version': '1.0',
         'verbose': False,
         'long_ids': False,
         'cli_parameters': '',

--- a/conductr_cli/test/test_conduct_services.py
+++ b/conductr_cli/test/test_conduct_services.py
@@ -13,6 +13,7 @@ class TestConductServicesCommand(TestCase, CliTestCase):
     default_args = {
         'ip': '127.0.0.1',
         'port': 9005,
+        'api_version': '1.0',
         'verbose': False,
         'long_ids': False
     }

--- a/conductr_cli/test/test_conduct_stop.py
+++ b/conductr_cli/test/test_conduct_stop.py
@@ -20,6 +20,7 @@ class TestConductStopCommand(TestCase, CliTestCase):
     default_args = {
         'ip': '127.0.0.1',
         'port': 9005,
+        'api_version': '1.0',
         'verbose': False,
         'long_ids': False,
         'cli_parameters': '',

--- a/conductr_cli/test/test_conduct_unload.py
+++ b/conductr_cli/test/test_conduct_unload.py
@@ -20,6 +20,7 @@ class TestConductUnloadCommand(TestCase, CliTestCase):
     default_args = {
         'ip': '127.0.0.1',
         'port': 9005,
+        'api_version': '1.0',
         'verbose': False,
         'cli_parameters': '',
         'bundle': '45e0c477d3e5ea92aa8d85c0d8f3e25c'

--- a/conductr_cli/test/test_conduct_url.py
+++ b/conductr_cli/test/test_conduct_url.py
@@ -1,0 +1,26 @@
+from unittest import TestCase
+from conductr_cli import conduct_url
+
+try:
+    from unittest.mock import MagicMock  # 3.3 and beyond
+except ImportError:
+    from mock import MagicMock
+
+
+class TestConductUrl(TestCase):
+
+    def test_url_v1_0(self):
+        args = MagicMock()
+        args.ip = '127.0.0.1'
+        args.port = 9005
+        args.api_version = '1.0'
+        result = conduct_url.url('test', args)
+        self.assertEqual('http://127.0.0.1:9005/test', result)
+
+    def test_url_v1_1(self):
+        args = MagicMock()
+        args.ip = '127.0.0.1'
+        args.port = 9005
+        args.api_version = '1.1'
+        result = conduct_url.url('test', args)
+        self.assertEqual('http://127.0.0.1:9005/v1.1/test', result)

--- a/conductr_cli/test/test_conduct_version.py
+++ b/conductr_cli/test/test_conduct_version.py
@@ -19,5 +19,6 @@ class TestConductVersionCommand(TestCase, CliTestCase):
         from conductr_cli import __version__
         self.assertEqual(
             strip_margin("""|{}
-                            |""".format(__version__)),
+                            |Supported API version(s): {}
+                            |""".format(__version__, ', '.join(conduct_version.supported_api_versions()))),
             self.output(stdout))


### PR DESCRIPTION
This will bring the CLI inline with the functionality provided by the SBT bundle.

The SBT Bundle change https://github.com/sbt/sbt-conductr/pull/103 is used as a reference for this PR.
- [x] Expose API version switch via `CONDUCTR_API_VERSION` environment variable and `--api-version` option switch
- [x] Switch the ConductR base URL depending on the selected API version
- [x] Switch Bundle upload payload depending on the selected API version
- [x] Reject unsupported API version
- [x] Update `conduct version` command to display supported API versions
- [x] Update documentation re API versions
