### PR TITLE
Color code terminal Warning and Error output

### DIFF
--- a/conductr_cli/ansi_colors.py
+++ b/conductr_cli/ansi_colors.py
@@ -1,0 +1,4 @@
+RED = '\033[91m'
+YELLOW = '\033[93m'
+UNDERLINE = '\033[4m'
+ENDC = '\033[0m'

--- a/conductr_cli/conduct_services.py
+++ b/conductr_cli/conduct_services.py
@@ -57,6 +57,6 @@ def services(args):
 
     if len(duplicate_endpoints) > 0:
         print()
-        validation.warning(
+        validation.warn(
             'Multiple endpoints found for the following services: {}'.format(', '.join(duplicate_endpoints)))
-        validation.warning('Service resolution for these services is undefined.')
+        validation.warn('Service resolution for these services is undefined.')

--- a/conductr_cli/test/cli_test_case.py
+++ b/conductr_cli/test/cli_test_case.py
@@ -3,6 +3,7 @@ import shutil
 import tempfile
 from unittest import TestCase
 from requests.exceptions import ConnectionError, HTTPError
+from conductr_cli.ansi_colors import RED, YELLOW, UNDERLINE, ENDC
 
 try:
     from unittest.mock import MagicMock  # 3.3 and beyond
@@ -15,10 +16,10 @@ class CliTestCase(TestCase):
 
     @property
     def default_connection_error(self):
-        return strip_margin("""|ERROR: Unable to contact ConductR.
-                               |ERROR: Reason: test reason
-                               |ERROR: Start the ConductR sandbox with: sandbox run IMAGE_VERSION
-                               |""")
+        return as_error(strip_margin("""|Error: Unable to contact ConductR.
+                               |Error: Reason: test reason
+                               |Error: Start the ConductR sandbox with: sandbox run IMAGE_VERSION
+                               |"""))
 
     @staticmethod
     def respond_with(status_code=200, text=''):
@@ -56,6 +57,14 @@ class CliTestCase(TestCase):
 
 def strip_margin(string, margin_char='|'):
     return '\n'.join([line[line.find(margin_char) + 1:] for line in string.split('\n')])
+
+
+def as_error(string):
+    return string.replace('Error:', '{red}{underline}Error{end}:'.format(red=RED, underline=UNDERLINE, end=ENDC))
+
+
+def as_warn(string):
+    return string.replace('Warning:', '{yellow}{underline}Warning{end}:'.format(yellow=YELLOW, underline=UNDERLINE, end=ENDC))
 
 
 def create_temp_bundle_with_contents(contents):

--- a/conductr_cli/test/conduct_load_test_base.py
+++ b/conductr_cli/test/conduct_load_test_base.py
@@ -1,5 +1,5 @@
 from conductr_cli.test.cli_test_case import CliTestCase, create_temp_bundle, create_temp_bundle_with_contents, \
-    strip_margin
+    strip_margin, as_error
 from conductr_cli import conduct_load
 from conductr_cli.conduct_load import LOAD_HTTP_TIMEOUT
 from urllib.error import URLError
@@ -170,8 +170,8 @@ class ConductLoadTestBase(CliTestCase):
         http_method.assert_called_with(self.default_url, files=self.default_files, timeout=LOAD_HTTP_TIMEOUT)
 
         self.assertEqual(
-            strip_margin("""|ERROR: 404 Not Found
-                            |"""),
+            as_error(strip_margin("""|Error: 404 Not Found
+                                     |""")),
             self.output(stderr))
 
     def base_test_failure_invalid_address(self):
@@ -208,9 +208,9 @@ class ConductLoadTestBase(CliTestCase):
             conduct_load.load(MagicMock(**args))
 
         self.assertEqual(
-            strip_margin("""|ERROR: Unable to parse bundle.conf.
-                            |ERROR: No configuration setting found for key nrOfCpus.
-                            |"""),
+            as_error(strip_margin("""|Error: Unable to parse bundle.conf.
+                                     |Error: No configuration setting found for key nrOfCpus.
+                                     |""")),
             self.output(stderr))
 
         shutil.rmtree(tmpdir)
@@ -230,9 +230,9 @@ class ConductLoadTestBase(CliTestCase):
             conduct_load.load(MagicMock(**args))
 
         self.assertEqual(
-            strip_margin("""|ERROR: Unable to parse bundle.conf.
-                            |ERROR: No configuration setting found for key memory.
-                            |"""),
+            as_error(strip_margin("""|Error: Unable to parse bundle.conf.
+                                     |Error: No configuration setting found for key memory.
+                                     |""")),
             self.output(stderr))
 
         shutil.rmtree(tmpdir)
@@ -252,9 +252,9 @@ class ConductLoadTestBase(CliTestCase):
             conduct_load.load(MagicMock(**args))
 
         self.assertEqual(
-            strip_margin("""|ERROR: Unable to parse bundle.conf.
-                            |ERROR: No configuration setting found for key diskSpace.
-                            |"""),
+            as_error(strip_margin("""|Error: Unable to parse bundle.conf.
+                                     |Error: No configuration setting found for key diskSpace.
+                                     |""")),
             self.output(stderr))
 
         shutil.rmtree(tmpdir)
@@ -274,9 +274,9 @@ class ConductLoadTestBase(CliTestCase):
             conduct_load.load(MagicMock(**args))
 
         self.assertEqual(
-            strip_margin("""|ERROR: Unable to parse bundle.conf.
-                            |ERROR: No configuration setting found for key roles.
-                            |"""),
+            as_error(strip_margin("""|Error: Unable to parse bundle.conf.
+                                     |Error: No configuration setting found for key roles.
+                                     |""")),
             self.output(stderr))
 
         shutil.rmtree(tmpdir)
@@ -297,9 +297,9 @@ class ConductLoadTestBase(CliTestCase):
             conduct_load.load(MagicMock(**args))
 
         self.assertEqual(
-            strip_margin("""|ERROR: Unable to parse bundle.conf.
-                            |ERROR: roles has type 'str' rather than 'list'.
-                            |"""),
+            as_error(strip_margin("""|Error: Unable to parse bundle.conf.
+                                     |Error: roles has type 'str' rather than 'list'.
+                                     |""")),
             self.output(stderr))
 
         shutil.rmtree(tmpdir)
@@ -314,8 +314,8 @@ class ConductLoadTestBase(CliTestCase):
             conduct_load.load(MagicMock(**args))
 
         self.assertEqual(
-            strip_margin("""|ERROR: File not found: no_such.bundle
-                            |"""),
+            as_error(strip_margin("""|Error: File not found: no_such.bundle
+                                     |""")),
             self.output(stderr))
 
     def base_test_failure_no_configuration(self):
@@ -329,6 +329,6 @@ class ConductLoadTestBase(CliTestCase):
             conduct_load.load(MagicMock(**args))
 
         self.assertEqual(
-            strip_margin("""|ERROR: File not found: no_such.conf
-                            |"""),
+            as_error(strip_margin("""|Error: File not found: no_such.conf
+                                     |""")),
             self.output(stderr))

--- a/conductr_cli/test/conduct_run_test_base.py
+++ b/conductr_cli/test/conduct_run_test_base.py
@@ -1,4 +1,4 @@
-from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
+from conductr_cli.test.cli_test_case import CliTestCase, strip_margin, as_error
 from conductr_cli import conduct_run
 
 try:
@@ -89,8 +89,8 @@ class ConductRunTestBase(CliTestCase):
         http_method.assert_called_with(self.default_url)
 
         self.assertEqual(
-            strip_margin("""|ERROR: 404 Not Found
-                            |"""),
+            as_error(strip_margin("""|Error: 404 Not Found
+                                     |""")),
             self.output(stderr))
 
     def base_test_failure_invalid_address(self):

--- a/conductr_cli/test/test_conduct_services.py
+++ b/conductr_cli/test/test_conduct_services.py
@@ -1,4 +1,4 @@
-from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
+from conductr_cli.test.cli_test_case import CliTestCase, strip_margin, as_warn
 from conductr_cli import conduct_services
 from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
 
@@ -43,19 +43,19 @@ class TestConductServicesCommand(CliTestCase):
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
         self.assertEqual(
-            strip_margin("""|SERVICE                   BUNDLE ID  BUNDLE NAME                   STATUS
-                            |http://:6011/comp2-endp2  6e4560e    multi2-comp-multi-endp-1.0.0  Running
-                            |http://:7010/comp3-endp1  6e4560e    multi2-comp-multi-endp-1.0.0  Running
-                            |http://:7011/comp3-endp2  6e4560e    multi2-comp-multi-endp-1.0.0  Running
-                            |http://:8010/comp1-endp1  f804d64    multi-comp-multi-endp-1.0.0   Running
-                            |http://:8011/comp1-endp2  f804d64    multi-comp-multi-endp-1.0.0   Running
-                            |http://:9010/comp2-endp1  f804d64    multi-comp-multi-endp-1.0.0   Running
-                            |http://:9010/comp2-endp1  6e4560e    multi2-comp-multi-endp-1.0.0  Running
-                            |http://:9011/comp2-endp2  f804d64    multi-comp-multi-endp-1.0.0   Running
-                            |
-                            |WARNING: Multiple endpoints found for the following services: /comp2-endp2
-                            |WARNING: Service resolution for these services is undefined.
-                            |"""),
+            as_warn(strip_margin("""|SERVICE                   BUNDLE ID  BUNDLE NAME                   STATUS
+                                    |http://:6011/comp2-endp2  6e4560e    multi2-comp-multi-endp-1.0.0  Running
+                                    |http://:7010/comp3-endp1  6e4560e    multi2-comp-multi-endp-1.0.0  Running
+                                    |http://:7011/comp3-endp2  6e4560e    multi2-comp-multi-endp-1.0.0  Running
+                                    |http://:8010/comp1-endp1  f804d64    multi-comp-multi-endp-1.0.0   Running
+                                    |http://:8011/comp1-endp2  f804d64    multi-comp-multi-endp-1.0.0   Running
+                                    |http://:9010/comp2-endp1  f804d64    multi-comp-multi-endp-1.0.0   Running
+                                    |http://:9010/comp2-endp1  6e4560e    multi2-comp-multi-endp-1.0.0  Running
+                                    |http://:9011/comp2-endp2  f804d64    multi-comp-multi-endp-1.0.0   Running
+                                    |
+                                    |Warning: Multiple endpoints found for the following services: /comp2-endp2
+                                    |Warning: Service resolution for these services is undefined.
+                                    |""")),
             self.output(stdout))
 
     def test_two_bundles_mult_components_endpoints_no_path(self):

--- a/conductr_cli/test/test_conduct_stop.py
+++ b/conductr_cli/test/test_conduct_stop.py
@@ -1,4 +1,4 @@
-from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
+from conductr_cli.test.cli_test_case import CliTestCase, strip_margin, as_error
 from conductr_cli import conduct_stop
 from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
 
@@ -101,8 +101,8 @@ class TestConductStopCommand(CliTestCase):
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
 
         self.assertEqual(
-            strip_margin("""|ERROR: 404 Not Found
-                            |"""),
+            as_error(strip_margin("""|Error: 404 Not Found
+                                     |""")),
             self.output(stderr))
 
     def test_failure_invalid_address(self):

--- a/conductr_cli/test/test_conduct_unload.py
+++ b/conductr_cli/test/test_conduct_unload.py
@@ -1,4 +1,4 @@
-from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
+from conductr_cli.test.cli_test_case import CliTestCase, strip_margin, as_error
 from conductr_cli import conduct_unload
 from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
 
@@ -85,8 +85,8 @@ class TestConductUnloadCommand(CliTestCase):
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
 
         self.assertEqual(
-            strip_margin("""|ERROR: 404 Not Found
-                            |"""),
+            as_error(strip_margin("""|Error: 404 Not Found
+                                     |""")),
             self.output(stderr))
 
     def test_failure_invalid_address(self):

--- a/conductr_cli/validation.py
+++ b/conductr_cli/validation.py
@@ -10,17 +10,18 @@ from requests.exceptions import ConnectionError, HTTPError
 from urllib.error import URLError
 from zipfile import BadZipFile
 from conductr_cli import terminal
+from conductr_cli.ansi_colors import RED, YELLOW, UNDERLINE, ENDC
 from conductr_cli.exceptions import DockerMachineError, Boot2DockerError
 from subprocess import CalledProcessError
 
 
 def error(message, *objs):
     """print to stderr"""
-    print('ERROR: {}'.format(message.format(*objs)), file=sys.stderr)
+    print('{}{}Error{}: {}'.format(RED, UNDERLINE, ENDC, message.format(*objs)), file=sys.stderr)
 
 
-def warning(message, *objs):
-    print('WARNING: {}'.format(message.format(*objs)), file=sys.stdout)
+def warn(message, *objs):
+    print('{}{}Warning{}: {}'.format(YELLOW, UNDERLINE, ENDC, message.format(*objs)), file=sys.stdout)
 
 
 def connection_error(err, args):
@@ -156,8 +157,8 @@ def handle_docker_errors(func):
             terminal.docker_ps()
             print('The Docker environment variables have been set for this command.')
             print('Continue processing..')
-            warning('To set the environment variables for each terminal session follow the instructions of the command:')
-            warning('  docker-machine env default')
+            warn('To set the environment variables for each terminal session follow the instructions of the command:')
+            warn('  docker-machine env default')
             print('')
             return func(*args, **kwargs)
         except CalledProcessError:
@@ -172,7 +173,7 @@ def handle_docker_errors(func):
             try:
                 env_lines = terminal.boot2docker_shellinit()
                 print('Retrieved docker environment variables with: boot2docker shellinit')
-                warning('boot2docker is deprecated. Upgrade to docker-machine.')
+                warn('boot2docker is deprecated. Upgrade to docker-machine.')
             except FileNotFoundError:
                 return []
         return [resolve_env(line) for line in env_lines if line.startswith('export')]


### PR DESCRIPTION
Improvement of the terminal output text `Error:` and `Warning:`.

Before an error message was looking like this:

```
ERROR: My error message
```

Now, the error message looks like this, whereas the `Error:` word is red and underlined (can't be displayed here in Markdown):

```
Error: My error message
```

ANSI Codes are used which are support on Unix (incl. OS X) systems and Windows: http://stackoverflow.com/questions/287871/print-in-terminal-with-colors-using-python
