### PR TITLE
Fix tests on osx

### DIFF
--- a/conductr_cli/test/cli_test_case.py
+++ b/conductr_cli/test/cli_test_case.py
@@ -47,7 +47,7 @@ class CliTestCase():
         return MagicMock(side_effect=ConnectionError(reason, request=MagicMock(url=url)))
 
     def output(self, logger):
-        return ''.join([args[0].rstrip(' ') for name, args, kwargs in logger.method_calls])
+        return ''.join([args[0] for name, args, kwargs in logger.method_calls])
 
 
 def strip_margin(string, margin_char='|'):

--- a/conductr_cli/test/test_shazar.py
+++ b/conductr_cli/test/test_shazar.py
@@ -46,7 +46,7 @@ class TestIntegration(TestCase, CliTestCase):
 
         self.assertRegex(
             self.output(stdout),
-            'Created digested ZIP archive at /tmp/tmp[a-z0-9_]{6,8}/tmp[a-z0-9_]{6,8}-[a-f0-9]{64}\.zip'
+            'Created digested ZIP archive at {}/tmp[a-z0-9_]{{6,8}}-[a-f0-9]{{64}}\.zip'.format(self.tmpdir)
         )
 
     def tearDown(self):  # noqa


### PR DESCRIPTION
- Fixes the testcase `conductr_cli.test.test_shazar.TestIntegration` on OSX
- Also removes the `rstrip()` method. It is not necessary anymore due to the PR #65.
