### PR TITLE
Introduce --affinity switch as part of conduct run

### DIFF
--- a/conductr_cli/conduct.py
+++ b/conductr_cli/conduct.py
@@ -96,6 +96,9 @@ def build_parser():
                             type=int,
                             default=1,
                             help='The optional number of executions, defaults to 1')
+    run_parser.add_argument('--affinity',
+                            default=None,
+                            help='The optional ID of the bundle to run alongside with (v1.1 onwards)')
     run_parser.add_argument('bundle',
                             help='The ID of the bundle')
     add_default_arguments(run_parser)

--- a/conductr_cli/conduct_run.py
+++ b/conductr_cli/conduct_run.py
@@ -1,6 +1,7 @@
 from conductr_cli import bundle_utils, conduct_url, conduct_logging
 import json
 import requests
+import sys
 
 
 @conduct_logging.handle_connection_error
@@ -8,7 +9,14 @@ import requests
 def run(args):
     """`conduct run` command"""
 
-    path = 'bundles/{}?scale={}'.format(args.bundle, args.scale)
+    if args.affinity is not None and args.api_version == '1.0':
+        print('ERROR: Affinity feature is only available for v1.1 onwards of ConductR', file=sys.stderr)
+        return
+    elif args.affinity is not None:
+        path = 'bundles/{}?scale={}&affinity={}'.format(args.bundle, args.scale, args.affinity)
+    else:
+        path = 'bundles/{}?scale={}'.format(args.bundle, args.scale)
+
     url = conduct_url.url(path, args)
     response = requests.put(url)
     conduct_logging.raise_for_status_inc_3xx(response)

--- a/conductr_cli/test/conduct_run_test_base.py
+++ b/conductr_cli/test/conduct_run_test_base.py
@@ -1,4 +1,3 @@
-from unittest import TestCase
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
 from conductr_cli import conduct_run
 
@@ -8,7 +7,7 @@ except ImportError:
     from mock import patch, MagicMock
 
 
-class TestConductRunCommand(TestCase, CliTestCase):
+class ConductRunTestBase(CliTestCase):
 
     @property
     def default_response(self):
@@ -16,24 +15,6 @@ class TestConductRunCommand(TestCase, CliTestCase):
                                |  "bundleId": "45e0c477d3e5ea92aa8d85c0d8f3e25c"
                                |}
                                |""")
-
-    default_args = {
-        'ip': '127.0.0.1',
-        'port': 9005,
-        'api_version': '1.0',
-        'verbose': False,
-        'long_ids': False,
-        'cli_parameters': '',
-        'bundle': '45e0c477d3e5ea92aa8d85c0d8f3e25c',
-        'scale': 3
-    }
-
-    default_url = 'http://127.0.0.1:9005/bundles/45e0c477d3e5ea92aa8d85c0d8f3e25c?scale=3'
-
-    output_template = """|Bundle run request sent.
-                         |Stop bundle with: conduct stop{params} {bundle_id}
-                         |Print ConductR info with: conduct info{params}
-                         |"""
 
     def default_output(self, params='', bundle_id='45e0c47'):
         return strip_margin(self.output_template.format(**{'params': params, 'bundle_id': bundle_id}))

--- a/conductr_cli/test/test_conduct_run_v1_0.py
+++ b/conductr_cli/test/test_conduct_run_v1_0.py
@@ -1,0 +1,54 @@
+from unittest import TestCase
+from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
+from conductr_cli.test.conduct_run_test_base import ConductRunTestBase
+from conductr_cli import conduct_run
+
+
+try:
+    from unittest.mock import patch, MagicMock  # 3.3 and beyond
+except ImportError:
+    from mock import patch, MagicMock
+
+
+class TestConductRunCommand(TestCase, ConductRunTestBase, CliTestCase):
+
+    default_args = {
+        'ip': '127.0.0.1',
+        'port': 9005,
+        'api_version': '1.0',
+        'verbose': False,
+        'long_ids': False,
+        'cli_parameters': '',
+        'bundle': '45e0c477d3e5ea92aa8d85c0d8f3e25c',
+        'scale': 3,
+        'affinity': None
+    }
+
+    default_url = 'http://127.0.0.1:9005/bundles/45e0c477d3e5ea92aa8d85c0d8f3e25c?scale=3'
+
+    output_template = """|Bundle run request sent.
+                         |Stop bundle with: conduct stop{params} {bundle_id}
+                         |Print ConductR info with: conduct info{params}
+                         |"""
+
+    def test_error_with_affinity_switch(self):
+        args = {
+            'ip': '127.0.0.1',
+            'port': 9005,
+            'api_version': '1.0',
+            'verbose': False,
+            'long_ids': False,
+            'cli_parameters': '',
+            'bundle': '45e0c477d3e5ea92aa8d85c0d8f3e25c',
+            'scale': 3,
+            'affinity': 'other-bundle'
+        }
+
+        stderr = MagicMock()
+        with patch('sys.stderr', stderr):
+            conduct_run.run(MagicMock(**args))
+
+        self.assertEqual(
+            strip_margin("""|ERROR: Affinity feature is only available for v1.1 onwards of ConductR
+                            |"""),
+            self.output(stderr))

--- a/conductr_cli/test/test_conduct_run_v1_1.py
+++ b/conductr_cli/test/test_conduct_run_v1_1.py
@@ -1,0 +1,56 @@
+from unittest import TestCase
+from conductr_cli.test.cli_test_case import CliTestCase
+from conductr_cli.test.conduct_run_test_base import ConductRunTestBase
+from conductr_cli import conduct_run
+
+try:
+    from unittest.mock import patch, MagicMock  # 3.3 and beyond
+except ImportError:
+    from mock import patch, MagicMock
+
+
+class TestConductRunCommand(TestCase, ConductRunTestBase, CliTestCase):
+
+    default_args = {
+        'ip': '127.0.0.1',
+        'port': 9005,
+        'api_version': '1.1',
+        'verbose': False,
+        'long_ids': False,
+        'cli_parameters': '',
+        'bundle': '45e0c477d3e5ea92aa8d85c0d8f3e25c',
+        'scale': 3,
+        'affinity': None
+    }
+
+    default_url = 'http://127.0.0.1:9005/v1.1/bundles/45e0c477d3e5ea92aa8d85c0d8f3e25c?scale=3'
+
+    output_template = """|Bundle run request sent.
+                         |Stop bundle with: conduct stop{params} {bundle_id}
+                         |Print ConductR info with: conduct info{params}
+                         |"""
+
+    def test_success_with_affinity(self):
+        args = {
+            'ip': '127.0.0.1',
+            'port': 9005,
+            'api_version': '1.1',
+            'verbose': False,
+            'long_ids': False,
+            'cli_parameters': '',
+            'bundle': '45e0c477d3e5ea92aa8d85c0d8f3e25c',
+            'scale': 3,
+            'affinity': 'other-bundle'
+        }
+
+        expected_url = 'http://127.0.0.1:9005/v1.1/bundles/45e0c477d3e5ea92aa8d85c0d8f3e25c?scale=3&affinity=other-bundle'
+
+        http_method = self.respond_with(200, self.default_response)
+        stdout = MagicMock()
+
+        with patch('requests.put', http_method), patch('sys.stdout', stdout):
+            conduct_run.run(MagicMock(**args))
+
+        http_method.assert_called_with(expected_url)
+
+        self.assertEqual(self.default_output(), self.output(stdout))


### PR DESCRIPTION
Allow specifying `--affinity` switch for `conduct run` command.

This switch is relevant for v1.1 of ConductR where the `--affinity` switch will be used the control where bundle can be run.
