### PR TITLE
Move calc_column_width to new module

### DIFF
--- a/conductr_cli/conduct_events.py
+++ b/conductr_cli/conduct_events.py
@@ -1,4 +1,4 @@
-from conductr_cli import conduct_logging, conduct_info, conduct_url
+from conductr_cli import conduct_logging, conduct_url, screen_utils
 import json
 import requests
 
@@ -22,7 +22,7 @@ def events(args):
     data.insert(0, {'time': 'TIME', 'event': 'EVENT', 'description': 'DESC'})
 
     padding = 2
-    column_widths = dict(conduct_info.calc_column_widths(data), **{'padding': ' ' * padding})
+    column_widths = dict(screen_utils.calc_column_widths(data), **{'padding': ' ' * padding})
 
     for row in data:
         print('''\

--- a/conductr_cli/conduct_info.py
+++ b/conductr_cli/conduct_info.py
@@ -1,4 +1,4 @@
-from conductr_cli import bundle_utils, conduct_url, conduct_logging
+from conductr_cli import bundle_utils, conduct_url, conduct_logging, screen_utils
 import json
 import requests
 
@@ -27,7 +27,7 @@ def info(args):
     data.insert(0, {'id': 'ID', 'name': 'NAME', 'replications': '#REP', 'starting': '#STR', 'executions': '#RUN'})
 
     padding = 2
-    column_widths = dict(calc_column_widths(data), **{'padding': ' ' * padding})
+    column_widths = dict(screen_utils.calc_column_widths(data), **{'padding': ' ' * padding})
     has_error = False
     for row in data:
         has_error |= '!' in row['id']
@@ -40,14 +40,3 @@ def info(args):
 
     if has_error:
         print('There are errors: use `conduct events` or `conduct logs` for further information')
-
-
-def calc_column_widths(data):
-    column_widths = {}
-    for row in data:
-        for column, value in row.items():
-            column_len = len(str(value))
-            width_key = column + '_width'
-            if column_len > column_widths.get(width_key, 0):
-                column_widths[width_key] = column_len
-    return column_widths

--- a/conductr_cli/conduct_logs.py
+++ b/conductr_cli/conduct_logs.py
@@ -1,4 +1,4 @@
-from conductr_cli import conduct_logging, conduct_info, conduct_url
+from conductr_cli import conduct_logging, conduct_url, screen_utils
 import json
 import requests
 
@@ -22,7 +22,7 @@ def logs(args):
     data.insert(0, {'time': 'TIME', 'host': 'HOST', 'log': 'LOG'})
 
     padding = 2
-    column_widths = dict(conduct_info.calc_column_widths(data), **{'padding': ' ' * padding})
+    column_widths = dict(screen_utils.calc_column_widths(data), **{'padding': ' ' * padding})
 
     for row in data:
         print('''\

--- a/conductr_cli/conduct_services.py
+++ b/conductr_cli/conduct_services.py
@@ -1,4 +1,4 @@
-from conductr_cli import bundle_utils, conduct_info, conduct_url, conduct_logging
+from conductr_cli import bundle_utils, conduct_url, conduct_logging, screen_utils
 import json
 import requests
 from urllib.parse import urlparse
@@ -45,7 +45,7 @@ def services(args):
     data.insert(0, {'service': 'SERVICE', 'bundle_id': 'BUNDLE ID', 'bundle_name': 'BUNDLE NAME', 'status': 'STATUS'})
 
     padding = 2
-    column_widths = dict(conduct_info.calc_column_widths(data), **{'padding': ' ' * padding})
+    column_widths = dict(screen_utils.calc_column_widths(data), **{'padding': ' ' * padding})
     for row in data:
         print('{service: <{service_width}}{padding}{bundle_id: <{bundle_id_width}}{padding}{bundle_name: <{bundle_name_width}}{padding}{status: <{status_width}}'.format(**dict(row, **column_widths)).rstrip())
 

--- a/conductr_cli/screen_utils.py
+++ b/conductr_cli/screen_utils.py
@@ -1,0 +1,9 @@
+def calc_column_widths(data):
+    column_widths = {}
+    for row in data:
+        for column, value in row.items():
+            column_len = len(str(value))
+            width_key = column + '_width'
+            if column_len > column_widths.get(width_key, 0):
+                column_widths[width_key] = column_len
+    return column_widths


### PR DESCRIPTION
`calc_column_width` was part of `conduct_info`, but it is used by multiple commands. Therefore it is now factored out to a module called `screen_utils`.
