### PR TITLE
Implement wait for conduct run and conduct stop command

### DIFF
--- a/conductr_cli/bundle_installation.py
+++ b/conductr_cli/bundle_installation.py
@@ -1,0 +1,49 @@
+from __future__ import unicode_literals
+from conductr_cli import conduct_url, sse_client
+from conductr_cli.exceptions import WaitTimeoutError
+from datetime import datetime
+import json
+import logging
+import requests
+
+
+def count_installations(bundle_id, args):
+    bundles_url = conduct_url.url('bundles', args)
+    response = requests.get(bundles_url)
+    response.raise_for_status()
+    bundles = json.loads(response.text)
+    matching_bundles = [bundle for bundle in bundles if bundle['bundleId'] == bundle_id]
+    if matching_bundles:
+        matching_bundle = matching_bundles[0]
+        if 'bundleInstallations' in matching_bundle:
+            return len(matching_bundle['bundleInstallations'])
+
+    return 0
+
+
+def wait_for_installation(bundle_id, args):
+    log = logging.getLogger(__name__)
+    start_time = datetime.now()
+
+    installed_bundles = count_installations(bundle_id, args)
+    if installed_bundles > 0:
+        log.info('Bundle {} is installed'.format(bundle_id))
+        return
+    else:
+        log.info('Bundle {} waiting to be installed'.format(bundle_id))
+        bundle_events_url = conduct_url.url('bundles/events', args)
+        sse_events = sse_client.get_events(bundle_events_url)
+        for event in sse_events:
+            elapsed = (datetime.now() - start_time).total_seconds()
+            if elapsed > args.wait_timeout:
+                raise WaitTimeoutError('Bundle {} waiting to be installed'.format(bundle_id))
+
+            if event.event and event.event.startswith('bundleInstallation'):
+                installed_bundles = count_installations(bundle_id, args)
+                if installed_bundles > 0:
+                    log.info('Bundle {} installed'.format(bundle_id))
+                    return
+                else:
+                    log.info('Bundle {} still waiting to be installed'.format(bundle_id))
+
+        raise WaitTimeoutError('Bundle {} still waiting to be installed'.format(bundle_id))

--- a/conductr_cli/bundle_scale.py
+++ b/conductr_cli/bundle_scale.py
@@ -1,0 +1,52 @@
+from __future__ import unicode_literals
+from conductr_cli import conduct_url, sse_client
+from conductr_cli.exceptions import WaitTimeoutError
+from datetime import datetime
+import json
+import logging
+import requests
+
+
+def get_scale(bundle_id, args):
+    bundles_url = conduct_url.url('bundles', args)
+    response = requests.get(bundles_url)
+    response.raise_for_status()
+    bundles = json.loads(response.text)
+    matching_bundles = [bundle for bundle in bundles if bundle['bundleId'] == bundle_id]
+    if matching_bundles:
+        matching_bundle = matching_bundles[0]
+        if 'bundleExecutions' in matching_bundle:
+            started_executions = [bundle_execution
+                                  for bundle_execution in matching_bundle['bundleExecutions']
+                                  if bundle_execution['isStarted']]
+            return len(started_executions)
+
+    return 0
+
+
+def wait_for_scale(bundle_id, expected_scale, args):
+    log = logging.getLogger(__name__)
+    start_time = datetime.now()
+
+    bundle_scale = get_scale(bundle_id, args)
+    if bundle_scale == expected_scale:
+        log.info('Bundle {} expected scale {} is met'.format(bundle_id, expected_scale))
+        return
+    else:
+        log.info('Bundle {} waiting to reach expected scale {}'.format(bundle_id, expected_scale))
+        bundle_events_url = conduct_url.url('bundles/events', args)
+        sse_events = sse_client.get_events(bundle_events_url)
+        for event in sse_events:
+            elapsed = (datetime.now() - start_time).total_seconds()
+            if elapsed > args.wait_timeout:
+                raise WaitTimeoutError('Bundle {} waiting to reach expected scale {}'.format(bundle_id, expected_scale))
+
+            if event.event and event.event.startswith('bundleExecution'):
+                bundle_scale = get_scale(bundle_id, args)
+                if bundle_scale == expected_scale:
+                    log.info('Bundle {} expected scale {} is met'.format(bundle_id, expected_scale))
+                    return
+                else:
+                    log.info('Bundle {} has scale {}, expected {}'.format(bundle_id, bundle_scale, expected_scale))
+
+        raise WaitTimeoutError('Bundle {} waiting to reach expected scale {}'.format(bundle_id, expected_scale))

--- a/conductr_cli/conduct.py
+++ b/conductr_cli/conduct.py
@@ -17,6 +17,7 @@ DEFAULT_CUSTOM_SETTINGS_FILE = os.getenv('CONDUCTR_CUSTOM_SETTINGS_FILE',
                                          '{}/settings.conf'.format(DEFAULT_CLI_SETTINGS_DIR))
 DEFAULT_CUSTOM_PLUGINS_DIR = os.getenv('CONDUCTR_CUSTOM_PLUGINS_DIR',
                                        '{}/plugins'.format(DEFAULT_CLI_SETTINGS_DIR))
+DEFAULT_WAIT_TIMEOUT = 60  # seconds
 
 
 def add_ip_and_port(sub_parser):
@@ -103,6 +104,24 @@ def add_quiet_flag(sub_parser):
                             action='store_true')
 
 
+def add_wait_timeout(sub_parser):
+    sub_parser.add_argument('--wait-timeout',
+                            help='Timeout in seconds waiting for bundle scale to be achieved in conduct run, '
+                                 'or bundle to be stopped in conduct stop, defaults to'.format(DEFAULT_WAIT_TIMEOUT),
+                            default=DEFAULT_WAIT_TIMEOUT,
+                            dest='wait_timeout',
+                            action='store_true')
+
+
+def add_no_wait(sub_parser):
+    sub_parser.add_argument('--no-wait',
+                            help='Disables waiting for bundle scale to be achieved in conduct run, or bundle to be '
+                                 'stopped in conduct stop, defaults to',
+                            default=False,
+                            dest='no_wait',
+                            action='store_true')
+
+
 def add_default_arguments(sub_parser):
     add_ip_and_port(sub_parser)
     add_verbose(sub_parser)
@@ -149,6 +168,8 @@ def build_parser():
                              help='The optional configuration for the bundle')
     add_default_arguments(load_parser)
     add_bundle_resolve_cache_dir(load_parser)
+    add_wait_timeout(load_parser)
+    add_no_wait(load_parser)
     load_parser.set_defaults(func=conduct_load.load)
 
     # Sub-parser for `run` sub-command
@@ -164,6 +185,8 @@ def build_parser():
     run_parser.add_argument('bundle',
                             help='The ID of the bundle')
     add_default_arguments(run_parser)
+    add_wait_timeout(run_parser)
+    add_no_wait(run_parser)
     run_parser.set_defaults(func=conduct_run.run)
 
     # Sub-parser for `stop` sub-command
@@ -172,6 +195,8 @@ def build_parser():
     stop_parser.add_argument('bundle',
                              help='The ID of the bundle')
     add_default_arguments(stop_parser)
+    add_wait_timeout(stop_parser)
+    add_no_wait(stop_parser)
     stop_parser.set_defaults(func=conduct_stop.stop)
 
     # Sub-parser for `unload` sub-command

--- a/conductr_cli/conduct_run.py
+++ b/conductr_cli/conduct_run.py
@@ -1,4 +1,5 @@
 from conductr_cli import bundle_utils, conduct_url, validation
+from conductr_cli import bundle_scale
 import json
 import logging
 import requests
@@ -6,6 +7,7 @@ import requests
 
 @validation.handle_connection_error
 @validation.handle_http_error
+@validation.handle_wait_timeout_error
 def run(args):
     """`conduct run` command"""
 
@@ -30,6 +32,10 @@ def run(args):
     bundle_id = response_json['bundleId'] if args.long_ids else bundle_utils.short_id(response_json['bundleId'])
 
     log.info('Bundle run request sent.')
+
+    if not args.no_wait:
+        bundle_scale.wait_for_scale(response_json['bundleId'], args.scale, args)
+
     log.info('Stop bundle with: conduct stop{} {}'.format(args.cli_parameters, bundle_id))
     log.info('Print ConductR info with: conduct info{}'.format(args.cli_parameters))
 

--- a/conductr_cli/conduct_stop.py
+++ b/conductr_cli/conduct_stop.py
@@ -1,4 +1,4 @@
-from conductr_cli import bundle_utils, conduct_url, validation
+from conductr_cli import bundle_utils, conduct_url, validation, bundle_scale
 import json
 import requests
 import logging
@@ -7,6 +7,7 @@ from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
 
 @validation.handle_connection_error
 @validation.handle_http_error
+@validation.handle_wait_timeout_error
 def stop(args):
     """`conduct stop` command"""
 
@@ -23,6 +24,10 @@ def stop(args):
     bundle_id = response_json['bundleId'] if args.long_ids else bundle_utils.short_id(response_json['bundleId'])
 
     log.info('Bundle stop request sent.')
+
+    if not args.no_wait:
+        bundle_scale.wait_for_scale(response_json['bundleId'], 0, args)
+
     log.info('Unload bundle with: conduct unload{} {}'.format(args.cli_parameters, bundle_id))
     log.info('Print ConductR info with: conduct info{}'.format(args.cli_parameters))
 

--- a/conductr_cli/exceptions.py
+++ b/conductr_cli/exceptions.py
@@ -44,3 +44,11 @@ class BintrayResolutionError(Exception):
 
     def __str__(self):
         return repr(self.value)
+
+
+class WaitTimeoutError(Exception):
+    def __init__(self, value):
+        self.value = value
+
+    def __str__(self):
+        return repr(self.value)

--- a/conductr_cli/sse_client.py
+++ b/conductr_cli/sse_client.py
@@ -1,0 +1,87 @@
+import re
+import requests
+
+
+SSE_REQUEST_INPUT = {
+    'headers': {
+        'Cache-Control': 'no-cache',
+        'Accept': 'text/event-stream'
+    }
+}
+
+
+SSE_END_OF_FIELD = re.compile(r'\r\n\r\n|\r\r|\n\n')
+
+
+def is_event_complete(buf):
+    return re.search(SSE_END_OF_FIELD, buf) is not None
+
+
+def parse_event(raw_sse_string):
+    event, data = None, None
+    lines = raw_sse_string.split('\n')
+    for line in lines:
+        key, value = line.split(':')
+        if key == 'event':
+            event = value
+        elif key == 'data':
+            data = value
+    return Event(event, data)
+
+
+class Event:
+    def __init__(self, event, data):
+        self.event = event
+        self.data = data
+
+    def __eq__(self, other):
+        if type(other) is type(self):
+            return self.__dict__ == other.__dict__
+        else:
+            return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+
+class Client:
+    """
+    The following SSE Client has been backported, cut down version of https://bitbucket.org/btubbs/sseclient -
+    look at sseclient.py.
+
+    We were not be able to use the SSE client library as it does not have the support for Python 3.2 due
+    to the presence of unicode string declaration (i.e. u''). The unicode string declaration is valid from Python 3.3 and
+    above, while in Python 3.2 it will result in Syntax error.
+
+    Changes introduced as part of the backport:
+    - Support for Python 3.2 (i.e. do not use u'')
+    - Parse only for event and data string within SSE
+    - No support for retries and last event id
+    """
+    def __init__(self, url):
+        self.url = url
+        self.response = None
+
+    def connect(self):
+        response = requests.get(self.url, stream=True, **SSE_REQUEST_INPUT)
+        response.raise_for_status()
+        self.response = response
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        buf = ''
+        while not is_event_complete(buf):
+            next_char = next(self.response.iter_content(decode_unicode=True))
+            buf += next_char
+
+        split = re.split(SSE_END_OF_FIELD, buf)
+        raw_sse = split[0]
+        return parse_event(raw_sse)
+
+
+def get_events(url):
+    client = Client(url)
+    client.connect()
+    return client

--- a/conductr_cli/test/conduct_load_test_base.py
+++ b/conductr_cli/test/conduct_load_test_base.py
@@ -1,7 +1,7 @@
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin, as_error
 from conductr_cli import conduct_load, logging_setup
 from conductr_cli.conduct_load import LOAD_HTTP_TIMEOUT
-from conductr_cli.exceptions import BundleResolutionError
+from conductr_cli.exceptions import BundleResolutionError, WaitTimeoutError
 from zipfile import BadZipFile
 from urllib.error import HTTPError, URLError
 
@@ -24,6 +24,7 @@ class ConductLoadTestBase(CliTestCase):
     def __init__(self, method_name):
         super().__init__(method_name)
 
+        self.bundle_id = None
         self.bundle_name = None
         self.bundle_file = None
         self.default_args = {}
@@ -55,17 +56,21 @@ class ConductLoadTestBase(CliTestCase):
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
+        wait_for_installation_mock = MagicMock()
 
+        input_args = MagicMock(**self.default_args)
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('requests.post', http_method), \
-                patch('builtins.open', open_mock):
-            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            result = conduct_load.load(MagicMock(**self.default_args))
+                patch('builtins.open', open_mock), \
+                patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_load.load(input_args)
             self.assertTrue(result)
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
         http_method.assert_called_with(self.default_url, files=self.default_files, timeout=LOAD_HTTP_TIMEOUT)
+        wait_for_installation_mock.assert_called_with(self.bundle_id, input_args)
 
         self.assertEqual(self.default_output(), self.output(stdout))
 
@@ -74,19 +79,24 @@ class ConductLoadTestBase(CliTestCase):
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
+        wait_for_installation_mock = MagicMock()
+
+        args = self.default_args.copy()
+        args.update({'verbose': True})
+        input_args = MagicMock(**args)
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('requests.post', http_method), \
-                patch('builtins.open', open_mock):
-            args = self.default_args.copy()
-            args.update({'verbose': True})
-            logging_setup.configure_logging(MagicMock(**args), stdout)
-            result = conduct_load.load(MagicMock(**args))
+                patch('builtins.open', open_mock), \
+                patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_load.load(input_args)
             self.assertTrue(result)
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
         http_method.assert_called_with(self.default_url, files=self.default_files, timeout=LOAD_HTTP_TIMEOUT)
+        wait_for_installation_mock.assert_called_with(self.bundle_id, input_args)
 
         self.assertEqual(self.default_output(verbose=self.default_response), self.output(stdout))
 
@@ -95,19 +105,24 @@ class ConductLoadTestBase(CliTestCase):
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
+        wait_for_installation_mock = MagicMock()
+
+        args = self.default_args.copy()
+        args.update({'quiet': True})
+        input_args = MagicMock(**args)
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('requests.post', http_method), \
-                patch('builtins.open', open_mock):
-            args = self.default_args.copy()
-            args.update({'quiet': True})
-            logging_setup.configure_logging(MagicMock(**args), stdout)
-            result = conduct_load.load(MagicMock(**args))
+                patch('builtins.open', open_mock), \
+                patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_load.load(input_args)
             self.assertTrue(result)
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
         http_method.assert_called_with(self.default_url, files=self.default_files, timeout=LOAD_HTTP_TIMEOUT)
+        wait_for_installation_mock.assert_called_with(self.bundle_id, input_args)
 
         self.assertEqual('45e0c477d3e5ea92aa8d85c0d8f3e25c\n', self.output(stdout))
 
@@ -116,19 +131,24 @@ class ConductLoadTestBase(CliTestCase):
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
+        wait_for_installation_mock = MagicMock()
+
+        args = self.default_args.copy()
+        args.update({'long_ids': True})
+        input_args = MagicMock(**args)
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('requests.post', http_method), \
-                patch('builtins.open', open_mock):
-            args = self.default_args.copy()
-            args.update({'long_ids': True})
-            logging_setup.configure_logging(MagicMock(**args), stdout)
-            result = conduct_load.load(MagicMock(**args))
+                patch('builtins.open', open_mock), \
+                patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_load.load(input_args)
             self.assertTrue(result)
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
         http_method.assert_called_with(self.default_url, files=self.default_files, timeout=LOAD_HTTP_TIMEOUT)
+        wait_for_installation_mock.assert_called_with(self.bundle_id, input_args)
 
         self.assertEqual(self.default_output(bundle_id='45e0c477d3e5ea92aa8d85c0d8f3e25c'), self.output(stdout))
 
@@ -137,24 +157,52 @@ class ConductLoadTestBase(CliTestCase):
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
+        wait_for_installation_mock = MagicMock()
 
         cli_parameters = ' --ip 127.0.1.1 --port 9006'
+        args = self.default_args.copy()
+        args.update({'cli_parameters': cli_parameters})
+        input_args = MagicMock(**args)
+
+        with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
+                patch('requests.post', http_method), \
+                patch('builtins.open', open_mock), \
+                patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_load.load(input_args)
+            self.assertTrue(result)
+
+        open_mock.assert_called_with(self.bundle_file, 'rb')
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
+        http_method.assert_called_with(self.default_url, files=self.default_files, timeout=LOAD_HTTP_TIMEOUT)
+        wait_for_installation_mock.assert_called_with(self.bundle_id, input_args)
+
+        self.assertEqual(
+            self.default_output(params=cli_parameters),
+            self.output(stdout))
+
+    def base_test_success_no_wait(self):
+        resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, self.bundle_file))
+        http_method = self.respond_with(200, self.default_response)
+        stdout = MagicMock()
+        open_mock = MagicMock(return_value=1)
+
+        args = self.default_args.copy()
+        args.update({'no_wait': True})
+        input_args = MagicMock(**args)
+
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock):
-            args = self.default_args.copy()
-            args.update({'cli_parameters': cli_parameters})
-            logging_setup.configure_logging(MagicMock(**args), stdout)
-            result = conduct_load.load(MagicMock(**args))
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_load.load(input_args)
             self.assertTrue(result)
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
         http_method.assert_called_with(self.default_url, files=self.default_files, timeout=LOAD_HTTP_TIMEOUT)
 
-        self.assertEqual(
-            self.default_output(params=cli_parameters),
-            self.output(stdout))
+        self.assertEqual(self.default_output(), self.output(stdout))
 
     def base_test_failure(self):
         resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, self.bundle_file))
@@ -295,5 +343,31 @@ class ConductLoadTestBase(CliTestCase):
 
         self.assertEqual(
             as_error(strip_margin("""|Error: File not found: reason
+                                     |""")),
+            self.output(stderr))
+
+    def base_test_failure_install_timeout(self):
+        resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, self.bundle_file))
+        http_method = self.respond_with(200, self.default_response)
+        stderr = MagicMock()
+        open_mock = MagicMock(return_value=1)
+        wait_for_installation_mock = MagicMock(side_effect=WaitTimeoutError('test timeout'))
+
+        input_args = MagicMock(**self.default_args)
+        with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
+                patch('requests.post', http_method), \
+                patch('builtins.open', open_mock), \
+                patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
+            logging_setup.configure_logging(input_args, err_output=stderr)
+            result = conduct_load.load(input_args)
+            self.assertFalse(result)
+
+        open_mock.assert_called_with(self.bundle_file, 'rb')
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
+        http_method.assert_called_with(self.default_url, files=self.default_files, timeout=LOAD_HTTP_TIMEOUT)
+        wait_for_installation_mock.assert_called_with(self.bundle_id, input_args)
+
+        self.assertEqual(
+            as_error(strip_margin("""|Error: Timed out: test timeout
                                      |""")),
             self.output(stderr))

--- a/conductr_cli/test/conduct_run_test_base.py
+++ b/conductr_cli/test/conduct_run_test_base.py
@@ -1,5 +1,6 @@
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin, as_error
 from conductr_cli import conduct_run, logging_setup
+from conductr_cli.exceptions import WaitTimeoutError
 
 try:
     from unittest.mock import patch, MagicMock  # 3.3 and beyond
@@ -12,6 +13,8 @@ class ConductRunTestBase(CliTestCase):
     def __init__(self, method_name):
         super().__init__(method_name)
 
+        self.bundle_id = None
+        self.scale = None
         self.default_args = {}
         self.default_url = None
         self.output_template = None
@@ -28,64 +31,101 @@ class ConductRunTestBase(CliTestCase):
 
     def base_test_success(self):
         http_method = self.respond_with(200, self.default_response)
+        wait_for_scale_mock = MagicMock()
         stdout = MagicMock()
 
-        with patch('requests.put', http_method):
-            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            result = conduct_run.run(MagicMock(**self.default_args))
+        input_args = MagicMock(**self.default_args)
+
+        with patch('requests.put', http_method), \
+                patch('conductr_cli.bundle_scale.wait_for_scale', wait_for_scale_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_run.run(input_args)
             self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url)
+        wait_for_scale_mock.assert_called_with(self.bundle_id, self.scale, input_args)
 
         self.assertEqual(self.default_output(), self.output(stdout))
 
     def base_test_success_verbose(self):
         http_method = self.respond_with(200, self.default_response)
+        wait_for_scale_mock = MagicMock()
         stdout = MagicMock()
 
-        with patch('requests.put', http_method):
-            args = self.default_args.copy()
-            args.update({'verbose': True})
-            logging_setup.configure_logging(MagicMock(**args), stdout)
-            result = conduct_run.run(MagicMock(**args))
+        args = self.default_args.copy()
+        args.update({'verbose': True})
+        input_args = MagicMock(**args)
+
+        with patch('requests.put', http_method), \
+                patch('conductr_cli.bundle_scale.wait_for_scale', wait_for_scale_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_run.run(input_args)
             self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url)
+        wait_for_scale_mock.assert_called_with(self.bundle_id, self.scale, input_args)
 
         self.assertEqual(self.default_response + self.default_output(), self.output(stdout))
 
     def base_test_success_long_ids(self):
         http_method = self.respond_with(200, self.default_response)
+        wait_for_scale_mock = MagicMock()
         stdout = MagicMock()
 
-        with patch('requests.put', http_method):
-            args = self.default_args.copy()
-            args.update({'long_ids': True})
-            logging_setup.configure_logging(MagicMock(**args), stdout)
-            result = conduct_run.run(MagicMock(**args))
+        args = self.default_args.copy()
+        args.update({'long_ids': True})
+        input_args = MagicMock(**args)
+
+        with patch('requests.put', http_method), \
+                patch('conductr_cli.bundle_scale.wait_for_scale', wait_for_scale_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_run.run(input_args)
             self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url)
+        wait_for_scale_mock.assert_called_with(self.bundle_id, self.scale, input_args)
 
         self.assertEqual(self.default_output(bundle_id='45e0c477d3e5ea92aa8d85c0d8f3e25c'), self.output(stdout))
 
     def base_test_success_with_configuration(self):
         http_method = self.respond_with(200, self.default_response)
+        wait_for_scale_mock = MagicMock()
         stdout = MagicMock()
 
+        args = self.default_args.copy()
         cli_parameters = ' --ip 127.0.1.1 --port 9006'
-        with patch('requests.put', http_method), patch('sys.stdout', stdout):
-            args = self.default_args.copy()
-            args.update({'cli_parameters': cli_parameters})
-            logging_setup.configure_logging(MagicMock(**args), stdout)
-            result = conduct_run.run(MagicMock(**args))
+        args.update({'cli_parameters': cli_parameters})
+        input_args = MagicMock(**args)
+
+        with patch('requests.put', http_method), \
+                patch('conductr_cli.bundle_scale.wait_for_scale', wait_for_scale_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_run.run(input_args)
             self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url)
+        wait_for_scale_mock.assert_called_with(self.bundle_id, self.scale, input_args)
 
         self.assertEqual(
             self.default_output(params=cli_parameters),
             self.output(stdout))
+
+    def base_test_success_no_wait(self):
+        http_method = self.respond_with(200, self.default_response)
+        stdout = MagicMock()
+
+        args = self.default_args.copy()
+        args.update({'no_wait': True})
+        input_args = MagicMock(**args)
+
+        with patch('requests.put', http_method):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_run.run(input_args)
+            self.assertTrue(result)
+
+        http_method.assert_called_with(self.default_url)
+
+        self.assertEqual(self.default_output(), self.output(stdout))
 
     def base_test_failure(self):
         http_method = self.respond_with(404)
@@ -116,4 +156,25 @@ class ConductRunTestBase(CliTestCase):
 
         self.assertEqual(
             self.default_connection_error.format(self.default_url),
+            self.output(stderr))
+
+    def base_test_failure_scale_timeout(self):
+        http_method = self.respond_with(200, self.default_response)
+        wait_for_scale_mock = MagicMock(side_effect=WaitTimeoutError('test wait timeout error'))
+        stderr = MagicMock()
+
+        input_args = MagicMock(**self.default_args)
+
+        with patch('requests.put', http_method), \
+                patch('conductr_cli.bundle_scale.wait_for_scale', wait_for_scale_mock):
+            logging_setup.configure_logging(input_args, err_output=stderr)
+            result = conduct_run.run(input_args)
+            self.assertFalse(result)
+
+        http_method.assert_called_with(self.default_url)
+        wait_for_scale_mock.assert_called_with(self.bundle_id, self.scale, input_args)
+
+        self.assertEqual(
+            as_error(strip_margin("""|Error: Timed out: test wait timeout error
+                                     |""")),
             self.output(stderr))

--- a/conductr_cli/test/test_bundle_installation.py
+++ b/conductr_cli/test/test_bundle_installation.py
@@ -1,0 +1,223 @@
+from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
+from conductr_cli import bundle_installation, logging_setup
+from conductr_cli.exceptions import WaitTimeoutError
+
+try:
+    from unittest.mock import call, patch, MagicMock  # 3.3 and beyond
+except ImportError:
+    from mock import call, patch, MagicMock
+
+
+class TestCountInstallation(CliTestCase):
+    def test_return_scale(self):
+        bundles_endpoint_reply = """
+            [{
+                "bundleId": "a101449418187d92c789d1adc240b6d6",
+                "bundleInstallations": [{
+                    "uniqueAddress": {
+                        "address": "akka.tcp://conductr@172.17.0.53:9004",
+                        "uid": 1288758867
+                    },
+                    "bundleFile": "file:///tmp/79e700212ddff716622b39ceace28fc2f51c4a05cfd993ebb50833ea8b772edf.zip"
+                }]
+            }]
+        """
+        http_method = self.respond_with(text=bundles_endpoint_reply)
+
+        with patch('requests.get', http_method):
+            bundle_id = 'a101449418187d92c789d1adc240b6d6'
+            args = {
+                'ip': '127.0.0.1',
+                'port': '9005',
+                'api_version': '1'
+            }
+            result = bundle_installation.count_installations(bundle_id, MagicMock(**args))
+            self.assertEqual(1, result)
+
+        http_method.assert_called_with('http://127.0.0.1:9005/bundles')
+
+    def test_return_scale_v2(self):
+        bundles_endpoint_reply = """
+            [{
+                "bundleId": "a101449418187d92c789d1adc240b6d6",
+                "bundleInstallations": [{
+                    "uniqueAddress": {
+                        "address": "akka.tcp://conductr@172.17.0.53:9004",
+                        "uid": 1288758867
+                    },
+                    "bundleFile": "file:///tmp/79e700212ddff716622b39ceace28fc2f51c4a05cfd993ebb50833ea8b772edf.zip"
+                }]
+            }]
+        """
+        http_method = self.respond_with(text=bundles_endpoint_reply)
+
+        with patch('requests.get', http_method):
+            bundle_id = 'a101449418187d92c789d1adc240b6d6'
+            args = {
+                'ip': '127.0.0.1',
+                'port': '9005',
+                'api_version': '2'
+            }
+            result = bundle_installation.count_installations(bundle_id, MagicMock(**args))
+            self.assertEqual(1, result)
+
+        http_method.assert_called_with('http://127.0.0.1:9005/v2/bundles')
+
+    def test_return_zero_v1(self):
+        bundles_endpoint_reply = '[]'
+        http_method = self.respond_with(text=bundles_endpoint_reply)
+
+        with patch('requests.get', http_method):
+            bundle_id = 'a101449418187d92c789d1adc240b6d6'
+            args = {
+                'ip': '127.0.0.1',
+                'port': '9005',
+                'api_version': '1'
+            }
+            result = bundle_installation.count_installations(bundle_id, MagicMock(**args))
+            self.assertEqual(0, result)
+
+        http_method.assert_called_with('http://127.0.0.1:9005/bundles')
+
+    def test_return_zero_v2(self):
+        bundles_endpoint_reply = '[]'
+        http_method = self.respond_with(text=bundles_endpoint_reply)
+
+        with patch('requests.get', http_method):
+            bundle_id = 'a101449418187d92c789d1adc240b6d6'
+            args = {
+                'ip': '127.0.0.1',
+                'port': '9005',
+                'api_version': '2'
+            }
+            result = bundle_installation.count_installations(bundle_id, MagicMock(**args))
+            self.assertEqual(0, result)
+
+        http_method.assert_called_with('http://127.0.0.1:9005/v2/bundles')
+
+
+class TestWaitForScale(CliTestCase):
+    def test_wait_for_installation(self):
+        count_installations_mock = MagicMock(side_effect=[0, 1])
+        url_mock = MagicMock(return_value='/bundle-events/endpoint')
+        get_events_mock = MagicMock(return_value=[
+            self.create_test_event(None),
+            self.create_test_event('bundleInstallationAdded'),
+            self.create_test_event('bundleInstallationAdded')
+        ])
+
+        stdout = MagicMock()
+
+        bundle_id = 'a101449418187d92c789d1adc240b6d6'
+        args = MagicMock(**{
+            'wait_timeout': 10
+        })
+        with patch('conductr_cli.conduct_url.url', url_mock), \
+                patch('conductr_cli.bundle_installation.count_installations', count_installations_mock), \
+                patch('conductr_cli.sse_client.get_events', get_events_mock):
+            logging_setup.configure_logging(args, stdout)
+            bundle_installation.wait_for_installation(bundle_id, args)
+
+        self.assertEqual(count_installations_mock.call_args_list, [
+            call(bundle_id, args),
+            call(bundle_id, args)
+        ])
+
+        url_mock.assert_called_with('bundles/events', args)
+        self.maxDiff = None
+
+        self.assertEqual(strip_margin("""|Bundle a101449418187d92c789d1adc240b6d6 waiting to be installed
+                                         |Bundle a101449418187d92c789d1adc240b6d6 installed
+                                         |"""), self.output(stdout))
+
+    def test_return_immediately_if_installed(self):
+        count_installations_mock = MagicMock(side_effect=[3])
+
+        stdout = MagicMock()
+
+        bundle_id = 'a101449418187d92c789d1adc240b6d6'
+        args = MagicMock(**{
+            'wait_timeout': 10
+        })
+        with patch('conductr_cli.bundle_installation.count_installations', count_installations_mock):
+            logging_setup.configure_logging(args, stdout)
+            bundle_installation.wait_for_installation(bundle_id, args)
+
+        self.assertEqual(count_installations_mock.call_args_list, [
+            call(bundle_id, args)
+        ])
+
+        self.assertEqual(strip_margin("""|Bundle a101449418187d92c789d1adc240b6d6 is installed
+                                         |"""), self.output(stdout))
+
+    def test_wait_timeout(self):
+        count_installations_mock = MagicMock(side_effect=[0, 1, 1])
+        url_mock = MagicMock(return_value='/bundle-events/endpoint')
+        get_events_mock = MagicMock(return_value=[
+            self.create_test_event('bundleExecutionAdded'),
+            self.create_test_event('bundleExecutionAdded'),
+            self.create_test_event('bundleExecutionAdded')
+        ])
+
+        stdout = MagicMock()
+
+        bundle_id = 'a101449418187d92c789d1adc240b6d6'
+        args = MagicMock(**{
+            # Purposely set no timeout to invoke the error
+            'wait_timeout': 0
+        })
+        with patch('conductr_cli.conduct_url.url', url_mock), \
+                patch('conductr_cli.bundle_installation.count_installations', count_installations_mock), \
+                patch('conductr_cli.sse_client.get_events', get_events_mock):
+            logging_setup.configure_logging(args, stdout)
+            self.assertRaises(WaitTimeoutError, bundle_installation.wait_for_installation, bundle_id, args)
+
+        self.assertEqual(count_installations_mock.call_args_list, [
+            call(bundle_id, args)
+        ])
+
+        url_mock.assert_called_with('bundles/events', args)
+
+        self.assertEqual(strip_margin("""|Bundle a101449418187d92c789d1adc240b6d6 waiting to be installed
+                                         |"""), self.output(stdout))
+
+    def test_wait_timeout_all_events(self):
+        count_installations_mock = MagicMock(return_value=0)
+        url_mock = MagicMock(return_value='/bundle-events/endpoint')
+        get_events_mock = MagicMock(return_value=[
+            self.create_test_event('bundleInstallationAdded'),
+            self.create_test_event('bundleInstallationAdded'),
+            self.create_test_event('bundleInstallationAdded')
+        ])
+
+        stdout = MagicMock()
+
+        bundle_id = 'a101449418187d92c789d1adc240b6d6'
+        args = MagicMock(**{
+            'wait_timeout': 10
+        })
+        with patch('conductr_cli.conduct_url.url', url_mock), \
+                patch('conductr_cli.bundle_installation.count_installations', count_installations_mock), \
+                patch('conductr_cli.sse_client.get_events', get_events_mock):
+            logging_setup.configure_logging(args, stdout)
+            self.assertRaises(WaitTimeoutError, bundle_installation.wait_for_installation, bundle_id, args)
+
+        self.assertEqual(count_installations_mock.call_args_list, [
+            call(bundle_id, args),
+            call(bundle_id, args),
+            call(bundle_id, args),
+            call(bundle_id, args)
+        ])
+
+        url_mock.assert_called_with('bundles/events', args)
+
+        self.assertEqual(strip_margin("""|Bundle a101449418187d92c789d1adc240b6d6 waiting to be installed
+                                         |Bundle a101449418187d92c789d1adc240b6d6 still waiting to be installed
+                                         |Bundle a101449418187d92c789d1adc240b6d6 still waiting to be installed
+                                         |Bundle a101449418187d92c789d1adc240b6d6 still waiting to be installed
+                                         |"""), self.output(stdout))
+
+    def create_test_event(self, event_name):
+        sse_mock = MagicMock()
+        sse_mock.event = event_name
+        return sse_mock

--- a/conductr_cli/test/test_bundle_scale.py
+++ b/conductr_cli/test/test_bundle_scale.py
@@ -1,0 +1,257 @@
+from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
+from conductr_cli import bundle_scale, logging_setup
+from conductr_cli.exceptions import WaitTimeoutError
+
+try:
+    from unittest.mock import call, patch, MagicMock  # 3.3 and beyond
+except ImportError:
+    from mock import call, patch, MagicMock
+
+
+class TestGetScale(CliTestCase):
+    def test_return_scale_v1(self):
+        bundles_endpoint_reply = """
+            [{
+                "bundleId": "a101449418187d92c789d1adc240b6d6",
+                "bundleExecutions": [
+                    {
+                        "host": "127.0.0.1",
+                        "endpoints": {
+                            "web": {
+                                "bindPort": 10822,
+                                "hostPort": 10822
+                            }
+                        },
+                        "isStarted": true
+                    },
+                    {
+                        "host": "127.0.0.2",
+                        "endpoints": {
+                            "web": {
+                                "bindPort": 10822,
+                                "hostPort": 10822
+                            }
+                        },
+                        "isStarted": false
+                    }
+                ]
+            }]
+        """
+        http_method = self.respond_with(text=bundles_endpoint_reply)
+
+        with patch('requests.get', http_method):
+            bundle_id = 'a101449418187d92c789d1adc240b6d6'
+            args = {
+                'ip': '127.0.0.1',
+                'port': '9005',
+                'api_version': '1'
+            }
+            result = bundle_scale.get_scale(bundle_id, MagicMock(**args))
+            self.assertEqual(1, result)
+
+        http_method.assert_called_with('http://127.0.0.1:9005/bundles')
+
+    def test_return_scale_v2(self):
+        bundles_endpoint_reply = """
+            [{
+                "bundleId": "a101449418187d92c789d1adc240b6d6",
+                "bundleExecutions": [
+                    {
+                        "host": "127.0.0.1",
+                        "endpoints": {
+                            "web": {
+                                "bindPort": 10822,
+                                "hostPort": 10822
+                            }
+                        },
+                        "isStarted": true
+                    },
+                    {
+                        "host": "127.0.0.2",
+                        "endpoints": {
+                            "web": {
+                                "bindPort": 10822,
+                                "hostPort": 10822
+                            }
+                        },
+                        "isStarted": false
+                    }
+                ]
+            }]
+        """
+        http_method = self.respond_with(text=bundles_endpoint_reply)
+
+        with patch('requests.get', http_method):
+            bundle_id = 'a101449418187d92c789d1adc240b6d6'
+            args = {
+                'ip': '127.0.0.1',
+                'port': '9005',
+                'api_version': '2'
+            }
+            result = bundle_scale.get_scale(bundle_id, MagicMock(**args))
+            self.assertEqual(1, result)
+
+        http_method.assert_called_with('http://127.0.0.1:9005/v2/bundles')
+
+    def test_return_zero_v1(self):
+        bundles_endpoint_reply = '[]'
+        http_method = self.respond_with(text=bundles_endpoint_reply)
+
+        with patch('requests.get', http_method):
+            bundle_id = 'a101449418187d92c789d1adc240b6d6'
+            args = {
+                'ip': '127.0.0.1',
+                'port': '9005',
+                'api_version': '1'
+            }
+            result = bundle_scale.get_scale(bundle_id, MagicMock(**args))
+            self.assertEqual(0, result)
+
+        http_method.assert_called_with('http://127.0.0.1:9005/bundles')
+
+    def test_return_zero_v2(self):
+        bundles_endpoint_reply = '[]'
+        http_method = self.respond_with(text=bundles_endpoint_reply)
+
+        with patch('requests.get', http_method):
+            bundle_id = 'a101449418187d92c789d1adc240b6d6'
+            args = {
+                'ip': '127.0.0.1',
+                'port': '9005',
+                'api_version': '2'
+            }
+            result = bundle_scale.get_scale(bundle_id, MagicMock(**args))
+            self.assertEqual(0, result)
+
+        http_method.assert_called_with('http://127.0.0.1:9005/v2/bundles')
+
+
+class TestWaitForScale(CliTestCase):
+    def test_wait_for_scale(self):
+        get_scale_mock = MagicMock(side_effect=[0, 1, 2, 3])
+        url_mock = MagicMock(return_value='/bundle-events/endpoint')
+        get_events_mock = MagicMock(return_value=[
+            self.create_test_event(None),
+            self.create_test_event('bundleExecutionAdded'),
+            self.create_test_event('bundleExecutionAdded'),
+            self.create_test_event('bundleExecutionAdded')
+        ])
+
+        stdout = MagicMock()
+
+        bundle_id = 'a101449418187d92c789d1adc240b6d6'
+        args = MagicMock(**{
+            'wait_timeout': 10
+        })
+        with patch('conductr_cli.conduct_url.url', url_mock), \
+                patch('conductr_cli.bundle_scale.get_scale', get_scale_mock), \
+                patch('conductr_cli.sse_client.get_events', get_events_mock):
+            logging_setup.configure_logging(args, stdout)
+            bundle_scale.wait_for_scale(bundle_id, 3, args)
+
+        self.assertEqual(get_scale_mock.call_args_list, [
+            call(bundle_id, args),
+            call(bundle_id, args),
+            call(bundle_id, args),
+            call(bundle_id, args)
+        ])
+
+        url_mock.assert_called_with('bundles/events', args)
+
+        self.assertEqual(strip_margin("""|Bundle a101449418187d92c789d1adc240b6d6 waiting to reach expected scale 3
+                                         |Bundle a101449418187d92c789d1adc240b6d6 has scale 1, expected 3
+                                         |Bundle a101449418187d92c789d1adc240b6d6 has scale 2, expected 3
+                                         |Bundle a101449418187d92c789d1adc240b6d6 expected scale 3 is met
+                                         |"""), self.output(stdout))
+
+    def test_return_immediately_if_scale_is_met(self):
+        get_scale_mock = MagicMock(side_effect=[3])
+
+        stdout = MagicMock()
+
+        bundle_id = 'a101449418187d92c789d1adc240b6d6'
+        args = MagicMock(**{
+            'wait_timeout': 10
+        })
+        with patch('conductr_cli.bundle_scale.get_scale', get_scale_mock):
+            logging_setup.configure_logging(args, stdout)
+            bundle_scale.wait_for_scale(bundle_id, 3, args)
+
+        self.assertEqual(get_scale_mock.call_args_list, [
+            call(bundle_id, args)
+        ])
+
+        self.assertEqual(strip_margin("""|Bundle a101449418187d92c789d1adc240b6d6 expected scale 3 is met
+                                         |"""), self.output(stdout))
+
+    def test_wait_timeout(self):
+        get_scale_mock = MagicMock(side_effect=[0, 1, 2, 3])
+        url_mock = MagicMock(return_value='/bundle-events/endpoint')
+        get_events_mock = MagicMock(return_value=[
+            self.create_test_event('bundleExecutionAdded'),
+            self.create_test_event('bundleExecutionAdded'),
+            self.create_test_event('bundleExecutionAdded')
+        ])
+
+        stdout = MagicMock()
+
+        bundle_id = 'a101449418187d92c789d1adc240b6d6'
+        args = MagicMock(**{
+            # Purposely set no timeout to invoke the error
+            'wait_timeout': 0
+        })
+        with patch('conductr_cli.conduct_url.url', url_mock), \
+                patch('conductr_cli.bundle_scale.get_scale', get_scale_mock), \
+                patch('conductr_cli.sse_client.get_events', get_events_mock):
+            logging_setup.configure_logging(args, stdout)
+            self.assertRaises(WaitTimeoutError, bundle_scale.wait_for_scale, bundle_id, 3, args)
+
+        self.assertEqual(get_scale_mock.call_args_list, [
+            call(bundle_id, args)
+        ])
+
+        url_mock.assert_called_with('bundles/events', args)
+
+        self.assertEqual(strip_margin("""|Bundle a101449418187d92c789d1adc240b6d6 waiting to reach expected scale 3
+                                         |"""), self.output(stdout))
+
+    def test_wait_timeout_all_events(self):
+        get_scale_mock = MagicMock(return_value=0)
+        url_mock = MagicMock(return_value='/bundle-events/endpoint')
+        get_events_mock = MagicMock(return_value=[
+            self.create_test_event('bundleExecutionAdded'),
+            self.create_test_event('bundleExecutionAdded'),
+            self.create_test_event('bundleExecutionAdded')
+        ])
+
+        stdout = MagicMock()
+
+        bundle_id = 'a101449418187d92c789d1adc240b6d6'
+        args = MagicMock(**{
+            'wait_timeout': 10
+        })
+        with patch('conductr_cli.conduct_url.url', url_mock), \
+                patch('conductr_cli.bundle_scale.get_scale', get_scale_mock), \
+                patch('conductr_cli.sse_client.get_events', get_events_mock):
+            logging_setup.configure_logging(args, stdout)
+            self.assertRaises(WaitTimeoutError, bundle_scale.wait_for_scale, bundle_id, 3, args)
+
+        self.assertEqual(get_scale_mock.call_args_list, [
+            call(bundle_id, args),
+            call(bundle_id, args),
+            call(bundle_id, args),
+            call(bundle_id, args)
+        ])
+
+        url_mock.assert_called_with('bundles/events', args)
+
+        self.assertEqual(strip_margin("""|Bundle a101449418187d92c789d1adc240b6d6 waiting to reach expected scale 3
+                                         |Bundle a101449418187d92c789d1adc240b6d6 has scale 0, expected 3
+                                         |Bundle a101449418187d92c789d1adc240b6d6 has scale 0, expected 3
+                                         |Bundle a101449418187d92c789d1adc240b6d6 has scale 0, expected 3
+                                         |"""), self.output(stdout))
+
+    def create_test_event(self, event_name):
+        sse_mock = MagicMock()
+        sse_mock.event = event_name
+        return sse_mock

--- a/conductr_cli/test/test_conduct_load_v2.py
+++ b/conductr_cli/test/test_conduct_load_v2.py
@@ -14,6 +14,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
     def __init__(self, method_name):
         super().__init__(method_name)
 
+        self.bundle_id = '45e0c477d3e5ea92aa8d85c0d8f3e25c'
         self.nr_of_cpus = 1.0
         self.memory = 200
         self.disk_space = 100
@@ -49,6 +50,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
             'api_version': '2',
             'verbose': False,
             'quiet': False,
+            'no_wait': False,
             'long_ids': False,
             'cli_parameters': '',
             'custom_settings': self.custom_settings,
@@ -105,15 +107,19 @@ class TestConductLoadCommand(ConductLoadTestBase):
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
+        wait_for_installation_mock = MagicMock()
+
+        args = self.default_args.copy()
+        args.update({'configuration': config_file})
+        input_args = MagicMock(**args)
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.bundle_utils.zip_entry', zip_entry_mock), \
                 patch('requests.post', http_method), \
-                patch('builtins.open', open_mock):
-            args = self.default_args.copy()
-            args.update({'configuration': config_file})
-            logging_setup.configure_logging(MagicMock(**args), stdout)
-            result = conduct_load.load(MagicMock(**args))
+                patch('builtins.open', open_mock), \
+                patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_load.load(input_args)
             self.assertTrue(result)
 
         self.assertEqual(
@@ -137,6 +143,8 @@ class TestConductLoadCommand(ConductLoadTestBase):
         ]
         http_method.assert_called_with(self.default_url, files=expected_files, timeout=LOAD_HTTP_TIMEOUT)
 
+        wait_for_installation_mock.assert_called_with(self.bundle_id, input_args)
+
         self.assertEqual(self.default_output(downloading_configuration='Retrieving configuration...\n'),
                          self.output(stdout))
 
@@ -155,15 +163,20 @@ class TestConductLoadCommand(ConductLoadTestBase):
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
+        wait_for_installation_mock = MagicMock()
+
+        args = self.default_args.copy()
+        args.update({'configuration': config_file})
+        input_args = MagicMock(**args)
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.bundle_utils.zip_entry', zip_entry_mock), \
                 patch('requests.post', http_method), \
-                patch('builtins.open', open_mock):
-            args = self.default_args.copy()
-            args.update({'configuration': config_file})
-            logging_setup.configure_logging(MagicMock(**args), stdout)
-            conduct_load.load(MagicMock(**args))
+                patch('builtins.open', open_mock), \
+                patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_load.load(input_args)
+            self.assertTrue(result)
 
         self.assertEqual(
             resolve_bundle_mock.call_args_list,
@@ -185,6 +198,8 @@ class TestConductLoadCommand(ConductLoadTestBase):
         ]
         http_method.assert_called_with(self.default_url, files=expected_files, timeout=LOAD_HTTP_TIMEOUT)
 
+        wait_for_installation_mock.assert_called_with(self.bundle_id, input_args)
+
         self.assertEqual(self.default_output(downloading_configuration='Retrieving configuration...\n'),
                          self.output(stdout))
 
@@ -192,6 +207,12 @@ class TestConductLoadCommand(ConductLoadTestBase):
             zip_entry_mock.call_args_list,
             [call('bundle.conf', self.bundle_file), call('bundle.conf', config_file)]
         )
+
+    def test_success_no_wait(self):
+        zip_entry_mock = MagicMock(return_value='mock bundle.conf')
+        with patch('conductr_cli.bundle_utils.zip_entry', zip_entry_mock):
+            self.base_test_success_no_wait()
+        zip_entry_mock.assert_called_with('bundle.conf', self.bundle_file)
 
     def test_failure(self):
         zip_entry_mock = MagicMock(return_value='mock bundle.conf')
@@ -235,4 +256,10 @@ class TestConductLoadCommand(ConductLoadTestBase):
             as_error(strip_margin("""|Error: Problem with the bundle: Unable to find bundle.conf within the bundle file
                                      |""")),
             self.output(stderr))
+        zip_entry_mock.assert_called_with('bundle.conf', self.bundle_file)
+
+    def test_failure_install_timeout(self):
+        zip_entry_mock = MagicMock(return_value='mock bundle.conf')
+        with patch('conductr_cli.bundle_utils.zip_entry', zip_entry_mock):
+            self.base_test_failure_install_timeout()
         zip_entry_mock.assert_called_with('bundle.conf', self.bundle_file)

--- a/conductr_cli/test/test_conduct_run_v1.py
+++ b/conductr_cli/test/test_conduct_run_v1.py
@@ -14,16 +14,19 @@ class TestConductRunCommand(ConductRunTestBase):
     def __init__(self, method_name):
         super().__init__(method_name)
 
+        self.bundle_id = '45e0c477d3e5ea92aa8d85c0d8f3e25c'
+        self.scale = 3
         self.default_args = {
             'ip': '127.0.0.1',
             'port': 9005,
             'api_version': '1',
             'verbose': False,
             'quiet': False,
+            'no_wait': False,
             'long_ids': False,
             'cli_parameters': '',
-            'bundle': '45e0c477d3e5ea92aa8d85c0d8f3e25c',
-            'scale': 3,
+            'bundle': self.bundle_id,
+            'scale': self.scale,
             'affinity': None
         }
 
@@ -46,11 +49,17 @@ class TestConductRunCommand(ConductRunTestBase):
     def test_success_with_configuration(self):
         self.base_test_success_with_configuration()
 
+    def test_success_no_wait(self):
+        self.base_test_success_no_wait()
+
     def test_failure(self):
         self.base_test_failure()
 
     def test_failure_invalid_address(self):
         self.base_test_failure_invalid_address()
+
+    def test_failure_scale_timeout(self):
+        self.base_test_failure_scale_timeout()
 
     def test_error_with_affinity_switch(self):
         args = {
@@ -58,10 +67,11 @@ class TestConductRunCommand(ConductRunTestBase):
             'port': 9005,
             'api_version': '1',
             'verbose': False,
+            'no_wait': False,
             'long_ids': False,
             'cli_parameters': '',
-            'bundle': '45e0c477d3e5ea92aa8d85c0d8f3e25c',
-            'scale': 3,
+            'bundle': self.bundle_id,
+            'scale': self.scale,
             'affinity': 'other-bundle'
         }
 

--- a/conductr_cli/test/test_conduct_run_v2.py
+++ b/conductr_cli/test/test_conduct_run_v2.py
@@ -12,16 +12,19 @@ class TestConductRunCommand(ConductRunTestBase):
     def __init__(self, method_name):
         super().__init__(method_name)
 
+        self.bundle_id = '45e0c477d3e5ea92aa8d85c0d8f3e25c'
+        self.scale = 3
         self.default_args = {
             'ip': '127.0.0.1',
             'port': 9005,
             'api_version': '2',
             'verbose': False,
             'quiet': False,
+            'no_wait': False,
             'long_ids': False,
             'cli_parameters': '',
-            'bundle': '45e0c477d3e5ea92aa8d85c0d8f3e25c',
-            'scale': 3,
+            'bundle': self.bundle_id,
+            'scale': self.scale,
             'affinity': None
         }
 
@@ -44,11 +47,17 @@ class TestConductRunCommand(ConductRunTestBase):
     def test_success_with_configuration(self):
         self.base_test_success_with_configuration()
 
+    def test_success_no_wait(self):
+        self.base_test_success_no_wait()
+
     def test_failure(self):
         self.base_test_failure()
 
     def test_failure_invalid_address(self):
         self.base_test_failure_invalid_address()
+
+    def test_failure_scale_timeout(self):
+        self.base_test_failure_scale_timeout()
 
     def test_success_with_affinity(self):
         args = {
@@ -57,10 +66,11 @@ class TestConductRunCommand(ConductRunTestBase):
             'api_version': '2',
             'verbose': False,
             'quiet': False,
+            'no_wait': False,
             'long_ids': False,
             'cli_parameters': '',
-            'bundle': '45e0c477d3e5ea92aa8d85c0d8f3e25c',
-            'scale': 3,
+            'bundle': self.bundle_id,
+            'scale': self.scale,
             'affinity': 'other-bundle'
         }
 
@@ -68,13 +78,17 @@ class TestConductRunCommand(ConductRunTestBase):
             'http://127.0.0.1:9005/v2/bundles/45e0c477d3e5ea92aa8d85c0d8f3e25c?scale=3&affinity=other-bundle'
 
         http_method = self.respond_with(200, self.default_response)
+        wait_for_scale_mock = MagicMock()
         stdout = MagicMock()
 
-        with patch('requests.put', http_method):
-            logging_setup.configure_logging(MagicMock(**args), stdout)
-            result = conduct_run.run(MagicMock(**args))
+        input_args = MagicMock(**args)
+        with patch('requests.put', http_method), \
+                patch('conductr_cli.bundle_scale.wait_for_scale', wait_for_scale_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_run.run(input_args)
             self.assertTrue(result)
 
         http_method.assert_called_with(expected_url)
+        wait_for_scale_mock.assert_called_with(self.bundle_id, self.scale, input_args)
 
         self.assertEqual(self.default_output(), self.output(stdout))

--- a/conductr_cli/test/test_conduct_stop.py
+++ b/conductr_cli/test/test_conduct_stop.py
@@ -1,5 +1,6 @@
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin, as_error
 from conductr_cli import conduct_stop, logging_setup
+from conductr_cli.exceptions import WaitTimeoutError
 from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
 
 
@@ -18,15 +19,18 @@ class TestConductStopCommand(CliTestCase):
                                |}
                                |""")
 
+    bundle_id = '45e0c477d3e5ea92aa8d85c0d8f3e25c'
+
     default_args = {
         'ip': '127.0.0.1',
         'port': 9005,
         'api_version': '1',
         'verbose': False,
         'quiet': False,
+        'no_wait': False,
         'long_ids': False,
         'cli_parameters': '',
-        'bundle': '45e0c477d3e5ea92aa8d85c0d8f3e25c'
+        'bundle': bundle_id
     }
 
     default_url = 'http://127.0.0.1:9005/bundles/45e0c477d3e5ea92aa8d85c0d8f3e25c?scale=0'
@@ -41,60 +45,77 @@ class TestConductStopCommand(CliTestCase):
 
     def test_success(self):
         http_method = self.respond_with(200, self.default_response)
+        wait_for_scale_mock = MagicMock()
         stdout = MagicMock()
 
-        with patch('requests.put', http_method):
-            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            result = conduct_stop.stop(MagicMock(**self.default_args))
+        input_args = MagicMock(**self.default_args)
+        with patch('requests.put', http_method), \
+                patch('conductr_cli.bundle_scale.wait_for_scale', wait_for_scale_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_stop.stop(input_args)
             self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        wait_for_scale_mock.assert_called_with(self.bundle_id, 0, input_args)
 
         self.assertEqual(self.default_output(), self.output(stdout))
 
     def test_success_verbose(self):
         http_method = self.respond_with(200, self.default_response)
+        wait_for_scale_mock = MagicMock()
         stdout = MagicMock()
 
-        with patch('requests.put', http_method):
-            args = self.default_args.copy()
-            args.update({'verbose': True})
-            logging_setup.configure_logging(MagicMock(**args), stdout)
-            result = conduct_stop.stop(MagicMock(**args))
+        args = self.default_args.copy()
+        args.update({'verbose': True})
+        input_args = MagicMock(**args)
+        with patch('requests.put', http_method), \
+                patch('conductr_cli.bundle_scale.wait_for_scale', wait_for_scale_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_stop.stop(input_args)
             self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        wait_for_scale_mock.assert_called_with(self.bundle_id, 0, input_args)
 
         self.assertEqual(self.default_response + self.default_output(), self.output(stdout))
 
     def test_success_long_ids(self):
         http_method = self.respond_with(200, self.default_response)
+        wait_for_scale_mock = MagicMock()
         stdout = MagicMock()
 
-        with patch('requests.put', http_method):
-            args = self.default_args.copy()
-            args.update({'long_ids': True})
-            logging_setup.configure_logging(MagicMock(**args), stdout)
-            result = conduct_stop.stop(MagicMock(**args))
+        args = self.default_args.copy()
+        args.update({'long_ids': True})
+        input_args = MagicMock(**args)
+        with patch('requests.put', http_method), \
+                patch('conductr_cli.bundle_scale.wait_for_scale', wait_for_scale_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_stop.stop(input_args)
             self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        wait_for_scale_mock.assert_called_with(self.bundle_id, 0, input_args)
 
         self.assertEqual(self.default_output(bundle_id='45e0c477d3e5ea92aa8d85c0d8f3e25c'), self.output(stdout))
 
     def test_success_with_configuration(self):
         http_method = self.respond_with(200, self.default_response)
+        wait_for_scale_mock = MagicMock()
         stdout = MagicMock()
 
+        args = self.default_args.copy()
         cli_parameters = ' --ip 127.0.1.1 --port 9006'
-        with patch('requests.put', http_method):
-            args = self.default_args.copy()
-            args.update({'cli_parameters': cli_parameters})
-            logging_setup.configure_logging(MagicMock(**args), stdout)
-            result = conduct_stop.stop(MagicMock(**args))
+        args.update({'cli_parameters': cli_parameters})
+        input_args = MagicMock(**args)
+
+        with patch('requests.put', http_method), \
+                patch('conductr_cli.bundle_scale.wait_for_scale', wait_for_scale_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_stop.stop(input_args)
             self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        wait_for_scale_mock.assert_called_with(self.bundle_id, 0, input_args)
 
         self.assertEqual(
             self.default_output(params=cli_parameters),
@@ -129,4 +150,24 @@ class TestConductStopCommand(CliTestCase):
 
         self.assertEqual(
             self.default_connection_error.format(self.default_url),
+            self.output(stderr))
+
+    def test_failure_stop_timeout(self):
+        http_method = self.respond_with(200, self.default_response)
+        wait_for_scale_mock = MagicMock(side_effect=WaitTimeoutError('test timeout error'))
+        stderr = MagicMock()
+
+        input_args = MagicMock(**self.default_args)
+        with patch('requests.put', http_method), \
+                patch('conductr_cli.bundle_scale.wait_for_scale', wait_for_scale_mock):
+            logging_setup.configure_logging(input_args, err_output=stderr)
+            result = conduct_stop.stop(input_args)
+            self.assertFalse(result)
+
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        wait_for_scale_mock.assert_called_with(self.bundle_id, 0, input_args)
+
+        self.assertEqual(
+            as_error(strip_margin("""|Error: Timed out: test timeout error
+                                     |""")),
             self.output(stderr))

--- a/conductr_cli/test/test_sse_client.py
+++ b/conductr_cli/test/test_sse_client.py
@@ -1,0 +1,46 @@
+from unittest import TestCase
+from conductr_cli.test.cli_test_case import strip_margin
+from conductr_cli import sse_client
+
+try:
+    from unittest.mock import patch, MagicMock  # 3.3 and beyond
+except ImportError:
+    from mock import patch, MagicMock
+
+
+class TestSSEClient(TestCase):
+    def test_sse(self):
+        raw_sse = strip_margin("""|data:
+                                  |
+                                  |event:My Test Event
+                                  |data:My Test Data
+                                  |
+                                  |data:
+                                  |
+                                  |""")
+        raw_sse_iterators = [iter(list(line)) for line in list(raw_sse)]
+        iter_content_mock = MagicMock(side_effect=raw_sse_iterators)
+
+        raise_for_status_mock = MagicMock()
+
+        response_mock = MagicMock()
+        response_mock.raise_for_status = raise_for_status_mock
+        response_mock.iter_content = iter_content_mock
+
+        request_get_mock = MagicMock(return_value=response_mock)
+
+        result = []
+        with patch('requests.get', request_get_mock):
+            events = sse_client.get_events('http://host.com')
+            for event in events:
+                result.append(event)
+
+        self.assertEqual([
+            sse_client.Event(event=None, data=''),
+            sse_client.Event(event='My Test Event', data='My Test Data'),
+            sse_client.Event(event=None, data='')
+        ], result)
+
+        request_get_mock.assert_called_with('http://host.com', stream=True, **sse_client.SSE_REQUEST_INPUT)
+        raise_for_status_mock.assert_called_with()
+        iter_content_mock.assert_called_with(decode_unicode=True)

--- a/conductr_cli/validation.py
+++ b/conductr_cli/validation.py
@@ -11,7 +11,8 @@ from requests.exceptions import ConnectionError, HTTPError
 from urllib.error import URLError
 from zipfile import BadZipFile
 from conductr_cli import terminal
-from conductr_cli.exceptions import DockerMachineError, Boot2DockerError, MalformedBundleError, BundleResolutionError
+from conductr_cli.exceptions import DockerMachineError, Boot2DockerError, MalformedBundleError, BundleResolutionError, \
+    WaitTimeoutError
 from subprocess import CalledProcessError
 
 
@@ -143,6 +144,22 @@ def handle_bundle_resolution_error(func):
         except BundleResolutionError as err:
             log = get_logger_for_func(func)
             log.error('Bundle not found: {}'.format(err.args[0]))
+            return False
+
+    # Do not change the wrapped function name,
+    # so argparse configuration can be tested.
+    handler.__name__ = func.__name__
+
+    return handler
+
+
+def handle_wait_timeout_error(func):
+    def handler(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except WaitTimeoutError as err:
+            log = get_logger_for_func(func)
+            log.error('Timed out: {}'.format(err.args[0]))
             return False
 
     # Do not change the wrapped function name,


### PR DESCRIPTION
- [x] Modify `conduct run` to wait until desired scale has been achieved
- [x] Modify `conduct stop` to wait until desired scale has been achieved
- [x] Modify `conduct load` to wait until bundle is installed
- [x] Introduce `--nowait` switch to allow the option for `conduct load`, `conduct run`, and `conduct stop` commands to return immediately
