### PR TITLE
Remove blank lines

### DIFF
--- a/conductr_cli/conduct_events.py
+++ b/conductr_cli/conduct_events.py
@@ -28,4 +28,4 @@ def events(args):
         print('''\
 {time: <{time_width}}{padding}\
 {event: <{event_width}}{padding}\
-{description: <{description_width}}{padding}'''.format(**dict(row, **column_widths)))
+{description: <{description_width}}{padding}'''.format(**dict(row, **column_widths)).rstrip())

--- a/conductr_cli/conduct_info.py
+++ b/conductr_cli/conduct_info.py
@@ -36,7 +36,7 @@ def info(args):
 {name: <{name_width}}{padding}\
 {replications: >{replications_width}}{padding}\
 {starting: >{starting_width}}{padding}\
-{executions: >{executions_width}}'''.format(**dict(row, **column_widths)))
+{executions: >{executions_width}}'''.format(**dict(row, **column_widths)).rstrip())
 
     if has_error:
         print('There are errors: use `conduct events` or `conduct logs` for further information')

--- a/conductr_cli/conduct_logs.py
+++ b/conductr_cli/conduct_logs.py
@@ -28,4 +28,4 @@ def logs(args):
         print('''\
 {time: <{time_width}}{padding}\
 {host: <{host_width}}{padding}\
-{log: <{log_width}}{padding}'''.format(**dict(row, **column_widths)))
+{log: <{log_width}}{padding}'''.format(**dict(row, **column_widths)).rstrip())

--- a/conductr_cli/conduct_services.py
+++ b/conductr_cli/conduct_services.py
@@ -47,7 +47,7 @@ def services(args):
     padding = 2
     column_widths = dict(conduct_info.calc_column_widths(data), **{'padding': ' ' * padding})
     for row in data:
-        print('{service: <{service_width}}{padding}{bundle_id: <{bundle_id_width}}{padding}{bundle_name: <{bundle_name_width}}{padding}{status: <{status_width}}'.format(**dict(row, **column_widths)))
+        print('{service: <{service_width}}{padding}{bundle_id: <{bundle_id_width}}{padding}{bundle_name: <{bundle_name_width}}{padding}{status: <{status_width}}'.format(**dict(row, **column_widths)).rstrip())
 
     if len(duplicate_endpoints) > 0:
         print()


### PR DESCRIPTION
This PR addresses the issue #59.

Blank lines are now stripped with `rstrip()` for the commands:
- logs
- info
- services
- events
