### PR TITLE
Add -q switch to conduct load command

### DIFF
--- a/conductr_cli/conduct.py
+++ b/conductr_cli/conduct.py
@@ -3,7 +3,7 @@ import argparse
 from conductr_cli import \
     conduct_info, conduct_load, conduct_run, conduct_services,\
     conduct_stop, conduct_unload, conduct_version, conduct_logs,\
-    conduct_events, host
+    conduct_events, host, logging_setup
 from pyhocon import ConfigFactory
 import os
 import sys
@@ -95,9 +95,18 @@ def add_bundle_resolve_cache_dir(sub_parser):
                             dest='resolve_cache_dir')
 
 
+def add_quiet_flag(sub_parser):
+    sub_parser.add_argument('-q',
+                            help='Prints affected bundle id on screen if enabled',
+                            default=False,
+                            dest='quiet',
+                            action='store_true')
+
+
 def add_default_arguments(sub_parser):
     add_ip_and_port(sub_parser)
     add_verbose(sub_parser)
+    add_quiet_flag(sub_parser)
     add_long_ids(sub_parser)
     add_api_version(sub_parser)
     add_local_connection_flag(sub_parser)
@@ -256,6 +265,7 @@ def run():
 
         args.cli_parameters = get_cli_parameters(args)
         args.custom_settings = get_custom_settings(args)
+        logging_setup.configure_logging(args)
         args.func(args)
 
 

--- a/conductr_cli/conduct_events.py
+++ b/conductr_cli/conduct_events.py
@@ -1,5 +1,6 @@
 from conductr_cli import validation, conduct_url, screen_utils
 import json
+import logging
 import requests
 from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
 
@@ -9,6 +10,7 @@ from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
 def events(args):
     """`conduct events` command"""
 
+    log = logging.getLogger(__name__)
     request_url = conduct_url.url('bundles/{}/events?count={}'.format(args.bundle, args.lines), args)
     response = requests.get(request_url, timeout=DEFAULT_HTTP_TIMEOUT)
     validation.raise_for_status_inc_3xx(response)
@@ -26,7 +28,7 @@ def events(args):
     column_widths = dict(screen_utils.calc_column_widths(data), **{'padding': ' ' * padding})
 
     for row in data:
-        print('''\
+        log.screen('''\
 {time: <{time_width}}{padding}\
 {event: <{event_width}}{padding}\
 {description: <{description_width}}{padding}'''.format(**dict(row, **column_widths)).rstrip())

--- a/conductr_cli/conduct_info.py
+++ b/conductr_cli/conduct_info.py
@@ -1,5 +1,6 @@
 from conductr_cli import bundle_utils, conduct_url, validation, screen_utils
 import json
+import logging
 import requests
 from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
 
@@ -9,12 +10,13 @@ from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
 def info(args):
     """`conduct info` command"""
 
+    log = logging.getLogger(__name__)
     url = conduct_url.url('bundles', args)
     response = requests.get(url, timeout=DEFAULT_HTTP_TIMEOUT)
     validation.raise_for_status_inc_3xx(response)
 
-    if args.verbose:
-        validation.pretty_json(response.text)
+    if log.is_verbose_enabled():
+        log.verbose(validation.pretty_json(response.text))
 
     data = [
         {
@@ -33,7 +35,7 @@ def info(args):
     has_error = False
     for row in data:
         has_error |= '!' in row['id']
-        print('''\
+        log.screen('''\
 {id: <{id_width}}{padding}\
 {name: <{name_width}}{padding}\
 {replications: >{replications_width}}{padding}\
@@ -41,4 +43,4 @@ def info(args):
 {executions: >{executions_width}}'''.format(**dict(row, **column_widths)).rstrip())
 
     if has_error:
-        print('There are errors: use `conduct events` or `conduct logs` for further information')
+        log.screen('There are errors: use `conduct events` or `conduct logs` for further information')

--- a/conductr_cli/conduct_load.py
+++ b/conductr_cli/conduct_load.py
@@ -6,6 +6,7 @@ from conductr_cli import resolver
 from functools import partial
 
 import json
+import logging
 import requests
 
 
@@ -27,14 +28,16 @@ def load(args):
 
 
 def load_v1(args):
-    print('Retrieving bundle...')
+    log = logging.getLogger(__name__)
+
+    log.info('Retrieving bundle...')
     custom_settings = args.custom_settings
     resolve_cache_dir = args.resolve_cache_dir
     bundle_name, bundle_file = resolver.resolve_bundle(custom_settings, resolve_cache_dir, args.bundle)
 
     configuration_name, configuration_file = (None, None)
     if args.configuration is not None:
-        print('Retrieving configuration...')
+        log.info('Retrieving configuration...')
         configuration_name, configuration_file = resolver.resolve_bundle(custom_settings, resolve_cache_dir, args.configuration)
 
     bundle_conf = ConfigFactory.parse_string(bundle_utils.conf(bundle_file))
@@ -48,20 +51,23 @@ def load_v1(args):
     if configuration_file is not None:
         files.append(('configuration', (configuration_name, open(configuration_file, 'rb'))))
 
-    print('Loading bundle to ConductR...')
+    log.info('Loading bundle to ConductR...')
     response = requests.post(url, files=files, timeout=LOAD_HTTP_TIMEOUT)
     validation.raise_for_status_inc_3xx(response)
 
-    if args.verbose:
-        validation.pretty_json(response.text)
+    if log.is_verbose_enabled():
+        log.verbose(validation.pretty_json(response.text))
 
     response_json = json.loads(response.text)
     bundle_id = response_json['bundleId'] if args.long_ids else bundle_utils.short_id(response_json['bundleId'])
 
-    print('Bundle loaded.')
-    print('Start bundle with: conduct run{} {}'.format(args.cli_parameters, bundle_id))
-    print('Unload bundle with: conduct unload{} {}'.format(args.cli_parameters, bundle_id))
-    print('Print ConductR info with: conduct info{}'.format(args.cli_parameters))
+    log.info('Bundle loaded.')
+    log.info('Start bundle with: conduct run{} {}'.format(args.cli_parameters, bundle_id))
+    log.info('Unload bundle with: conduct unload{} {}'.format(args.cli_parameters, bundle_id))
+    log.info('Print ConductR info with: conduct info{}'.format(args.cli_parameters))
+
+    if not log.is_info_enabled() and log.is_quiet_enabled():
+        log.quiet(response_json['bundleId'])
 
 
 def apply_to_configurations(base_conf, overlay_conf, method, key):
@@ -87,7 +93,9 @@ def get_payload(bundle_name, bundle_file, bundle_configuration):
 
 
 def load_v2(args):
-    print('Retrieving bundle...')
+    log = logging.getLogger(__name__)
+
+    log.info('Retrieving bundle...')
     custom_settings = args.custom_settings
     resolve_cache_dir = args.resolve_cache_dir
     bundle_name, bundle_file = resolver.resolve_bundle(custom_settings, resolve_cache_dir, args.bundle)
@@ -98,8 +106,9 @@ def load_v2(args):
     else:
         configuration_name, configuration_file, bundle_conf_overlay = (None, None, None)
         if args.configuration is not None:
-            print('Retrieving configuration...')
-            configuration_name, configuration_file = resolver.resolve_bundle(custom_settings, resolve_cache_dir, args.configuration)
+            log.info('Retrieving configuration...')
+            configuration_name, configuration_file = resolver.resolve_bundle(custom_settings, resolve_cache_dir,
+                                                                             args.configuration)
             bundle_conf_overlay = bundle_utils.zip_entry('bundle.conf', configuration_file)
 
         files = [('bundleConf', ('bundle.conf', bundle_conf))]
@@ -111,17 +120,20 @@ def load_v2(args):
 
         url = conduct_url.url('bundles', args)
 
-        print('Loading bundle to ConductR...')
+        log.info('Loading bundle to ConductR...')
         response = requests.post(url, files=files, timeout=LOAD_HTTP_TIMEOUT)
         validation.raise_for_status_inc_3xx(response)
 
-        if args.verbose:
-            validation.pretty_json(response.text)
+        if log.is_verbose_enabled():
+            log.verbose(validation.pretty_json(response.text))
 
         response_json = json.loads(response.text)
         bundle_id = response_json['bundleId'] if args.long_ids else bundle_utils.short_id(response_json['bundleId'])
 
-        print('Bundle loaded.')
-        print('Start bundle with: conduct run{} {}'.format(args.cli_parameters, bundle_id))
-        print('Unload bundle with: conduct unload{} {}'.format(args.cli_parameters, bundle_id))
-        print('Print ConductR info with: conduct info{}'.format(args.cli_parameters))
+        log.info('Bundle loaded.')
+        log.info('Start bundle with: conduct run{} {}'.format(args.cli_parameters, bundle_id))
+        log.info('Unload bundle with: conduct unload{} {}'.format(args.cli_parameters, bundle_id))
+        log.info('Print ConductR info with: conduct info{}'.format(args.cli_parameters))
+
+        if not log.is_info_enabled() and log.is_quiet_enabled():
+            log.quiet(response_json['bundleId'])

--- a/conductr_cli/conduct_logs.py
+++ b/conductr_cli/conduct_logs.py
@@ -1,5 +1,6 @@
 from conductr_cli import validation, conduct_url, screen_utils
 import json
+import logging
 import requests
 from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
 
@@ -9,6 +10,7 @@ from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
 def logs(args):
     """`conduct logs` command"""
 
+    log = logging.getLogger(__name__)
     request_url = conduct_url.url('bundles/{}/logs?count={}'.format(args.bundle, args.lines), args)
     response = requests.get(request_url, timeout=DEFAULT_HTTP_TIMEOUT)
     validation.raise_for_status_inc_3xx(response)
@@ -26,7 +28,7 @@ def logs(args):
     column_widths = dict(screen_utils.calc_column_widths(data), **{'padding': ' ' * padding})
 
     for row in data:
-        print('''\
+        log.screen('''\
 {time: <{time_width}}{padding}\
 {host: <{host_width}}{padding}\
 {log: <{log_width}}{padding}'''.format(**dict(row, **column_widths)).rstrip())

--- a/conductr_cli/conduct_run.py
+++ b/conductr_cli/conduct_run.py
@@ -1,7 +1,7 @@
 from conductr_cli import bundle_utils, conduct_url, validation
 import json
+import logging
 import requests
-import sys
 
 
 @validation.handle_connection_error
@@ -9,8 +9,10 @@ import sys
 def run(args):
     """`conduct run` command"""
 
-    if args.affinity is not None and args.api_version == '1.0':
-        print('ERROR: Affinity feature is only available for v1.1 onwards of ConductR', file=sys.stderr)
+    log = logging.getLogger(__name__)
+
+    if args.affinity is not None and args.api_version == '1':
+        log.error('Affinity feature is only available for v1.1 onwards of ConductR')
         return
     elif args.affinity is not None:
         path = 'bundles/{}?scale={}&affinity={}'.format(args.bundle, args.scale, args.affinity)
@@ -21,12 +23,12 @@ def run(args):
     response = requests.put(url)
     validation.raise_for_status_inc_3xx(response)
 
-    if args.verbose:
-        validation.pretty_json(response.text)
+    if log.is_verbose_enabled():
+        log.verbose(validation.pretty_json(response.text))
 
     response_json = json.loads(response.text)
     bundle_id = response_json['bundleId'] if args.long_ids else bundle_utils.short_id(response_json['bundleId'])
 
-    print('Bundle run request sent.')
-    print('Stop bundle with: conduct stop{} {}'.format(args.cli_parameters, bundle_id))
-    print('Print ConductR info with: conduct info{}'.format(args.cli_parameters))
+    log.info('Bundle run request sent.')
+    log.info('Stop bundle with: conduct stop{} {}'.format(args.cli_parameters, bundle_id))
+    log.info('Print ConductR info with: conduct info{}'.format(args.cli_parameters))

--- a/conductr_cli/conduct_stop.py
+++ b/conductr_cli/conduct_stop.py
@@ -1,6 +1,7 @@
 from conductr_cli import bundle_utils, conduct_url, validation
 import json
 import requests
+import logging
 from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
 
 
@@ -9,17 +10,18 @@ from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
 def stop(args):
     """`conduct stop` command"""
 
+    log = logging.getLogger(__name__)
     path = 'bundles/{}?scale=0'.format(args.bundle)
     url = conduct_url.url(path, args)
     response = requests.put(url, timeout=DEFAULT_HTTP_TIMEOUT)
     validation.raise_for_status_inc_3xx(response)
 
-    if args.verbose:
-        validation.pretty_json(response.text)
+    if log.is_verbose_enabled():
+        log.verbose(validation.pretty_json(response.text))
 
     response_json = json.loads(response.text)
     bundle_id = response_json['bundleId'] if args.long_ids else bundle_utils.short_id(response_json['bundleId'])
 
-    print('Bundle stop request sent.')
-    print('Unload bundle with: conduct unload{} {}'.format(args.cli_parameters, bundle_id))
-    print('Print ConductR info with: conduct info{}'.format(args.cli_parameters))
+    log.info('Bundle stop request sent.')
+    log.info('Unload bundle with: conduct unload{} {}'.format(args.cli_parameters, bundle_id))
+    log.info('Print ConductR info with: conduct info{}'.format(args.cli_parameters))

--- a/conductr_cli/conduct_unload.py
+++ b/conductr_cli/conduct_unload.py
@@ -1,4 +1,5 @@
 from conductr_cli import conduct_url, validation
+import logging
 import requests
 from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
 
@@ -8,13 +9,14 @@ from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
 def unload(args):
     """`conduct unload` command"""
 
+    log = logging.getLogger(__name__)
     path = 'bundles/{}'.format(args.bundle)
     url = conduct_url.url(path, args)
     response = requests.delete(url, timeout=DEFAULT_HTTP_TIMEOUT)
     validation.raise_for_status_inc_3xx(response)
 
-    if args.verbose:
-        validation.pretty_json(response.text)
+    if log.is_verbose_enabled():
+        log.verbose(validation.pretty_json(response.text))
 
-    print('Bundle unload request sent.')
-    print('Print ConductR info with: conduct info{}'.format(args.cli_parameters))
+    log.info('Bundle unload request sent.')
+    log.info('Print ConductR info with: conduct info{}'.format(args.cli_parameters))

--- a/conductr_cli/conduct_version.py
+++ b/conductr_cli/conduct_version.py
@@ -1,4 +1,5 @@
 from conductr_cli import __version__
+import logging
 
 
 def supported_api_versions():
@@ -7,5 +8,6 @@ def supported_api_versions():
 
 def version(args):
     """`conduct version` command"""
-    print(__version__)
-    print('Supported API version(s): {}'.format(', '.join(supported_api_versions())))
+    log = logging.getLogger(__name__)
+    log.screen(__version__)
+    log.screen('Supported API version(s): {}'.format(', '.join(supported_api_versions())))

--- a/conductr_cli/logging_setup.py
+++ b/conductr_cli/logging_setup.py
@@ -1,0 +1,114 @@
+from conductr_cli.ansi_colors import RED, YELLOW, UNDERLINE, ENDC
+import logging
+import sys
+
+# Default python log levels
+LOG_LEVEL_DEBUG = logging.getLevelName('DEBUG')
+LOG_LEVEL_INFO = logging.getLevelName('INFO')
+LOG_LEVEL_WARN = logging.getLevelName('WARN')
+LOG_LEVEL_ERROR = logging.getLevelName('ERROR')
+LOG_LEVEL_CRITICAL = logging.getLevelName('CRITICAL')
+
+# Custom log level for ConductR CLI
+LOG_LEVEL_VERBOSE = int((LOG_LEVEL_DEBUG + LOG_LEVEL_INFO) / 2)
+LOG_LEVEL_QUIET = int((LOG_LEVEL_INFO + LOG_LEVEL_WARN) / 2)
+LOG_LEVEL_SCREEN = int(LOG_LEVEL_CRITICAL + 10)
+
+
+class ThresholdFilter(logging.Filter):
+    def __init__(self, threshold):
+        super().__init__()
+        self.threshold = threshold
+
+    def filter(self, record):
+        return record.levelno < self.threshold
+
+
+def verbose(self, message, *args, **kwargs):
+    self.log(LOG_LEVEL_VERBOSE, message, *args, **kwargs)
+
+
+def quiet(self, message, *args, **kwargs):
+    self.log(LOG_LEVEL_QUIET, message, *args, **kwargs)
+
+
+def screen(self, message, *args, **kwargs):
+    self.log(LOG_LEVEL_SCREEN, message, *args, **kwargs)
+
+
+def is_verbose_enabled(self):
+    return self.isEnabledFor(LOG_LEVEL_VERBOSE)
+
+
+def is_debug_enabled(self):
+    return self.isEnabledFor(LOG_LEVEL_DEBUG)
+
+
+def is_info_enabled(self):
+    return self.isEnabledFor(LOG_LEVEL_INFO)
+
+
+def is_quiet_enabled(self):
+    return self.isEnabledFor(LOG_LEVEL_QUIET)
+
+
+def is_warn_enabled(self):
+    return self.isEnabledFor(LOG_LEVEL_WARN)
+
+
+def configure_logging(args, output=sys.stdout, err_output=sys.stderr):
+    logging.addLevelName(LOG_LEVEL_VERBOSE, 'VERBOSE')
+    logging.Logger.verbose = verbose
+
+    logging.addLevelName(LOG_LEVEL_QUIET, 'QUIET')
+    logging.Logger.quiet = quiet
+
+    logging.addLevelName(LOG_LEVEL_SCREEN, 'SCREEN')
+    logging.Logger.screen = screen
+
+    logging.Logger.is_verbose_enabled = is_verbose_enabled
+    logging.Logger.is_debug_enabled = is_debug_enabled
+    logging.Logger.is_info_enabled = is_info_enabled
+    logging.Logger.is_quiet_enabled = is_quiet_enabled
+    logging.Logger.is_warn_enabled = is_warn_enabled
+
+    logger = logging.getLogger()
+    logger.setLevel('ERROR')
+
+    formatter = logging.Formatter('%(message)s')
+
+    # Clear existing handlers to prevent duplicate log messages
+    for handler in logger.handlers:
+        logger.removeHandler(handler)
+
+    output_handler = logging.StreamHandler(stream=output)
+    output_handler.setFormatter(formatter)
+    output_handler.addFilter(ThresholdFilter(LOG_LEVEL_WARN))
+    logger.addHandler(output_handler)
+
+    warn_output_formatter = logging.Formatter('{}{}Warning{}: %(message)s'.format(YELLOW, UNDERLINE, ENDC))
+    warn_output_handler = logging.StreamHandler(stream=output)
+    warn_output_handler.setFormatter(warn_output_formatter)
+    warn_output_handler.setLevel(LOG_LEVEL_WARN)
+    warn_output_handler.addFilter(ThresholdFilter(LOG_LEVEL_ERROR))
+    logger.addHandler(warn_output_handler)
+
+    err_output_formatter = logging.Formatter('{}{}Error{}: %(message)s'.format(RED, UNDERLINE, ENDC))
+    err_output_handler = logging.StreamHandler(stream=err_output)
+    err_output_handler.setFormatter(err_output_formatter)
+    err_output_handler.setLevel(LOG_LEVEL_ERROR)
+    err_output_handler.addFilter(ThresholdFilter(LOG_LEVEL_SCREEN))
+    logger.addHandler(err_output_handler)
+
+    screen_output_handler = logging.StreamHandler(stream=output)
+    screen_output_handler.setFormatter(formatter)
+    screen_output_handler.setLevel(LOG_LEVEL_SCREEN)
+    logger.addHandler(screen_output_handler)
+
+    conductr_log = logging.getLogger('conductr_cli')
+    if vars(args).get('verbose'):
+        conductr_log.setLevel('VERBOSE')
+    elif vars(args).get('quiet'):
+        conductr_log.setLevel('QUIET')
+    else:
+        conductr_log.setLevel('INFO')

--- a/conductr_cli/resolver.py
+++ b/conductr_cli/resolver.py
@@ -1,6 +1,7 @@
 from conductr_cli.exceptions import BundleResolutionError
 from conductr_cli.resolvers import bintray_resolver, uri_resolver
 import importlib
+import logging
 
 
 # Try to resolve from local file system before we attempting resolution using bintray
@@ -24,10 +25,11 @@ def resolve_bundle(custom_settings, cache_dir, uri):
 
 
 def resolver_chain(custom_settings):
+    log = logging.getLogger(__name__)
     if custom_settings is not None and 'resolvers' in custom_settings:
         resolver_names = custom_settings.get_list('resolvers')
         if resolver_names:
-            print('Using custom bundle resolver chain {}'.format(resolver_names))
+            log.info('Using custom bundle resolver chain {}'.format(resolver_names))
             custom_resolver_chain = [importlib.import_module(resolver_name) for resolver_name in resolver_names]
             return custom_resolver_chain
 

--- a/conductr_cli/resolvers/test/test_uri_resolver.py
+++ b/conductr_cli/resolvers/test/test_uri_resolver.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 from urllib.error import URLError
 from conductr_cli.resolvers import uri_resolver
+from conductr_cli.test.cli_test_case import create_mock_logger
 import os
 
 try:
@@ -16,10 +17,13 @@ class TestResolveBundle(TestCase):
         get_url_mock = MagicMock(return_value=('bundle-name', '/bundle-url-resolved'))
         urlretrieve_mock = MagicMock(return_value=('mock-bundle-file', ()))
 
+        get_logger_mock, log_mock = create_mock_logger()
+
         with patch('os.path.exists', os_path_exists_mock), \
                 patch('conductr_cli.resolvers.uri_resolver.cache_path', cache_path_mock), \
                 patch('conductr_cli.resolvers.uri_resolver.get_url', get_url_mock), \
-                patch('conductr_cli.resolvers.uri_resolver.urlretrieve', urlretrieve_mock):
+                patch('conductr_cli.resolvers.uri_resolver.urlretrieve', urlretrieve_mock), \
+                patch('logging.getLogger', get_logger_mock):
             is_resolved, bundle_name, bundle_file = uri_resolver.resolve_bundle('/cache-dir', '/bundle-url')
             self.assertTrue(is_resolved)
             self.assertEqual('bundle-name', bundle_name)
@@ -30,6 +34,9 @@ class TestResolveBundle(TestCase):
         get_url_mock.assert_called_with('/bundle-url')
         urlretrieve_mock.assert_called_with('/bundle-url-resolved', '/bundle-cached-path')
 
+        get_logger_mock.assert_called_with('conductr_cli.resolvers.uri_resolver')
+        log_mock.info.assert_called_with('Retrieving /bundle-url-resolved')
+
     def test_resolve_success_create_cache_dir(self):
         os_path_exists_mock = MagicMock(return_value=False)
         os_mkdirs_mock = MagicMock(return_value=())
@@ -37,11 +44,14 @@ class TestResolveBundle(TestCase):
         get_url_mock = MagicMock(return_value=('bundle-name', '/bundle-url-resolved'))
         urlretrieve_mock = MagicMock(return_value=('mock-bundle-file', ()))
 
+        get_logger_mock, log_mock = create_mock_logger()
+
         with patch('os.path.exists', os_path_exists_mock), \
                 patch('os.makedirs', os_mkdirs_mock), \
                 patch('conductr_cli.resolvers.uri_resolver.cache_path', cache_path_mock), \
                 patch('conductr_cli.resolvers.uri_resolver.get_url', get_url_mock), \
-                patch('conductr_cli.resolvers.uri_resolver.urlretrieve', urlretrieve_mock):
+                patch('conductr_cli.resolvers.uri_resolver.urlretrieve', urlretrieve_mock), \
+                patch('logging.getLogger', get_logger_mock):
             is_resolved, bundle_name, bundle_file = uri_resolver.resolve_bundle('/cache-dir', '/bundle-url')
             self.assertTrue(is_resolved)
             self.assertEqual('bundle-name', bundle_name)
@@ -53,16 +63,22 @@ class TestResolveBundle(TestCase):
         get_url_mock.assert_called_with('/bundle-url')
         urlretrieve_mock.assert_called_with('/bundle-url-resolved', '/bundle-cached-path')
 
+        get_logger_mock.assert_called_with('conductr_cli.resolvers.uri_resolver')
+        log_mock.info.assert_called_with('Retrieving /bundle-url-resolved')
+
     def test_resolve_not_found(self):
         os_path_exists_mock = MagicMock(return_value=True)
         cache_path_mock = MagicMock(return_value='/bundle-cached-path')
         urlretrieve_mock = MagicMock(side_effect=URLError('no_such.bundle'))
         get_url_mock = MagicMock(return_value=('bundle-name', '/bundle-url-resolved'))
 
+        get_logger_mock, log_mock = create_mock_logger()
+
         with patch('os.path.exists', os_path_exists_mock), \
                 patch('conductr_cli.resolvers.uri_resolver.cache_path', cache_path_mock), \
                 patch('conductr_cli.resolvers.uri_resolver.get_url', get_url_mock), \
-                patch('conductr_cli.resolvers.uri_resolver.urlretrieve', urlretrieve_mock):
+                patch('conductr_cli.resolvers.uri_resolver.urlretrieve', urlretrieve_mock), \
+                patch('logging.getLogger', get_logger_mock):
             is_resolved, bundle_name, bundle_file = uri_resolver.resolve_bundle('/cache-dir', '/bundle-url')
             self.assertFalse(is_resolved)
             self.assertIsNone(bundle_name)
@@ -72,6 +88,9 @@ class TestResolveBundle(TestCase):
         cache_path_mock.assert_called_with('/cache-dir', '/bundle-url')
         get_url_mock.assert_called_with('/bundle-url')
         urlretrieve_mock.assert_called_with('/bundle-url-resolved', '/bundle-cached-path')
+
+        get_logger_mock.assert_called_with('conductr_cli.resolvers.uri_resolver')
+        log_mock.info.assert_called_with('Retrieving /bundle-url-resolved')
 
 
 class TestLoadFromCache(TestCase):
@@ -84,7 +103,10 @@ class TestLoadFromCache(TestCase):
     def test_uri_found(self):
         exists_mock = MagicMock(return_value=True)
 
-        with patch('os.path.exists', exists_mock):
+        get_logger_mock, log_mock = create_mock_logger()
+
+        with patch('os.path.exists', exists_mock), \
+                patch('logging.getLogger', get_logger_mock):
             is_resolved, bundle_name, bundle_file = uri_resolver.load_from_cache('/cache-dir',
                                                                                  'http://site.com/path/bundle-file.zip')
             self.assertTrue(is_resolved)
@@ -92,6 +114,9 @@ class TestLoadFromCache(TestCase):
             self.assertEqual('/cache-dir/bundle-file.zip', bundle_file)
 
         exists_mock.assert_called_with('/cache-dir/bundle-file.zip')
+
+        get_logger_mock.assert_called_with('conductr_cli.resolvers.uri_resolver')
+        log_mock.info.assert_called_with('Retrieving from cache /cache-dir/bundle-file.zip')
 
     def test_uri_not_found(self):
         exists_mock = MagicMock(return_value=False)

--- a/conductr_cli/resolvers/uri_resolver.py
+++ b/conductr_cli/resolvers/uri_resolver.py
@@ -3,16 +3,19 @@ from urllib.parse import ParseResult, urlparse, urlunparse
 from urllib.error import URLError
 from pathlib import Path
 import os
+import logging
 
 
 def resolve_bundle(cache_dir, uri):
+    log = logging.getLogger(__name__)
+
     if not os.path.exists(cache_dir):
         os.makedirs(cache_dir)
 
     try:
         bundle_name, bundle_url = get_url(uri)
         cached_file = cache_path(cache_dir, uri)
-        print('Retrieving {}'.format(bundle_url))
+        log.info('Retrieving {}'.format(bundle_url))
         bundle_file, bundle_headers = urlretrieve(bundle_url, cached_file)
         return True, bundle_name, bundle_file
     except URLError:
@@ -25,10 +28,12 @@ def load_from_cache(cache_dir, uri):
     if parsed.scheme == 'file':
         return False, None, None
     else:
+        log = logging.getLogger(__name__)
+
         cached_file = cache_path(cache_dir, uri)
         if os.path.exists(cached_file):
             bundle_name = os.path.basename(cached_file)
-            print('Retrieving from cache {}'.format(cached_file))
+            log.info('Retrieving from cache {}'.format(cached_file))
             return True, bundle_name, cached_file
         else:
             return False, None, None

--- a/conductr_cli/sandbox.py
+++ b/conductr_cli/sandbox.py
@@ -1,7 +1,7 @@
 import argcomplete
 import argparse
 from conductr_cli.sandbox_common import CONDUCTR_DEV_IMAGE
-from conductr_cli import sandbox_run, sandbox_stop, sandbox_common
+from conductr_cli import sandbox_run, sandbox_stop, sandbox_common, logging_setup
 
 
 def build_parser():
@@ -121,6 +121,7 @@ def run():
                     'to obtain the current version information.')
     # Call sandbox function
     else:
+        logging_setup.configure_logging(args)
         args.func(args)
 
 

--- a/conductr_cli/sandbox_stop.py
+++ b/conductr_cli/sandbox_stop.py
@@ -1,11 +1,13 @@
 from conductr_cli import sandbox_common, terminal, validation
+import logging
 
 
 @validation.handle_docker_errors
 def stop(args):
     """`sandbox stop` command"""
 
+    log = logging.getLogger(__name__)
     running_containers = sandbox_common.resolve_running_docker_containers()
     if running_containers:
-        print('Stopping ConductR..')
+        log.info('Stopping ConductR..')
         terminal.docker_rm(running_containers)

--- a/conductr_cli/shazar.py
+++ b/conductr_cli/shazar.py
@@ -1,7 +1,9 @@
 import argcomplete
 import argparse
 from functools import partial
+from conductr_cli import logging_setup
 import hashlib
+import logging
 import os
 import shutil
 import tempfile
@@ -12,6 +14,7 @@ def run(argv=None):
     parser = build_parser()
     argcomplete.autocomplete(parser)
     args = parser.parse_args(argv)
+    logging_setup.configure_logging(args)
     args.func(args)
 
 
@@ -29,6 +32,7 @@ def build_parser():
 
 
 def shazar(args):
+    log = logging.getLogger(__name__)
     source_base_name = os.path.basename(args.source.rstrip('\\/'))
     temp_file = tempfile.NamedTemporaryFile(suffix='.zip', delete=False).name
 
@@ -44,7 +48,7 @@ def shazar(args):
 
     dest = os.path.join(args.output_dir, '{}-{}.zip'.format(source_base_name, create_digest(temp_file)))
     shutil.move(temp_file, dest)
-    print('Created digested ZIP archive at {}'.format(dest))
+    log.info('Created digested ZIP archive at {}'.format(dest))
 
 
 def create_digest(file_name):

--- a/conductr_cli/test/cli_test_case.py
+++ b/conductr_cli/test/cli_test_case.py
@@ -52,7 +52,7 @@ class CliTestCase(TestCase):
 
     @staticmethod
     def output(logger):
-        return ''.join([args[0] for name, args, kwargs in logger.method_calls])
+        return ''.join([args[0] for name, args, kwargs in logger.method_calls if len(args) > 0])
 
 
 def strip_margin(string, margin_char='|'):
@@ -84,3 +84,17 @@ def create_temp_bundle_with_contents(contents):
 
 def create_temp_bundle(bundle_conf):
     return create_temp_bundle_with_contents({'bundle.conf': bundle_conf, 'password.txt': 'monkey'})
+
+
+def create_mock_logger():
+    log_mock = MagicMock()
+    log_mock.debug = MagicMock()
+    log_mock.verbose = MagicMock()
+    log_mock.info = MagicMock()
+    log_mock.quiet = MagicMock()
+    log_mock.warn = MagicMock()
+    log_mock.error = MagicMock()
+
+    get_logger_mock = MagicMock(return_value=log_mock)
+
+    return get_logger_mock, log_mock

--- a/conductr_cli/test/conduct_run_test_base.py
+++ b/conductr_cli/test/conduct_run_test_base.py
@@ -1,5 +1,5 @@
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin, as_error
-from conductr_cli import conduct_run
+from conductr_cli import conduct_run, logging_setup
 
 try:
     from unittest.mock import patch, MagicMock  # 3.3 and beyond
@@ -30,7 +30,8 @@ class ConductRunTestBase(CliTestCase):
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
 
-        with patch('requests.put', http_method), patch('sys.stdout', stdout):
+        with patch('requests.put', http_method):
+            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
             conduct_run.run(MagicMock(**self.default_args))
 
         http_method.assert_called_with(self.default_url)
@@ -41,9 +42,10 @@ class ConductRunTestBase(CliTestCase):
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
 
-        with patch('requests.put', http_method), patch('sys.stdout', stdout):
+        with patch('requests.put', http_method):
             args = self.default_args.copy()
             args.update({'verbose': True})
+            logging_setup.configure_logging(MagicMock(**args), stdout)
             conduct_run.run(MagicMock(**args))
 
         http_method.assert_called_with(self.default_url)
@@ -54,9 +56,10 @@ class ConductRunTestBase(CliTestCase):
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
 
-        with patch('requests.put', http_method), patch('sys.stdout', stdout):
+        with patch('requests.put', http_method):
             args = self.default_args.copy()
             args.update({'long_ids': True})
+            logging_setup.configure_logging(MagicMock(**args), stdout)
             conduct_run.run(MagicMock(**args))
 
         http_method.assert_called_with(self.default_url)
@@ -71,6 +74,7 @@ class ConductRunTestBase(CliTestCase):
         with patch('requests.put', http_method), patch('sys.stdout', stdout):
             args = self.default_args.copy()
             args.update({'cli_parameters': cli_parameters})
+            logging_setup.configure_logging(MagicMock(**args), stdout)
             conduct_run.run(MagicMock(**args))
 
         http_method.assert_called_with(self.default_url)
@@ -83,7 +87,8 @@ class ConductRunTestBase(CliTestCase):
         http_method = self.respond_with(404)
         stderr = MagicMock()
 
-        with patch('requests.put', http_method), patch('sys.stderr', stderr):
+        with patch('requests.put', http_method):
+            logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
             conduct_run.run(MagicMock(**self.default_args))
 
         http_method.assert_called_with(self.default_url)
@@ -97,7 +102,8 @@ class ConductRunTestBase(CliTestCase):
         http_method = self.raise_connection_error('test reason', self.default_url)
         stderr = MagicMock()
 
-        with patch('requests.put', http_method), patch('sys.stderr', stderr):
+        with patch('requests.put', http_method):
+            logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
             conduct_run.run(MagicMock(**self.default_args))
 
         http_method.assert_called_with(self.default_url)

--- a/conductr_cli/test/test_conduct.py
+++ b/conductr_cli/test/test_conduct.py
@@ -76,6 +76,7 @@ class TestConduct(TestCase):
         self.assertEqual(args.long_ids, False)
         self.assertEqual(args.bundle, 'path-to-bundle')
         self.assertEqual(args.configuration, 'path-to-conf')
+        self.assertFalse(args.quiet)
 
     def test_parser_run(self):
         args = self.parser.parse_args('run --scale 5 path-to-bundle'.split())

--- a/conductr_cli/test/test_conduct_events.py
+++ b/conductr_cli/test/test_conduct_events.py
@@ -1,5 +1,5 @@
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
-from conductr_cli import conduct_events
+from conductr_cli import conduct_events, logging_setup
 from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
 
 
@@ -27,7 +27,8 @@ class TestConductEventsCommand(CliTestCase):
         http_method = self.respond_with(text='{}')
         stdout = MagicMock()
 
-        with patch('requests.get', http_method), patch('sys.stdout', stdout):
+        with patch('requests.get', http_method):
+            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
             conduct_events.events(MagicMock(**self.default_args))
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
@@ -51,7 +52,8 @@ class TestConductEventsCommand(CliTestCase):
         ]""")
         stdout = MagicMock()
 
-        with patch('requests.get', http_method), patch('sys.stdout', stdout):
+        with patch('requests.get', http_method):
+            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
             conduct_events.events(MagicMock(**self.default_args))
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
@@ -66,7 +68,8 @@ class TestConductEventsCommand(CliTestCase):
         http_method = self.raise_connection_error('test reason', self.default_url)
         stderr = MagicMock()
 
-        with patch('requests.get', http_method), patch('sys.stderr', stderr):
+        with patch('requests.get', http_method):
+            logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
             conduct_events.events(MagicMock(**self.default_args))
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)

--- a/conductr_cli/test/test_conduct_info.py
+++ b/conductr_cli/test/test_conduct_info.py
@@ -1,5 +1,5 @@
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
-from conductr_cli import conduct_info
+from conductr_cli import conduct_info, logging_setup
 from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
 
 
@@ -16,6 +16,7 @@ class TestConductInfoCommand(CliTestCase):
         'port': 9005,
         'api_version': '1',
         'verbose': False,
+        'quiet': False,
         'long_ids': False
     }
 
@@ -25,7 +26,8 @@ class TestConductInfoCommand(CliTestCase):
         http_method = self.respond_with(text='[]')
         stdout = MagicMock()
 
-        with patch('requests.get', http_method), patch('sys.stdout', stdout):
+        with patch('requests.get', http_method):
+            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
             conduct_info.info(MagicMock(**self.default_args))
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
@@ -45,7 +47,8 @@ class TestConductInfoCommand(CliTestCase):
         ]""")
         stdout = MagicMock()
 
-        with patch('requests.get', http_method), patch('sys.stdout', stdout):
+        with patch('requests.get', http_method):
+            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
             conduct_info.info(MagicMock(**self.default_args))
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
@@ -78,7 +81,8 @@ class TestConductInfoCommand(CliTestCase):
         ]""")
         stdout = MagicMock()
 
-        with patch('requests.get', http_method), patch('sys.stdout', stdout):
+        with patch('requests.get', http_method):
+            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
             conduct_info.info(MagicMock(**self.default_args))
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
@@ -107,9 +111,10 @@ class TestConductInfoCommand(CliTestCase):
         ]""")
         stdout = MagicMock()
 
-        with patch('requests.get', http_method), patch('sys.stdout', stdout):
+        with patch('requests.get', http_method):
             args = self.default_args.copy()
             args.update({'verbose': True})
+            logging_setup.configure_logging(MagicMock(**args), stdout)
             conduct_info.info(MagicMock(**args))
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
@@ -167,9 +172,10 @@ class TestConductInfoCommand(CliTestCase):
         ]""")
         stdout = MagicMock()
 
-        with patch('requests.get', http_method), patch('sys.stdout', stdout):
+        with patch('requests.get', http_method):
             args = self.default_args.copy()
             args.update({'long_ids': True})
+            logging_setup.configure_logging(MagicMock(**args), stdout)
             conduct_info.info(MagicMock(**args))
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
@@ -190,7 +196,8 @@ class TestConductInfoCommand(CliTestCase):
         ]""")
         stdout = MagicMock()
 
-        with patch('requests.get', http_method), patch('sys.stdout', stdout):
+        with patch('requests.get', http_method):
+            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
             conduct_info.info(MagicMock(**self.default_args))
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
@@ -212,7 +219,8 @@ class TestConductInfoCommand(CliTestCase):
         ]""")
         stdout = MagicMock()
 
-        with patch('requests.get', http_method), patch('sys.stdout', stdout):
+        with patch('requests.get', http_method):
+            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
             conduct_info.info(MagicMock(**self.default_args))
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
@@ -227,7 +235,8 @@ class TestConductInfoCommand(CliTestCase):
         http_method = self.raise_connection_error('test reason', self.default_url)
         stderr = MagicMock()
 
-        with patch('requests.get', http_method), patch('sys.stderr', stderr):
+        with patch('requests.get', http_method):
+            logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
             conduct_info.info(MagicMock(**self.default_args))
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)

--- a/conductr_cli/test/test_conduct_load_v1.py
+++ b/conductr_cli/test/test_conduct_load_v1.py
@@ -1,7 +1,7 @@
 from conductr_cli.test.conduct_load_test_base import ConductLoadTestBase
 from conductr_cli.test.cli_test_case import create_temp_bundle, strip_margin, as_error, \
     create_temp_bundle_with_contents
-from conductr_cli import conduct_load
+from conductr_cli import conduct_load, logging_setup
 from conductr_cli.conduct_load import LOAD_HTTP_TIMEOUT
 import shutil
 
@@ -43,6 +43,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
             'port': 9005,
             'api_version': '1',
             'verbose': False,
+            'quiet': False,
             'long_ids': False,
             'cli_parameters': '',
             'custom_settings': self.custom_settings,
@@ -69,6 +70,9 @@ class TestConductLoadCommand(ConductLoadTestBase):
     def test_success_verbose(self):
         self.base_test_success_verbose()
 
+    def test_success_quiet(self):
+        self.base_test_success_quiet()
+
     def test_success_long_ids(self):
         self.base_test_success_long_ids()
 
@@ -88,10 +92,10 @@ class TestConductLoadCommand(ConductLoadTestBase):
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('requests.post', http_method), \
-                patch('sys.stdout', stdout), \
                 patch('builtins.open', open_mock):
             args = self.default_args.copy()
             args.update({'configuration': config_file})
+            logging_setup.configure_logging(MagicMock(**args), stdout)
             conduct_load.load(MagicMock(**args))
 
         self.assertEqual(
@@ -135,10 +139,10 @@ class TestConductLoadCommand(ConductLoadTestBase):
                             |""").format(self.memory, self.disk_space, ', '.join(self.roles)))
 
         resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, bundle_file))
-        with patch('sys.stderr', stderr), \
-                patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
+        with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
             args = self.default_args.copy()
             args.update({'bundle': bundle_file})
+            logging_setup.configure_logging(MagicMock(**args), err_output=stderr)
             conduct_load.load(MagicMock(**args))
 
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, bundle_file)
@@ -161,10 +165,10 @@ class TestConductLoadCommand(ConductLoadTestBase):
                             |""").format(self.nr_of_cpus, self.disk_space, ', '.join(self.roles)))
 
         resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, bundle_file))
-        with patch('sys.stderr', stderr), \
-                patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
+        with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
             args = self.default_args.copy()
             args.update({'bundle': bundle_file})
+            logging_setup.configure_logging(MagicMock(**args), err_output=stderr)
             conduct_load.load(MagicMock(**args))
 
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, bundle_file)
@@ -187,10 +191,10 @@ class TestConductLoadCommand(ConductLoadTestBase):
                             |""").format(self.nr_of_cpus, self.memory, ', '.join(self.roles)))
 
         resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, bundle_file))
-        with patch('sys.stderr', stderr), \
-                patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
+        with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
             args = self.default_args.copy()
             args.update({'bundle': bundle_file})
+            logging_setup.configure_logging(MagicMock(**args), err_output=stderr)
             conduct_load.load(MagicMock(**args))
 
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, bundle_file)
@@ -213,10 +217,10 @@ class TestConductLoadCommand(ConductLoadTestBase):
                             |""").format(self.nr_of_cpus, self.memory, self.disk_space))
 
         resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, bundle_file))
-        with patch('sys.stderr', stderr), \
-                patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
+        with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
             args = self.default_args.copy()
             args.update({'bundle': bundle_file})
+            logging_setup.configure_logging(MagicMock(**args), err_output=stderr)
             conduct_load.load(MagicMock(**args))
 
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, bundle_file)
@@ -240,10 +244,10 @@ class TestConductLoadCommand(ConductLoadTestBase):
                             |""").format(self.nr_of_cpus, self.memory, self.disk_space, '-'.join(self.roles)))
 
         resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, bundle_file))
-        with patch('sys.stderr', stderr), \
-                patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
+        with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
             args = self.default_args.copy()
             args.update({'bundle': bundle_file})
+            logging_setup.configure_logging(MagicMock(**args), err_output=stderr)
             conduct_load.load(MagicMock(**args))
 
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, bundle_file)
@@ -255,3 +259,12 @@ class TestConductLoadCommand(ConductLoadTestBase):
             self.output(stderr))
 
         shutil.rmtree(tmpdir)
+
+    def test_failure_bad_zip(self):
+        self.base_test_failure_bad_zip()
+
+    def test_failure_no_file_http_error(self):
+        self.base_test_failure_no_file_http_error()
+
+    def test_failure_no_file_url_error(self):
+        self.base_test_failure_no_file_url_error()

--- a/conductr_cli/test/test_conduct_logs.py
+++ b/conductr_cli/test/test_conduct_logs.py
@@ -1,5 +1,5 @@
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
-from conductr_cli import conduct_logs
+from conductr_cli import conduct_logs, logging_setup
 from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
 
 
@@ -27,7 +27,8 @@ class TestConductLogsCommand(CliTestCase):
         http_method = self.respond_with(text='{}')
         stdout = MagicMock()
 
-        with patch('requests.get', http_method), patch('sys.stdout', stdout):
+        with patch('requests.get', http_method):
+            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
             conduct_logs.logs(MagicMock(**self.default_args))
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
@@ -51,7 +52,8 @@ class TestConductLogsCommand(CliTestCase):
         ]""")
         stdout = MagicMock()
 
-        with patch('requests.get', http_method), patch('sys.stdout', stdout):
+        with patch('requests.get', http_method):
+            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
             conduct_logs.logs(MagicMock(**self.default_args))
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
@@ -66,7 +68,8 @@ class TestConductLogsCommand(CliTestCase):
         http_method = self.raise_connection_error('test reason', self.default_url)
         stderr = MagicMock()
 
-        with patch('requests.get', http_method), patch('sys.stderr', stderr):
+        with patch('requests.get', http_method):
+            logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
             conduct_logs.logs(MagicMock(**self.default_args))
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)

--- a/conductr_cli/test/test_conduct_run_v1.py
+++ b/conductr_cli/test/test_conduct_run_v1.py
@@ -1,12 +1,12 @@
-from conductr_cli.test.cli_test_case import strip_margin
+from conductr_cli.test.cli_test_case import strip_margin, as_error
 from conductr_cli.test.conduct_run_test_base import ConductRunTestBase
-from conductr_cli import conduct_run
+from conductr_cli import conduct_run, logging_setup
 
 
 try:
-    from unittest.mock import patch, MagicMock  # 3.3 and beyond
+    from unittest.mock import MagicMock  # 3.3 and beyond
 except ImportError:
-    from mock import patch, MagicMock
+    from mock import MagicMock
 
 
 class TestConductRunCommand(ConductRunTestBase):
@@ -19,6 +19,7 @@ class TestConductRunCommand(ConductRunTestBase):
             'port': 9005,
             'api_version': '1',
             'verbose': False,
+            'quiet': False,
             'long_ids': False,
             'cli_parameters': '',
             'bundle': '45e0c477d3e5ea92aa8d85c0d8f3e25c',
@@ -55,7 +56,7 @@ class TestConductRunCommand(ConductRunTestBase):
         args = {
             'ip': '127.0.0.1',
             'port': 9005,
-            'api_version': '1.0',
+            'api_version': '1',
             'verbose': False,
             'long_ids': False,
             'cli_parameters': '',
@@ -65,10 +66,11 @@ class TestConductRunCommand(ConductRunTestBase):
         }
 
         stderr = MagicMock()
-        with patch('sys.stderr', stderr):
-            conduct_run.run(MagicMock(**args))
+
+        logging_setup.configure_logging(MagicMock(**args), err_output=stderr)
+        conduct_run.run(MagicMock(**args))
 
         self.assertEqual(
-            strip_margin("""|ERROR: Affinity feature is only available for v1.1 onwards of ConductR
-                            |"""),
+            as_error(strip_margin("""|Error: Affinity feature is only available for v1.1 onwards of ConductR
+                            |""")),
             self.output(stderr))

--- a/conductr_cli/test/test_conduct_run_v2.py
+++ b/conductr_cli/test/test_conduct_run_v2.py
@@ -1,5 +1,5 @@
 from conductr_cli.test.conduct_run_test_base import ConductRunTestBase
-from conductr_cli import conduct_run
+from conductr_cli import conduct_run, logging_setup
 
 try:
     from unittest.mock import patch, MagicMock  # 3.3 and beyond
@@ -17,6 +17,7 @@ class TestConductRunCommand(ConductRunTestBase):
             'port': 9005,
             'api_version': '2',
             'verbose': False,
+            'quiet': False,
             'long_ids': False,
             'cli_parameters': '',
             'bundle': '45e0c477d3e5ea92aa8d85c0d8f3e25c',
@@ -55,6 +56,7 @@ class TestConductRunCommand(ConductRunTestBase):
             'port': 9005,
             'api_version': '2',
             'verbose': False,
+            'quiet': False,
             'long_ids': False,
             'cli_parameters': '',
             'bundle': '45e0c477d3e5ea92aa8d85c0d8f3e25c',
@@ -68,7 +70,8 @@ class TestConductRunCommand(ConductRunTestBase):
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
 
-        with patch('requests.put', http_method), patch('sys.stdout', stdout):
+        with patch('requests.put', http_method):
+            logging_setup.configure_logging(MagicMock(**args), stdout)
             conduct_run.run(MagicMock(**args))
 
         http_method.assert_called_with(expected_url)

--- a/conductr_cli/test/test_conduct_services.py
+++ b/conductr_cli/test/test_conduct_services.py
@@ -1,5 +1,5 @@
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin, as_warn
-from conductr_cli import conduct_services
+from conductr_cli import conduct_services, logging_setup
 from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
 
 
@@ -25,7 +25,8 @@ class TestConductServicesCommand(CliTestCase):
         http_method = self.respond_with(200, '[]')
         stdout = MagicMock()
 
-        with patch('requests.get', http_method), patch('sys.stdout', stdout):
+        with patch('requests.get', http_method):
+            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
             conduct_services.services(MagicMock(**self.default_args))
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
@@ -38,7 +39,8 @@ class TestConductServicesCommand(CliTestCase):
         http_method = self.respond_with_file_contents('data/two_bundles.json')
         stdout = MagicMock()
 
-        with patch('requests.get', http_method), patch('sys.stdout', stdout):
+        with patch('requests.get', http_method):
+            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
             conduct_services.services(MagicMock(**self.default_args))
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
@@ -62,7 +64,8 @@ class TestConductServicesCommand(CliTestCase):
         http_method = self.respond_with_file_contents('data/two_bundles_no_path.json')
         stdout = MagicMock()
 
-        with patch('requests.get', http_method), patch('sys.stdout', stdout):
+        with patch('requests.get', http_method):
+            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
             conduct_services.services(MagicMock(**self.default_args))
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
@@ -83,7 +86,8 @@ class TestConductServicesCommand(CliTestCase):
         http_method = self.respond_with_file_contents('data/one_bundle_starting.json')
         stdout = MagicMock()
 
-        with patch('requests.get', http_method), patch('sys.stdout', stdout):
+        with patch('requests.get', http_method):
+            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
             conduct_services.services(MagicMock(**self.default_args))
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
@@ -101,9 +105,10 @@ class TestConductServicesCommand(CliTestCase):
         http_method = self.respond_with_file_contents('data/one_bundle_starting.json')
         stdout = MagicMock()
 
-        with patch('requests.get', http_method), patch('sys.stdout', stdout):
+        with patch('requests.get', http_method):
             args = self.default_args.copy()
             args.update({'long_ids': True})
+            logging_setup.configure_logging(MagicMock(**args), stdout)
             conduct_services.services(MagicMock(**args))
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)

--- a/conductr_cli/test/test_conduct_stop.py
+++ b/conductr_cli/test/test_conduct_stop.py
@@ -1,5 +1,5 @@
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin, as_error
-from conductr_cli import conduct_stop
+from conductr_cli import conduct_stop, logging_setup
 from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
 
 
@@ -23,6 +23,7 @@ class TestConductStopCommand(CliTestCase):
         'port': 9005,
         'api_version': '1',
         'verbose': False,
+        'quiet': False,
         'long_ids': False,
         'cli_parameters': '',
         'bundle': '45e0c477d3e5ea92aa8d85c0d8f3e25c'
@@ -42,7 +43,8 @@ class TestConductStopCommand(CliTestCase):
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
 
-        with patch('requests.put', http_method), patch('sys.stdout', stdout):
+        with patch('requests.put', http_method):
+            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
             conduct_stop.stop(MagicMock(**self.default_args))
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
@@ -53,9 +55,10 @@ class TestConductStopCommand(CliTestCase):
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
 
-        with patch('requests.put', http_method), patch('sys.stdout', stdout):
+        with patch('requests.put', http_method):
             args = self.default_args.copy()
             args.update({'verbose': True})
+            logging_setup.configure_logging(MagicMock(**args), stdout)
             conduct_stop.stop(MagicMock(**args))
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
@@ -66,9 +69,10 @@ class TestConductStopCommand(CliTestCase):
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
 
-        with patch('requests.put', http_method), patch('sys.stdout', stdout):
+        with patch('requests.put', http_method):
             args = self.default_args.copy()
             args.update({'long_ids': True})
+            logging_setup.configure_logging(MagicMock(**args), stdout)
             conduct_stop.stop(MagicMock(**args))
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
@@ -80,9 +84,10 @@ class TestConductStopCommand(CliTestCase):
         stdout = MagicMock()
 
         cli_parameters = ' --ip 127.0.1.1 --port 9006'
-        with patch('requests.put', http_method), patch('sys.stdout', stdout):
+        with patch('requests.put', http_method):
             args = self.default_args.copy()
             args.update({'cli_parameters': cli_parameters})
+            logging_setup.configure_logging(MagicMock(**args), stdout)
             conduct_stop.stop(MagicMock(**args))
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
@@ -95,7 +100,8 @@ class TestConductStopCommand(CliTestCase):
         http_method = self.respond_with(404)
         stderr = MagicMock()
 
-        with patch('requests.put', http_method), patch('sys.stderr', stderr):
+        with patch('requests.put', http_method):
+            logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
             conduct_stop.stop(MagicMock(**self.default_args))
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
@@ -109,7 +115,8 @@ class TestConductStopCommand(CliTestCase):
         http_method = self.raise_connection_error('test reason', self.default_url)
         stderr = MagicMock()
 
-        with patch('requests.put', http_method), patch('sys.stderr', stderr):
+        with patch('requests.put', http_method):
+            logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
             conduct_stop.stop(MagicMock(**self.default_args))
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)

--- a/conductr_cli/test/test_conduct_unload.py
+++ b/conductr_cli/test/test_conduct_unload.py
@@ -1,5 +1,5 @@
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin, as_error
-from conductr_cli import conduct_unload
+from conductr_cli import conduct_unload, logging_setup
 from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
 
 try:
@@ -22,6 +22,7 @@ class TestConductUnloadCommand(CliTestCase):
         'port': 9005,
         'api_version': '1',
         'verbose': False,
+        'quiet': False,
         'cli_parameters': '',
         'bundle': '45e0c477d3e5ea92aa8d85c0d8f3e25c'
     }
@@ -39,7 +40,8 @@ class TestConductUnloadCommand(CliTestCase):
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
 
-        with patch('requests.delete', http_method), patch('sys.stdout', stdout):
+        with patch('requests.delete', http_method):
+            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
             conduct_unload.unload(MagicMock(**self.default_args))
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
@@ -53,6 +55,7 @@ class TestConductUnloadCommand(CliTestCase):
         with patch('requests.delete', http_method), patch('sys.stdout', stdout):
             args = self.default_args.copy()
             args.update({'verbose': True})
+            logging_setup.configure_logging(MagicMock(**args), stdout)
             conduct_unload.unload(MagicMock(**args))
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
@@ -64,9 +67,10 @@ class TestConductUnloadCommand(CliTestCase):
         stdout = MagicMock()
 
         cli_parameters = ' --ip 127.0.1.1 --port 9006'
-        with patch('requests.delete', http_method), patch('sys.stdout', stdout):
+        with patch('requests.delete', http_method):
             args = self.default_args.copy()
             args.update({'cli_parameters': cli_parameters})
+            logging_setup.configure_logging(MagicMock(**args), stdout)
             conduct_unload.unload(MagicMock(**args))
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
@@ -79,7 +83,8 @@ class TestConductUnloadCommand(CliTestCase):
         http_method = self.respond_with(404)
         stderr = MagicMock()
 
-        with patch('requests.delete', http_method), patch('sys.stderr', stderr):
+        with patch('requests.delete', http_method):
+            logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
             conduct_unload.unload(MagicMock(**self.default_args))
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
@@ -93,7 +98,8 @@ class TestConductUnloadCommand(CliTestCase):
         http_method = self.raise_connection_error('test reason', self.default_url)
         stderr = MagicMock()
 
-        with patch('requests.delete', http_method), patch('sys.stderr', stderr):
+        with patch('requests.delete', http_method):
+            logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
             conduct_unload.unload(MagicMock(**self.default_args))
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)

--- a/conductr_cli/test/test_conduct_version.py
+++ b/conductr_cli/test/test_conduct_version.py
@@ -1,10 +1,10 @@
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
-from conductr_cli import conduct_version
+from conductr_cli import conduct_version, logging_setup
 
 try:
-    from unittest.mock import patch, MagicMock  # 3.3 and beyond
+    from unittest.mock import MagicMock  # 3.3 and beyond
 except ImportError:
-    from mock import patch, MagicMock
+    from mock import MagicMock
 
 
 class TestConductVersionCommand(CliTestCase):
@@ -13,8 +13,8 @@ class TestConductVersionCommand(CliTestCase):
         args = MagicMock()
         stdout = MagicMock()
 
-        with patch('sys.stdout', stdout):
-            conduct_version.version(args)
+        logging_setup.configure_logging(args, stdout)
+        conduct_version.version(args)
 
         from conductr_cli import __version__
         self.assertEqual(

--- a/conductr_cli/test/test_logging_setup.py
+++ b/conductr_cli/test/test_logging_setup.py
@@ -1,0 +1,85 @@
+from conductr_cli.test.cli_test_case import CliTestCase, as_error, as_warn, strip_margin
+from conductr_cli import logging_setup
+import logging
+
+try:
+    from unittest.mock import MagicMock  # 3.3 and beyond
+except ImportError:
+    from mock import MagicMock
+
+
+class TestRootLogger(CliTestCase):
+    def test_should_display_error_only(self):
+        stdout = MagicMock()
+        stderr = MagicMock()
+        logging_setup.configure_logging(MagicMock(), stdout, stderr)
+
+        log = logging.getLogger()
+        log.debug('this is debug')
+        log.verbose('this is verbose')
+        log.info('this is info')
+        log.quiet('this is quiet')
+        log.warn('this is warning')
+        log.error('this is error')
+
+        self.assertFalse(log.is_debug_enabled())
+        self.assertFalse(log.is_verbose_enabled())
+        self.assertFalse(log.is_info_enabled())
+        self.assertFalse(log.is_quiet_enabled())
+        self.assertFalse(log.is_warn_enabled())
+
+        self.assertEqual('', self.output(stdout))
+        self.assertEqual(as_error('Error: this is error\n'), self.output(stderr))
+
+
+class TestConductrCliLogger(CliTestCase):
+    def test_default_settings(self):
+        stdout = MagicMock()
+        stderr = MagicMock()
+        logging_setup.configure_logging(MagicMock(), stdout, stderr)
+
+        log = logging.getLogger('conductr_cli')
+        log.debug('this is debug')
+        log.verbose('this is verbose')
+        log.info('this is info')
+        log.quiet('this is quiet')
+        log.warn('this is warning')
+        log.error('this is error')
+
+        self.assertFalse(log.is_debug_enabled())
+        self.assertFalse(log.is_verbose_enabled())
+        self.assertTrue(log.is_info_enabled())
+        self.assertTrue(log.is_quiet_enabled())
+        self.assertTrue(log.is_warn_enabled())
+
+        self.assertEqual(as_warn(strip_margin("""|this is info
+                                                 |this is quiet
+                                                 |Warning: this is warning
+                                                 |""")), self.output(stdout))
+        self.assertEqual(as_error('Error: this is error\n'), self.output(stderr))
+
+    def test_verbose_settings(self):
+        stdout = MagicMock()
+        stderr = MagicMock()
+        logging_setup.configure_logging(MagicMock(**{'verbose': True}), stdout, stderr)
+
+        log = logging.getLogger('conductr_cli')
+        log.debug('this is debug')
+        log.verbose('this is verbose')
+        log.info('this is info')
+        log.quiet('this is quiet')
+        log.warn('this is warning')
+        log.error('this is error')
+
+        self.assertFalse(log.is_debug_enabled())
+        self.assertTrue(log.is_verbose_enabled())
+        self.assertTrue(log.is_info_enabled())
+        self.assertTrue(log.is_quiet_enabled())
+        self.assertTrue(log.is_warn_enabled())
+
+        self.assertEqual(as_warn(strip_margin("""|this is verbose
+                                                 |this is info
+                                                 |this is quiet
+                                                 |Warning: this is warning
+                                                 |""")), self.output(stdout))
+        self.assertEqual(as_error('Error: this is error\n'), self.output(stderr))

--- a/conductr_cli/test/test_resolver.py
+++ b/conductr_cli/test/test_resolver.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from conductr_cli.test.cli_test_case import strip_margin
+from conductr_cli.test.cli_test_case import strip_margin, create_mock_logger
 from conductr_cli.exceptions import BundleResolutionError
 from conductr_cli import resolver
 from conductr_cli.resolvers import bintray_resolver, uri_resolver
@@ -81,9 +81,16 @@ class TestResolverChain(TestCase):
                             |]
                             |""")
         )
-        result = resolver.resolver_chain(custom_settings)
-        expected_result = [uri_resolver]
-        self.assertEqual(expected_result, result)
+
+        get_logger_mock, log_mock = create_mock_logger()
+
+        with patch('logging.getLogger', get_logger_mock):
+            result = resolver.resolver_chain(custom_settings)
+            expected_result = [uri_resolver]
+            self.assertEqual(expected_result, result)
+
+        get_logger_mock.assert_called_with('conductr_cli.resolver')
+        log_mock.info.assert_called_with('Using custom bundle resolver chain [\'conductr_cli.resolvers.uri_resolver\']')
 
     def test_none_input(self):
         result = resolver.resolver_chain(None)

--- a/conductr_cli/test/test_sandbox_run.py
+++ b/conductr_cli/test/test_sandbox_run.py
@@ -1,5 +1,5 @@
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
-from conductr_cli import sandbox_run
+from conductr_cli import sandbox_run, logging_setup
 from conductr_cli.sandbox_common import CONDUCTR_DEV_IMAGE, LATEST_CONDUCTR_VERSION
 
 
@@ -45,8 +45,8 @@ class TestSandboxRunCommand(CliTestCase):
                 patch('conductr_cli.terminal.docker_inspect', return_value='10.10.10.10'), \
                 patch('conductr_cli.terminal.docker_run', return_value='') as mock_docker_run, \
                 patch('conductr_cli.sandbox_common.resolve_running_docker_containers', return_value=[]), \
-                patch('conductr_cli.sandbox_common.resolve_host_ip', return_value='192.168.99.100'), \
-                patch('sys.stdout', stdout):
+                patch('conductr_cli.sandbox_common.resolve_host_ip', return_value='192.168.99.100'):
+            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
             sandbox_run.run(MagicMock(**self.default_args))
 
         expected_stdout = strip_margin("""|Pulling down the ConductR development image..
@@ -70,10 +70,10 @@ class TestSandboxRunCommand(CliTestCase):
                 patch('conductr_cli.terminal.docker_inspect', return_value='10.10.10.10'), \
                 patch('conductr_cli.terminal.docker_run', return_value='') as mock_docker_run, \
                 patch('conductr_cli.sandbox_common.resolve_running_docker_containers', return_value=[]), \
-                patch('conductr_cli.sandbox_common.resolve_host_ip', return_value='192.168.99.100'), \
-                patch('sys.stdout', stdout):
+                patch('conductr_cli.sandbox_common.resolve_host_ip', return_value='192.168.99.100'):
             args = self.default_args.copy()
             args.update({'nr_of_containers': nr_of_containers})
+            logging_setup.configure_logging(MagicMock(**args), stdout)
             sandbox_run.run(MagicMock(**args))
 
         expected_stdout = strip_margin("""|Starting ConductR nodes..
@@ -126,8 +126,7 @@ class TestSandboxRunCommand(CliTestCase):
                 patch('conductr_cli.terminal.docker_inspect', return_value='10.10.10.10'), \
                 patch('conductr_cli.terminal.docker_run', return_value='') as mock_docker_run, \
                 patch('conductr_cli.sandbox_common.resolve_running_docker_containers', return_value=[]), \
-                patch('conductr_cli.sandbox_common.resolve_host_ip', return_value='192.168.99.100'), \
-                patch('sys.stdout', stdout):
+                patch('conductr_cli.sandbox_common.resolve_host_ip', return_value='192.168.99.100'):
             args = self.default_args.copy()
             args.update({
                 'image_version': image_version,
@@ -139,6 +138,7 @@ class TestSandboxRunCommand(CliTestCase):
                 'ports': ports,
                 'features': features
             })
+            logging_setup.configure_logging(MagicMock(**args), stdout)
             sandbox_run.run(MagicMock(**args))
 
         expected_stdout = strip_margin("""|Starting ConductR nodes..
@@ -166,13 +166,13 @@ class TestSandboxRunCommand(CliTestCase):
                 patch('conductr_cli.terminal.docker_inspect', return_value='10.10.10.10'), \
                 patch('conductr_cli.terminal.docker_run', return_value='') as mock_docker_run, \
                 patch('conductr_cli.sandbox_common.resolve_running_docker_containers', return_value=[]), \
-                patch('conductr_cli.sandbox_common.resolve_host_ip', return_value='192.168.99.100'), \
-                patch('sys.stdout', stdout):
+                patch('conductr_cli.sandbox_common.resolve_host_ip', return_value='192.168.99.100'):
             args = self.default_args.copy()
             args.update({
                 'nr_of_containers': nr_of_containers,
                 'conductr_roles': conductr_roles
             })
+            logging_setup.configure_logging(MagicMock(**args), stdout)
             sandbox_run.run(MagicMock(**args))
 
         expected_stdout = strip_margin("""|Starting ConductR nodes..
@@ -216,8 +216,8 @@ class TestSandboxRunCommand(CliTestCase):
         with \
                 patch('conductr_cli.terminal.docker_images', return_value='some-image'), \
                 patch('conductr_cli.sandbox_common.resolve_running_docker_containers',
-                      return_value=['cond-0']), \
-                patch('sys.stdout', stdout):
+                      return_value=['cond-0']):
+            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
             sandbox_run.run(MagicMock(**self.default_args))
 
         expected_stdout = strip_margin("""|ConductR nodes {} already exists, leaving them alone.
@@ -232,8 +232,8 @@ class TestSandboxRunCommand(CliTestCase):
                 patch('conductr_cli.terminal.docker_images', return_value='some-image'), \
                 patch('conductr_cli.terminal.docker_rm', return_value='') as mock_docker_rm, \
                 patch('conductr_cli.sandbox_common.resolve_running_docker_containers',
-                      return_value=['cond-0', 'cond-1', 'cond-2']), \
-                patch('sys.stdout', stdout):
+                      return_value=['cond-0', 'cond-1', 'cond-2']):
+            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
             sandbox_run.run(MagicMock(**self.default_args))
 
         expected_stdout = strip_margin("""|Stopping ConductR nodes..

--- a/conductr_cli/test/test_sandbox_stop.py
+++ b/conductr_cli/test/test_sandbox_stop.py
@@ -1,5 +1,5 @@
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
-from conductr_cli import sandbox_stop
+from conductr_cli import sandbox_stop, logging_setup
 
 
 try:
@@ -11,7 +11,9 @@ except ImportError:
 class TestSandboxStopCommand(CliTestCase):
 
     default_args = {
-        'local_connection': True
+        'local_connection': True,
+        'verbose': False,
+        'quiet': False
     }
 
     def expected_output(self):
@@ -22,8 +24,8 @@ class TestSandboxStopCommand(CliTestCase):
         containers = ['cond-0', 'cond-1']
 
         with patch('conductr_cli.sandbox_common.resolve_running_docker_containers', return_value=containers), \
-                patch('conductr_cli.terminal.docker_rm') as mock_docker_rm, \
-                patch('sys.stdout', stdout):
+                patch('conductr_cli.terminal.docker_rm') as mock_docker_rm:
+            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
             sandbox_stop.stop(MagicMock(**self.default_args))
 
         self.assertEqual('Stopping ConductR..\n', self.output(stdout))

--- a/conductr_cli/test/test_shazar.py
+++ b/conductr_cli/test/test_shazar.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 import shutil
 import tempfile
 from os import remove
+from conductr_cli import logging_setup
 from conductr_cli.shazar import create_digest, build_parser, run
 from conductr_cli.test.cli_test_case import CliTestCase
 
@@ -44,7 +45,12 @@ class TestIntegration(CliTestCase):
 
     def test(self):
         stdout = MagicMock()
-        with patch('sys.stdout', stdout):
+
+        logging_setup.configure_logging(MagicMock(), stdout)
+
+        # Patch configure logging to preserve the output to mock stdout
+        configure_logging_mock = MagicMock()
+        with patch('conductr_cli.logging_setup.configure_logging', configure_logging_mock):
             run('--output-dir {} {}'.format(self.tmpdir, self.tmpfile.name).split())
 
         self.assertRegex(


### PR DESCRIPTION
This change would mean `conduct load` will only display bundle id upon the activation of `-q` switch.

Replace all the `println()` with python's logging library, ensuring same behaviour and output.

Utilize python logging's message formatter to provide warning and error message formatting (i.e. colours and underlines).
