### PR TITLE
Implement Support for Custom Resolver

### DIFF
--- a/conductr_cli/conduct_load.py
+++ b/conductr_cli/conduct_load.py
@@ -28,13 +28,14 @@ def load(args):
 
 def load_v1(args):
     print('Retrieving bundle...')
+    custom_settings = args.custom_settings
     resolve_cache_dir = args.resolve_cache_dir
-    bundle_name, bundle_file = resolver.resolve_bundle(resolve_cache_dir, args.bundle)
+    bundle_name, bundle_file = resolver.resolve_bundle(custom_settings, resolve_cache_dir, args.bundle)
 
     configuration_name, configuration_file = (None, None)
     if args.configuration is not None:
         print('Retrieving configuration...')
-        configuration_name, configuration_file = resolver.resolve_bundle(resolve_cache_dir, args.configuration)
+        configuration_name, configuration_file = resolver.resolve_bundle(custom_settings, resolve_cache_dir, args.configuration)
 
     bundle_conf = ConfigFactory.parse_string(bundle_utils.conf(bundle_file))
     overlay_bundle_conf = None if configuration_file is None else \
@@ -87,8 +88,9 @@ def get_payload(bundle_name, bundle_file, bundle_configuration):
 
 def load_v2(args):
     print('Retrieving bundle...')
+    custom_settings = args.custom_settings
     resolve_cache_dir = args.resolve_cache_dir
-    bundle_name, bundle_file = resolver.resolve_bundle(resolve_cache_dir, args.bundle)
+    bundle_name, bundle_file = resolver.resolve_bundle(custom_settings, resolve_cache_dir, args.bundle)
     bundle_conf = bundle_utils.zip_entry('bundle.conf', bundle_file)
 
     if bundle_conf is None:
@@ -97,7 +99,7 @@ def load_v2(args):
         configuration_name, configuration_file, bundle_conf_overlay = (None, None, None)
         if args.configuration is not None:
             print('Retrieving configuration...')
-            configuration_name, configuration_file = resolver.resolve_bundle(resolve_cache_dir, args.configuration)
+            configuration_name, configuration_file = resolver.resolve_bundle(custom_settings, resolve_cache_dir, args.configuration)
             bundle_conf_overlay = bundle_utils.zip_entry('bundle.conf', configuration_file)
 
         files = [('bundleConf', ('bundle.conf', bundle_conf))]

--- a/conductr_cli/resolver.py
+++ b/conductr_cli/resolver.py
@@ -1,21 +1,34 @@
 from conductr_cli.exceptions import BundleResolutionError
 from conductr_cli.resolvers import bintray_resolver, uri_resolver
+import importlib
 
 
-def all_resolvers():
-    # Try to resolve from local file system before we attempting resolution using bintray
-    return [uri_resolver, bintray_resolver]
+# Try to resolve from local file system before we attempting resolution using bintray
+DEFAULT_RESOLVERS = [uri_resolver, bintray_resolver]
 
 
-def resolve_bundle(cache_dir, uri):
-    for resolver in all_resolvers():
+def resolve_bundle(custom_settings, cache_dir, uri):
+    all_resolvers = resolver_chain(custom_settings)
+
+    for resolver in all_resolvers:
         is_cached, bundle_name, cached_bundle = resolver.load_from_cache(cache_dir, uri)
         if is_cached:
             return bundle_name, cached_bundle
 
-    for resolver in all_resolvers():
+    for resolver in all_resolvers:
         is_resolved, bundle_name, bundle_file = resolver.resolve_bundle(cache_dir, uri)
         if is_resolved:
             return bundle_name, bundle_file
 
     raise BundleResolutionError('Unable to resolve bundle using {}'.format(uri))
+
+
+def resolver_chain(custom_settings):
+    if custom_settings is not None and 'resolvers' in custom_settings:
+        resolver_names = custom_settings.get_list('resolvers')
+        if resolver_names:
+            print('Using custom bundle resolver chain {}'.format(resolver_names))
+            custom_resolver_chain = [importlib.import_module(resolver_name) for resolver_name in resolver_names]
+            return custom_resolver_chain
+
+    return DEFAULT_RESOLVERS

--- a/conductr_cli/test/conduct_load_test_base.py
+++ b/conductr_cli/test/conduct_load_test_base.py
@@ -31,6 +31,7 @@ class ConductLoadTestBase(CliTestCase):
         self.memory = None
         self.nr_of_cpus = None
         self.roles = []
+        self.custom_settings = None
         self.bundle_resolve_cache_dir = None
 
     @property
@@ -60,7 +61,7 @@ class ConductLoadTestBase(CliTestCase):
             conduct_load.load(MagicMock(**self.default_args))
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
-        resolve_bundle_mock.assert_called_with(self.bundle_resolve_cache_dir, self.bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
         http_method.assert_called_with(self.default_url, files=self.default_files, timeout=LOAD_HTTP_TIMEOUT)
 
         self.assertEqual(self.default_output(), self.output(stdout))
@@ -80,7 +81,7 @@ class ConductLoadTestBase(CliTestCase):
             conduct_load.load(MagicMock(**args))
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
-        resolve_bundle_mock.assert_called_with(self.bundle_resolve_cache_dir, self.bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
         http_method.assert_called_with(self.default_url, files=self.default_files, timeout=LOAD_HTTP_TIMEOUT)
 
         self.assertEqual(self.default_output(verbose=self.default_response), self.output(stdout))
@@ -100,7 +101,7 @@ class ConductLoadTestBase(CliTestCase):
             conduct_load.load(MagicMock(**args))
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
-        resolve_bundle_mock.assert_called_with(self.bundle_resolve_cache_dir, self.bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
         http_method.assert_called_with(self.default_url, files=self.default_files, timeout=LOAD_HTTP_TIMEOUT)
 
         self.assertEqual(self.default_output(bundle_id='45e0c477d3e5ea92aa8d85c0d8f3e25c'), self.output(stdout))
@@ -121,7 +122,7 @@ class ConductLoadTestBase(CliTestCase):
             conduct_load.load(MagicMock(**args))
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
-        resolve_bundle_mock.assert_called_with(self.bundle_resolve_cache_dir, self.bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
         http_method.assert_called_with(self.default_url, files=self.default_files, timeout=LOAD_HTTP_TIMEOUT)
 
         self.assertEqual(
@@ -141,7 +142,7 @@ class ConductLoadTestBase(CliTestCase):
             conduct_load.load(MagicMock(**self.default_args))
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
-        resolve_bundle_mock.assert_called_with(self.bundle_resolve_cache_dir, self.bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
         http_method.assert_called_with(self.default_url, files=self.default_files, timeout=LOAD_HTTP_TIMEOUT)
 
         self.assertEqual(
@@ -162,7 +163,7 @@ class ConductLoadTestBase(CliTestCase):
             conduct_load.load(MagicMock(**self.default_args))
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
-        resolve_bundle_mock.assert_called_with(self.bundle_resolve_cache_dir, self.bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
         http_method.assert_called_with(self.default_url, files=self.default_files, timeout=LOAD_HTTP_TIMEOUT)
 
         self.assertEqual(
@@ -178,7 +179,7 @@ class ConductLoadTestBase(CliTestCase):
             args.update({'bundle': 'no_such.bundle'})
             conduct_load.load(MagicMock(**args))
 
-        resolve_bundle_mock.assert_called_with(self.bundle_resolve_cache_dir, 'no_such.bundle')
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, 'no_such.bundle')
 
         self.assertEqual(
             as_error(strip_margin("""|Error: Bundle not found: some message
@@ -199,8 +200,8 @@ class ConductLoadTestBase(CliTestCase):
         self.assertEqual(
             resolve_bundle_mock.call_args_list,
             [
-                call(self.bundle_resolve_cache_dir, self.bundle_file),
-                call(self.bundle_resolve_cache_dir, 'no_such.conf')
+                call(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file),
+                call(self.custom_settings, self.bundle_resolve_cache_dir, 'no_such.conf')
             ]
         )
 

--- a/conductr_cli/test/test_conduct.py
+++ b/conductr_cli/test/test_conduct.py
@@ -15,13 +15,15 @@ class TestConduct(TestCase):
 
     def test_default(self):
         args = self.parser.parse_args(
-            'info --ip 127.0.1.1 --port 9999 -v --long-ids --api-version 2 --settings-dir /settings-dir'.split())
+            'info --ip 127.0.1.1 --port 9999 -v --long-ids --api-version 2 '
+            '--settings-dir /settings-dir --custom-plugins-dir /custom-plugins-dir'.split())
 
         self.assertEqual(args.func.__name__, 'info')
         self.assertEqual(args.ip, '127.0.1.1')
         self.assertEqual(args.port, 9999)
         self.assertEqual(args.api_version, '2')
         self.assertEqual(args.cli_settings_dir, '/settings-dir')
+        self.assertEqual(args.custom_plugins_dir, '/custom-plugins-dir')
         self.assertEqual(args.verbose, True)
         self.assertEqual(args.long_ids, True)
 

--- a/conductr_cli/test/test_conduct_load_v1.py
+++ b/conductr_cli/test/test_conduct_load_v1.py
@@ -6,9 +6,9 @@ from conductr_cli.conduct_load import LOAD_HTTP_TIMEOUT
 import shutil
 
 try:
-    from unittest.mock import call, patch, MagicMock  # 3.3 and beyond
+    from unittest.mock import call, patch, MagicMock, Mock  # 3.3 and beyond
 except ImportError:
-    from mock import call, patch, MagicMock
+    from mock import call, patch, MagicMock, Mock
 
 
 class TestConductLoadCommand(ConductLoadTestBase):
@@ -22,6 +22,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
         self.roles = ['web-server']
         self.bundle_name = 'bundle.zip'
         self.system = 'bundle'
+        self.custom_settings = Mock()
         self.bundle_resolve_cache_dir = 'bundle-resolve-cache-dir'
 
         self.tmpdir, self.bundle_file = create_temp_bundle(
@@ -37,7 +38,6 @@ class TestConductLoadCommand(ConductLoadTestBase):
                                          ', '.join(self.roles),
                                          self.bundle_name,
                                          self.system))
-
         self.default_args = {
             'ip': '127.0.0.1',
             'port': 9005,
@@ -45,6 +45,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
             'verbose': False,
             'long_ids': False,
             'cli_parameters': '',
+            'custom_settings': self.custom_settings,
             'resolve_cache_dir': self.bundle_resolve_cache_dir,
             'bundle': self.bundle_file,
             'configuration': None
@@ -101,8 +102,8 @@ class TestConductLoadCommand(ConductLoadTestBase):
         self.assertEqual(
             resolve_bundle_mock.call_args_list,
             [
-                call(self.bundle_resolve_cache_dir, self.bundle_file),
-                call(self.bundle_resolve_cache_dir, config_file)
+                call(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file),
+                call(self.custom_settings, self.bundle_resolve_cache_dir, config_file)
             ]
         )
         expected_files = self.default_files + [('configuration', ('config.zip', 1))]
@@ -140,7 +141,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
             args.update({'bundle': bundle_file})
             conduct_load.load(MagicMock(**args))
 
-        resolve_bundle_mock.assert_called_with(self.bundle_resolve_cache_dir, bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, bundle_file)
 
         self.assertEqual(
             as_error(strip_margin("""|Error: Unable to parse bundle.conf.
@@ -166,7 +167,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
             args.update({'bundle': bundle_file})
             conduct_load.load(MagicMock(**args))
 
-        resolve_bundle_mock.assert_called_with(self.bundle_resolve_cache_dir, bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, bundle_file)
 
         self.assertEqual(
             as_error(strip_margin("""|Error: Unable to parse bundle.conf.
@@ -192,7 +193,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
             args.update({'bundle': bundle_file})
             conduct_load.load(MagicMock(**args))
 
-        resolve_bundle_mock.assert_called_with(self.bundle_resolve_cache_dir, bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, bundle_file)
 
         self.assertEqual(
             as_error(strip_margin("""|Error: Unable to parse bundle.conf.
@@ -218,7 +219,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
             args.update({'bundle': bundle_file})
             conduct_load.load(MagicMock(**args))
 
-        resolve_bundle_mock.assert_called_with(self.bundle_resolve_cache_dir, bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, bundle_file)
 
         self.assertEqual(
             as_error(strip_margin("""|Error: Unable to parse bundle.conf.
@@ -245,7 +246,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
             args.update({'bundle': bundle_file})
             conduct_load.load(MagicMock(**args))
 
-        resolve_bundle_mock.assert_called_with(self.bundle_resolve_cache_dir, bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, bundle_file)
 
         self.assertEqual(
             as_error(strip_margin("""|Error: Unable to parse bundle.conf.

--- a/conductr_cli/test/test_conduct_load_v2.py
+++ b/conductr_cli/test/test_conduct_load_v2.py
@@ -5,9 +5,9 @@ from conductr_cli import conduct_load
 from conductr_cli.conduct_load import LOAD_HTTP_TIMEOUT
 
 try:
-    from unittest.mock import call, patch, MagicMock  # 3.3 and beyond
+    from unittest.mock import call, patch, MagicMock, Mock  # 3.3 and beyond
 except ImportError:
-    from mock import call, patch, MagicMock
+    from mock import call, patch, MagicMock, Mock
 
 
 class TestConductLoadCommand(ConductLoadTestBase):
@@ -22,6 +22,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
         self.system = 'bundle'
         self.system_version = '2.3'
         self.compatibility_version = '2.0'
+        self.custom_settings = Mock()
         self.bundle_resolve_cache_dir = 'bundle-resolve-cache-dir'
 
         self.tmpdir, self.bundle_file = create_temp_bundle(
@@ -49,6 +50,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
             'verbose': False,
             'long_ids': False,
             'cli_parameters': '',
+            'custom_settings': self.custom_settings,
             'resolve_cache_dir': self.bundle_resolve_cache_dir,
             'bundle': self.bundle_file,
             'configuration': None
@@ -109,8 +111,8 @@ class TestConductLoadCommand(ConductLoadTestBase):
         self.assertEqual(
             resolve_bundle_mock.call_args_list,
             [
-                call(self.bundle_resolve_cache_dir, self.bundle_file),
-                call(self.bundle_resolve_cache_dir, config_file)
+                call(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file),
+                call(self.custom_settings, self.bundle_resolve_cache_dir, config_file)
             ]
         )
 
@@ -158,8 +160,8 @@ class TestConductLoadCommand(ConductLoadTestBase):
         self.assertEqual(
             resolve_bundle_mock.call_args_list,
             [
-                call(self.bundle_resolve_cache_dir, self.bundle_file),
-                call(self.bundle_resolve_cache_dir, config_file)
+                call(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file),
+                call(self.custom_settings, self.bundle_resolve_cache_dir, config_file)
             ]
         )
 
@@ -208,7 +210,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
             args = self.default_args.copy()
             conduct_load.load(MagicMock(**args))
 
-        resolve_bundle_mock.assert_called_with(self.bundle_resolve_cache_dir, self.bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
 
         self.assertEqual(
             as_error(strip_margin("""|Error: Problem with the bundle: Unable to find bundle.conf within the bundle file

--- a/conductr_cli/test/test_resolver.py
+++ b/conductr_cli/test/test_resolver.py
@@ -1,7 +1,9 @@
 from unittest import TestCase
+from conductr_cli.test.cli_test_case import strip_margin
 from conductr_cli.exceptions import BundleResolutionError
 from conductr_cli import resolver
 from conductr_cli.resolvers import bintray_resolver, uri_resolver
+from pyhocon import ConfigFactory
 
 try:
     from unittest.mock import patch, MagicMock, Mock  # 3.3 and beyond
@@ -10,11 +12,9 @@ except ImportError:
 
 
 class TestResolver(TestCase):
-    def test_resolver_chain(self):
-        expected_resolver_chain = [uri_resolver, bintray_resolver]
-        self.assertEqual(expected_resolver_chain, resolver.all_resolvers())
-
     def test_resolve_bundle_success(self):
+        custom_settings = Mock()
+
         first_resolver_mock = Mock()
         first_resolver_mock.load_from_cache = MagicMock(return_value=(False, None, None))
         first_resolver_mock.resolve_bundle = MagicMock(return_value=(False, None, None))
@@ -23,12 +23,14 @@ class TestResolver(TestCase):
         second_resolver_mock.load_from_cache = MagicMock(return_value=(False, None, None))
         second_resolver_mock.resolve_bundle = MagicMock(return_value=(True, 'bundle_name', 'mock bundle_file'))
 
-        all_resolvers_mock = MagicMock(return_value=[first_resolver_mock, second_resolver_mock])
+        resolver_chain_mock = MagicMock(return_value=[first_resolver_mock, second_resolver_mock])
 
-        with patch('conductr_cli.resolver.all_resolvers', all_resolvers_mock):
-            bundle_name, bundle_file = resolver.resolve_bundle('/some-cache-dir', '/some-bundle-path')
+        with patch('conductr_cli.resolver.resolver_chain', resolver_chain_mock):
+            bundle_name, bundle_file = resolver.resolve_bundle(custom_settings, '/some-cache-dir', '/some-bundle-path')
             self.assertEqual('bundle_name', bundle_name)
             self.assertEqual('mock bundle_file', bundle_file)
+
+        resolver_chain_mock.assert_called_with(custom_settings)
 
         first_resolver_mock.load_from_cache('/some-cache-dir', '/some-bundle-path')
         first_resolver_mock.resolve_bundle.assert_called_with('/some-cache-dir', '/some-bundle-path')
@@ -37,25 +39,62 @@ class TestResolver(TestCase):
         second_resolver_mock.resolve_bundle.assert_called_with('/some-cache-dir', '/some-bundle-path')
 
     def test_resolve_bundle_failure(self):
+        custom_settings = Mock()
+
         first_resolver_mock = Mock()
         first_resolver_mock.load_from_cache = MagicMock(return_value=(False, None, None))
         first_resolver_mock.resolve_bundle = MagicMock(return_value=(False, None, None))
 
-        all_resolvers_mock = MagicMock(return_value=[first_resolver_mock])
-        with patch('conductr_cli.resolver.all_resolvers', all_resolvers_mock):
-            self.assertRaises(BundleResolutionError, resolver.resolve_bundle, '/some-cache-dir', '/some-bundle-path')
+        resolver_chain_mock = MagicMock(return_value=[first_resolver_mock])
+        with patch('conductr_cli.resolver.resolver_chain', resolver_chain_mock):
+            self.assertRaises(BundleResolutionError, resolver.resolve_bundle, custom_settings, '/some-cache-dir',
+                              '/some-bundle-path')
+
+        resolver_chain_mock.assert_called_with(custom_settings)
 
         first_resolver_mock.load_from_cache('/some-cache-dir', '/some-bundle-path')
         first_resolver_mock.resolve_bundle.assert_called_with('/some-cache-dir', '/some-bundle-path')
 
     def test_resolve_bundle_from_cache(self):
+        custom_settings = Mock()
+
         first_resolver_mock = Mock()
         first_resolver_mock.load_from_cache = MagicMock(return_value=(True, 'bundle_name', 'mock bundle_file'))
 
-        all_resolvers_mock = MagicMock(return_value=[first_resolver_mock])
-        with patch('conductr_cli.resolver.all_resolvers', all_resolvers_mock):
-            bundle_name, bundle_file = resolver.resolve_bundle('/some-cache-dir', '/some-bundle-path')
+        resolver_chain_mock = MagicMock(return_value=[first_resolver_mock])
+        with patch('conductr_cli.resolver.resolver_chain', resolver_chain_mock):
+            bundle_name, bundle_file = resolver.resolve_bundle(custom_settings, '/some-cache-dir',
+                                                               '/some-bundle-path')
             self.assertEqual('bundle_name', bundle_name)
             self.assertEqual('mock bundle_file', bundle_file)
 
+        resolver_chain_mock.assert_called_with(custom_settings)
+
         first_resolver_mock.load_from_cache('/some-cache-dir', '/some-bundle-path')
+
+
+class TestResolverChain(TestCase):
+    def test_custom_resolver_chain(self):
+        custom_settings = ConfigFactory.parse_string(
+            strip_margin("""|resolvers = [
+                            |   conductr_cli.resolvers.uri_resolver
+                            |]
+                            |""")
+        )
+        result = resolver.resolver_chain(custom_settings)
+        expected_result = [uri_resolver]
+        self.assertEqual(expected_result, result)
+
+    def test_none_input(self):
+        result = resolver.resolver_chain(None)
+        expected_result = [uri_resolver, bintray_resolver]
+        self.assertEqual(expected_result, result)
+
+    def test_custom_settings_no_resolver_config(self):
+        custom_settings = ConfigFactory.parse_string(
+            strip_margin("""|dummy = foo
+                            |""")
+        )
+        result = resolver.resolver_chain(custom_settings)
+        expected_result = [uri_resolver, bintray_resolver]
+        self.assertEqual(expected_result, result)


### PR DESCRIPTION
The custom resolver will be loaded by default from `~/.conductr/plugins` and resolver chain can be configured in `~/.conductr/settings.conf`. The settings configuration file is stored as HOCON format.

An example configuration of a custom resolver chain:

```
resolvers = [
  my_custom_resolver,
  conductr_cli.resolvers.uri_resolver,
  conductr_cli.resolvers.bintray_resolver
]
```

On the setup above `my_custom_resolver` will be called before the built-in `conductr_cli.resolvers.uri_resolver` and `conductr_cli.resolvers.bintray_resolver`.

If the `~/.conductr/settings.conf` is not present, the default, built-in resolver chain will be used instead.

`my_custom_resolver` must define the following methods:

```
def load_from_cache(cache_dir, uri):
  # Returns False, None, None if bundle is not in cache
  # Returns True, bundle_name, bundle_file if bundle is found in cache
  # bundle_file is path to the bundle
  # bundle_name is the name of the bundle, in most cases it's the basename of the bundle_file


def resolve_bundle(cache_dir, uri):
  # Returns False, None, None if bundle can't be resolved
  # Returns True, bundle_name, bundle_file if bundle can be resolved
  # bundle_file is reference to the bundle can be opened using open() method, i.e. file path or result from urlretrieve
  # bundle_name is the name of the bundle, name of the bundle file
```
