### PR TITLE
Return non-zero return code for conduct commands upon encountering error trapped by validation handler functions

### DIFF
--- a/conductr_cli/conduct.py
+++ b/conductr_cli/conduct.py
@@ -266,7 +266,10 @@ def run():
         args.cli_parameters = get_cli_parameters(args)
         args.custom_settings = get_custom_settings(args)
         logging_setup.configure_logging(args)
-        args.func(args)
+
+        is_completed_without_error = args.func(args)
+        if not is_completed_without_error:
+            exit(1)
 
 
 if __name__ == '__main__':

--- a/conductr_cli/conduct_events.py
+++ b/conductr_cli/conduct_events.py
@@ -32,3 +32,5 @@ def events(args):
 {time: <{time_width}}{padding}\
 {event: <{event_width}}{padding}\
 {description: <{description_width}}{padding}'''.format(**dict(row, **column_widths)).rstrip())
+
+    return True

--- a/conductr_cli/conduct_info.py
+++ b/conductr_cli/conduct_info.py
@@ -44,3 +44,5 @@ def info(args):
 
     if has_error:
         log.screen('There are errors: use `conduct events` or `conduct logs` for further information')
+
+    return True

--- a/conductr_cli/conduct_load.py
+++ b/conductr_cli/conduct_load.py
@@ -69,6 +69,8 @@ def load_v1(args):
     if not log.is_info_enabled() and log.is_quiet_enabled():
         log.quiet(response_json['bundleId'])
 
+    return True
+
 
 def apply_to_configurations(base_conf, overlay_conf, method, key):
     if overlay_conf is None:
@@ -137,3 +139,5 @@ def load_v2(args):
 
         if not log.is_info_enabled() and log.is_quiet_enabled():
             log.quiet(response_json['bundleId'])
+
+    return True

--- a/conductr_cli/conduct_logs.py
+++ b/conductr_cli/conduct_logs.py
@@ -32,3 +32,5 @@ def logs(args):
 {time: <{time_width}}{padding}\
 {host: <{host_width}}{padding}\
 {log: <{log_width}}{padding}'''.format(**dict(row, **column_widths)).rstrip())
+
+    return True

--- a/conductr_cli/conduct_run.py
+++ b/conductr_cli/conduct_run.py
@@ -32,3 +32,5 @@ def run(args):
     log.info('Bundle run request sent.')
     log.info('Stop bundle with: conduct stop{} {}'.format(args.cli_parameters, bundle_id))
     log.info('Print ConductR info with: conduct info{}'.format(args.cli_parameters))
+
+    return True

--- a/conductr_cli/conduct_services.py
+++ b/conductr_cli/conduct_services.py
@@ -61,3 +61,5 @@ def services(args):
         log.screen('')
         log.warning('Multiple endpoints found for the following services: {}'.format(', '.join(duplicate_endpoints)))
         log.warning('Service resolution for these services is undefined.')
+
+    return True

--- a/conductr_cli/conduct_stop.py
+++ b/conductr_cli/conduct_stop.py
@@ -25,3 +25,5 @@ def stop(args):
     log.info('Bundle stop request sent.')
     log.info('Unload bundle with: conduct unload{} {}'.format(args.cli_parameters, bundle_id))
     log.info('Print ConductR info with: conduct info{}'.format(args.cli_parameters))
+
+    return True

--- a/conductr_cli/conduct_unload.py
+++ b/conductr_cli/conduct_unload.py
@@ -20,3 +20,5 @@ def unload(args):
 
     log.info('Bundle unload request sent.')
     log.info('Print ConductR info with: conduct info{}'.format(args.cli_parameters))
+
+    return True

--- a/conductr_cli/conduct_version.py
+++ b/conductr_cli/conduct_version.py
@@ -11,3 +11,4 @@ def version(args):
     log = logging.getLogger(__name__)
     log.screen(__version__)
     log.screen('Supported API version(s): {}'.format(', '.join(supported_api_versions())))
+    return True

--- a/conductr_cli/test/conduct_load_test_base.py
+++ b/conductr_cli/test/conduct_load_test_base.py
@@ -60,7 +60,8 @@ class ConductLoadTestBase(CliTestCase):
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock):
             logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            conduct_load.load(MagicMock(**self.default_args))
+            result = conduct_load.load(MagicMock(**self.default_args))
+            self.assertTrue(result)
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
@@ -80,7 +81,8 @@ class ConductLoadTestBase(CliTestCase):
             args = self.default_args.copy()
             args.update({'verbose': True})
             logging_setup.configure_logging(MagicMock(**args), stdout)
-            conduct_load.load(MagicMock(**args))
+            result = conduct_load.load(MagicMock(**args))
+            self.assertTrue(result)
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
@@ -100,7 +102,8 @@ class ConductLoadTestBase(CliTestCase):
             args = self.default_args.copy()
             args.update({'quiet': True})
             logging_setup.configure_logging(MagicMock(**args), stdout)
-            conduct_load.load(MagicMock(**args))
+            result = conduct_load.load(MagicMock(**args))
+            self.assertTrue(result)
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
@@ -120,7 +123,8 @@ class ConductLoadTestBase(CliTestCase):
             args = self.default_args.copy()
             args.update({'long_ids': True})
             logging_setup.configure_logging(MagicMock(**args), stdout)
-            conduct_load.load(MagicMock(**args))
+            result = conduct_load.load(MagicMock(**args))
+            self.assertTrue(result)
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
@@ -141,7 +145,8 @@ class ConductLoadTestBase(CliTestCase):
             args = self.default_args.copy()
             args.update({'cli_parameters': cli_parameters})
             logging_setup.configure_logging(MagicMock(**args), stdout)
-            conduct_load.load(MagicMock(**args))
+            result = conduct_load.load(MagicMock(**args))
+            self.assertTrue(result)
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
@@ -162,7 +167,8 @@ class ConductLoadTestBase(CliTestCase):
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock):
             logging_setup.configure_logging(MagicMock(**self.default_args), stdout, stderr)
-            conduct_load.load(MagicMock(**self.default_args))
+            result = conduct_load.load(MagicMock(**self.default_args))
+            self.assertFalse(result)
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
@@ -184,7 +190,8 @@ class ConductLoadTestBase(CliTestCase):
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock):
             logging_setup.configure_logging(MagicMock(**self.default_args), stdout, stderr)
-            conduct_load.load(MagicMock(**self.default_args))
+            result = conduct_load.load(MagicMock(**self.default_args))
+            self.assertFalse(result)
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
@@ -203,7 +210,8 @@ class ConductLoadTestBase(CliTestCase):
             args = self.default_args.copy()
             args.update({'bundle': 'no_such.bundle'})
             logging_setup.configure_logging(MagicMock(**args), stdout, stderr)
-            conduct_load.load(MagicMock(**args))
+            result = conduct_load.load(MagicMock(**args))
+            self.assertFalse(result)
 
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, 'no_such.bundle')
 
@@ -222,7 +230,8 @@ class ConductLoadTestBase(CliTestCase):
             args = self.default_args.copy()
             args.update({'configuration': 'no_such.conf'})
             logging_setup.configure_logging(MagicMock(**args), stdout, stderr)
-            conduct_load.load(MagicMock(**args))
+            result = conduct_load.load(MagicMock(**args))
+            self.assertFalse(result)
 
         self.assertEqual(
             resolve_bundle_mock.call_args_list,
@@ -245,7 +254,8 @@ class ConductLoadTestBase(CliTestCase):
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('builtins.open', open_mock):
             logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
-            conduct_load.load(MagicMock(**self.default_args))
+            result = conduct_load.load(MagicMock(**self.default_args))
+            self.assertFalse(result)
 
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
         open_mock.assert_called_with(self.bundle_file, 'rb')
@@ -262,7 +272,8 @@ class ConductLoadTestBase(CliTestCase):
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
             logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
-            conduct_load.load(MagicMock(**self.default_args))
+            result = conduct_load.load(MagicMock(**self.default_args))
+            self.assertFalse(result)
 
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
 
@@ -277,7 +288,8 @@ class ConductLoadTestBase(CliTestCase):
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
             logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
-            conduct_load.load(MagicMock(**self.default_args))
+            result = conduct_load.load(MagicMock(**self.default_args))
+            self.assertFalse(result)
 
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
 

--- a/conductr_cli/test/conduct_run_test_base.py
+++ b/conductr_cli/test/conduct_run_test_base.py
@@ -32,7 +32,8 @@ class ConductRunTestBase(CliTestCase):
 
         with patch('requests.put', http_method):
             logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            conduct_run.run(MagicMock(**self.default_args))
+            result = conduct_run.run(MagicMock(**self.default_args))
+            self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url)
 
@@ -46,7 +47,8 @@ class ConductRunTestBase(CliTestCase):
             args = self.default_args.copy()
             args.update({'verbose': True})
             logging_setup.configure_logging(MagicMock(**args), stdout)
-            conduct_run.run(MagicMock(**args))
+            result = conduct_run.run(MagicMock(**args))
+            self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url)
 
@@ -60,7 +62,8 @@ class ConductRunTestBase(CliTestCase):
             args = self.default_args.copy()
             args.update({'long_ids': True})
             logging_setup.configure_logging(MagicMock(**args), stdout)
-            conduct_run.run(MagicMock(**args))
+            result = conduct_run.run(MagicMock(**args))
+            self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url)
 
@@ -75,7 +78,8 @@ class ConductRunTestBase(CliTestCase):
             args = self.default_args.copy()
             args.update({'cli_parameters': cli_parameters})
             logging_setup.configure_logging(MagicMock(**args), stdout)
-            conduct_run.run(MagicMock(**args))
+            result = conduct_run.run(MagicMock(**args))
+            self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url)
 
@@ -89,7 +93,8 @@ class ConductRunTestBase(CliTestCase):
 
         with patch('requests.put', http_method):
             logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
-            conduct_run.run(MagicMock(**self.default_args))
+            result = conduct_run.run(MagicMock(**self.default_args))
+            self.assertFalse(result)
 
         http_method.assert_called_with(self.default_url)
 
@@ -104,7 +109,8 @@ class ConductRunTestBase(CliTestCase):
 
         with patch('requests.put', http_method):
             logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
-            conduct_run.run(MagicMock(**self.default_args))
+            result = conduct_run.run(MagicMock(**self.default_args))
+            self.assertFalse(result)
 
         http_method.assert_called_with(self.default_url)
 

--- a/conductr_cli/test/test_conduct_events.py
+++ b/conductr_cli/test/test_conduct_events.py
@@ -29,7 +29,8 @@ class TestConductEventsCommand(CliTestCase):
 
         with patch('requests.get', http_method):
             logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            conduct_events.events(MagicMock(**self.default_args))
+            result = conduct_events.events(MagicMock(**self.default_args))
+            self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
         self.assertEqual(
@@ -54,7 +55,8 @@ class TestConductEventsCommand(CliTestCase):
 
         with patch('requests.get', http_method):
             logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            conduct_events.events(MagicMock(**self.default_args))
+            result = conduct_events.events(MagicMock(**self.default_args))
+            self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
         self.assertEqual(
@@ -70,7 +72,8 @@ class TestConductEventsCommand(CliTestCase):
 
         with patch('requests.get', http_method):
             logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
-            conduct_events.events(MagicMock(**self.default_args))
+            result = conduct_events.events(MagicMock(**self.default_args))
+            self.assertFalse(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
         self.assertEqual(

--- a/conductr_cli/test/test_conduct_info.py
+++ b/conductr_cli/test/test_conduct_info.py
@@ -28,7 +28,8 @@ class TestConductInfoCommand(CliTestCase):
 
         with patch('requests.get', http_method):
             logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            conduct_info.info(MagicMock(**self.default_args))
+            result = conduct_info.info(MagicMock(**self.default_args))
+            self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
         self.assertEqual(
@@ -49,7 +50,8 @@ class TestConductInfoCommand(CliTestCase):
 
         with patch('requests.get', http_method):
             logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            conduct_info.info(MagicMock(**self.default_args))
+            result = conduct_info.info(MagicMock(**self.default_args))
+            self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
         self.assertEqual(
@@ -83,7 +85,8 @@ class TestConductInfoCommand(CliTestCase):
 
         with patch('requests.get', http_method):
             logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            conduct_info.info(MagicMock(**self.default_args))
+            result = conduct_info.info(MagicMock(**self.default_args))
+            self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
         self.assertEqual(
@@ -115,7 +118,8 @@ class TestConductInfoCommand(CliTestCase):
             args = self.default_args.copy()
             args.update({'verbose': True})
             logging_setup.configure_logging(MagicMock(**args), stdout)
-            conduct_info.info(MagicMock(**args))
+            result = conduct_info.info(MagicMock(**args))
+            self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
         self.assertEqual(
@@ -176,7 +180,8 @@ class TestConductInfoCommand(CliTestCase):
             args = self.default_args.copy()
             args.update({'long_ids': True})
             logging_setup.configure_logging(MagicMock(**args), stdout)
-            conduct_info.info(MagicMock(**args))
+            result = conduct_info.info(MagicMock(**args))
+            self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
         self.assertEqual(
@@ -198,7 +203,8 @@ class TestConductInfoCommand(CliTestCase):
 
         with patch('requests.get', http_method):
             logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            conduct_info.info(MagicMock(**self.default_args))
+            result = conduct_info.info(MagicMock(**self.default_args))
+            self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
         self.assertEqual(
@@ -221,7 +227,8 @@ class TestConductInfoCommand(CliTestCase):
 
         with patch('requests.get', http_method):
             logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            conduct_info.info(MagicMock(**self.default_args))
+            result = conduct_info.info(MagicMock(**self.default_args))
+            self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
         self.assertEqual(
@@ -237,7 +244,8 @@ class TestConductInfoCommand(CliTestCase):
 
         with patch('requests.get', http_method):
             logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
-            conduct_info.info(MagicMock(**self.default_args))
+            result = conduct_info.info(MagicMock(**self.default_args))
+            self.assertFalse(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
         self.assertEqual(

--- a/conductr_cli/test/test_conduct_load_v1.py
+++ b/conductr_cli/test/test_conduct_load_v1.py
@@ -143,7 +143,8 @@ class TestConductLoadCommand(ConductLoadTestBase):
             args = self.default_args.copy()
             args.update({'bundle': bundle_file})
             logging_setup.configure_logging(MagicMock(**args), err_output=stderr)
-            conduct_load.load(MagicMock(**args))
+            result = conduct_load.load(MagicMock(**args))
+            self.assertFalse(result)
 
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, bundle_file)
 
@@ -169,7 +170,8 @@ class TestConductLoadCommand(ConductLoadTestBase):
             args = self.default_args.copy()
             args.update({'bundle': bundle_file})
             logging_setup.configure_logging(MagicMock(**args), err_output=stderr)
-            conduct_load.load(MagicMock(**args))
+            result = conduct_load.load(MagicMock(**args))
+            self.assertFalse(result)
 
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, bundle_file)
 
@@ -195,7 +197,8 @@ class TestConductLoadCommand(ConductLoadTestBase):
             args = self.default_args.copy()
             args.update({'bundle': bundle_file})
             logging_setup.configure_logging(MagicMock(**args), err_output=stderr)
-            conduct_load.load(MagicMock(**args))
+            result = conduct_load.load(MagicMock(**args))
+            self.assertFalse(result)
 
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, bundle_file)
 
@@ -221,7 +224,8 @@ class TestConductLoadCommand(ConductLoadTestBase):
             args = self.default_args.copy()
             args.update({'bundle': bundle_file})
             logging_setup.configure_logging(MagicMock(**args), err_output=stderr)
-            conduct_load.load(MagicMock(**args))
+            result = conduct_load.load(MagicMock(**args))
+            self.assertFalse(result)
 
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, bundle_file)
 
@@ -248,7 +252,8 @@ class TestConductLoadCommand(ConductLoadTestBase):
             args = self.default_args.copy()
             args.update({'bundle': bundle_file})
             logging_setup.configure_logging(MagicMock(**args), err_output=stderr)
-            conduct_load.load(MagicMock(**args))
+            result = conduct_load.load(MagicMock(**args))
+            self.assertFalse(result)
 
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, bundle_file)
 

--- a/conductr_cli/test/test_conduct_load_v2.py
+++ b/conductr_cli/test/test_conduct_load_v2.py
@@ -113,7 +113,8 @@ class TestConductLoadCommand(ConductLoadTestBase):
             args = self.default_args.copy()
             args.update({'configuration': config_file})
             logging_setup.configure_logging(MagicMock(**args), stdout)
-            conduct_load.load(MagicMock(**args))
+            result = conduct_load.load(MagicMock(**args))
+            self.assertTrue(result)
 
         self.assertEqual(
             resolve_bundle_mock.call_args_list,
@@ -225,7 +226,8 @@ class TestConductLoadCommand(ConductLoadTestBase):
                 patch('conductr_cli.bundle_utils.zip_entry', zip_entry_mock):
             args = self.default_args.copy()
             logging_setup.configure_logging(MagicMock(**args), err_output=stderr)
-            conduct_load.load(MagicMock(**args))
+            result = conduct_load.load(MagicMock(**args))
+            self.assertFalse(result)
 
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
 

--- a/conductr_cli/test/test_conduct_logs.py
+++ b/conductr_cli/test/test_conduct_logs.py
@@ -29,7 +29,8 @@ class TestConductLogsCommand(CliTestCase):
 
         with patch('requests.get', http_method):
             logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            conduct_logs.logs(MagicMock(**self.default_args))
+            result = conduct_logs.logs(MagicMock(**self.default_args))
+            self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
         self.assertEqual(
@@ -54,7 +55,8 @@ class TestConductLogsCommand(CliTestCase):
 
         with patch('requests.get', http_method):
             logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            conduct_logs.logs(MagicMock(**self.default_args))
+            result = conduct_logs.logs(MagicMock(**self.default_args))
+            self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
         self.assertEqual(
@@ -70,7 +72,8 @@ class TestConductLogsCommand(CliTestCase):
 
         with patch('requests.get', http_method):
             logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
-            conduct_logs.logs(MagicMock(**self.default_args))
+            result = conduct_logs.logs(MagicMock(**self.default_args))
+            self.assertFalse(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
         self.assertEqual(

--- a/conductr_cli/test/test_conduct_run_v1.py
+++ b/conductr_cli/test/test_conduct_run_v1.py
@@ -68,7 +68,8 @@ class TestConductRunCommand(ConductRunTestBase):
         stderr = MagicMock()
 
         logging_setup.configure_logging(MagicMock(**args), err_output=stderr)
-        conduct_run.run(MagicMock(**args))
+        result = conduct_run.run(MagicMock(**args))
+        self.assertFalse(result)
 
         self.assertEqual(
             as_error(strip_margin("""|Error: Affinity feature is only available for v1.1 onwards of ConductR

--- a/conductr_cli/test/test_conduct_run_v2.py
+++ b/conductr_cli/test/test_conduct_run_v2.py
@@ -72,7 +72,8 @@ class TestConductRunCommand(ConductRunTestBase):
 
         with patch('requests.put', http_method):
             logging_setup.configure_logging(MagicMock(**args), stdout)
-            conduct_run.run(MagicMock(**args))
+            result = conduct_run.run(MagicMock(**args))
+            self.assertTrue(result)
 
         http_method.assert_called_with(expected_url)
 

--- a/conductr_cli/test/test_conduct_services.py
+++ b/conductr_cli/test/test_conduct_services.py
@@ -27,7 +27,8 @@ class TestConductServicesCommand(CliTestCase):
 
         with patch('requests.get', http_method):
             logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            conduct_services.services(MagicMock(**self.default_args))
+            result = conduct_services.services(MagicMock(**self.default_args))
+            self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
         self.assertEqual(
@@ -41,7 +42,8 @@ class TestConductServicesCommand(CliTestCase):
 
         with patch('requests.get', http_method):
             logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            conduct_services.services(MagicMock(**self.default_args))
+            result = conduct_services.services(MagicMock(**self.default_args))
+            self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
         self.assertEqual(
@@ -66,7 +68,8 @@ class TestConductServicesCommand(CliTestCase):
 
         with patch('requests.get', http_method):
             logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            conduct_services.services(MagicMock(**self.default_args))
+            result = conduct_services.services(MagicMock(**self.default_args))
+            self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
         self.assertEqual(
@@ -88,7 +91,8 @@ class TestConductServicesCommand(CliTestCase):
 
         with patch('requests.get', http_method):
             logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            conduct_services.services(MagicMock(**self.default_args))
+            result = conduct_services.services(MagicMock(**self.default_args))
+            self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
         self.assertEqual(
@@ -109,7 +113,8 @@ class TestConductServicesCommand(CliTestCase):
             args = self.default_args.copy()
             args.update({'long_ids': True})
             logging_setup.configure_logging(MagicMock(**args), stdout)
-            conduct_services.services(MagicMock(**args))
+            result = conduct_services.services(MagicMock(**args))
+            self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
         self.assertEqual(

--- a/conductr_cli/test/test_conduct_stop.py
+++ b/conductr_cli/test/test_conduct_stop.py
@@ -45,7 +45,8 @@ class TestConductStopCommand(CliTestCase):
 
         with patch('requests.put', http_method):
             logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            conduct_stop.stop(MagicMock(**self.default_args))
+            result = conduct_stop.stop(MagicMock(**self.default_args))
+            self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
 
@@ -59,7 +60,8 @@ class TestConductStopCommand(CliTestCase):
             args = self.default_args.copy()
             args.update({'verbose': True})
             logging_setup.configure_logging(MagicMock(**args), stdout)
-            conduct_stop.stop(MagicMock(**args))
+            result = conduct_stop.stop(MagicMock(**args))
+            self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
 
@@ -73,7 +75,8 @@ class TestConductStopCommand(CliTestCase):
             args = self.default_args.copy()
             args.update({'long_ids': True})
             logging_setup.configure_logging(MagicMock(**args), stdout)
-            conduct_stop.stop(MagicMock(**args))
+            result = conduct_stop.stop(MagicMock(**args))
+            self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
 
@@ -88,7 +91,8 @@ class TestConductStopCommand(CliTestCase):
             args = self.default_args.copy()
             args.update({'cli_parameters': cli_parameters})
             logging_setup.configure_logging(MagicMock(**args), stdout)
-            conduct_stop.stop(MagicMock(**args))
+            result = conduct_stop.stop(MagicMock(**args))
+            self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
 
@@ -102,7 +106,8 @@ class TestConductStopCommand(CliTestCase):
 
         with patch('requests.put', http_method):
             logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
-            conduct_stop.stop(MagicMock(**self.default_args))
+            result = conduct_stop.stop(MagicMock(**self.default_args))
+            self.assertFalse(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
 
@@ -117,7 +122,8 @@ class TestConductStopCommand(CliTestCase):
 
         with patch('requests.put', http_method):
             logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
-            conduct_stop.stop(MagicMock(**self.default_args))
+            result = conduct_stop.stop(MagicMock(**self.default_args))
+            self.assertFalse(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
 

--- a/conductr_cli/test/test_conduct_unload.py
+++ b/conductr_cli/test/test_conduct_unload.py
@@ -42,7 +42,8 @@ class TestConductUnloadCommand(CliTestCase):
 
         with patch('requests.delete', http_method):
             logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            conduct_unload.unload(MagicMock(**self.default_args))
+            result = conduct_unload.unload(MagicMock(**self.default_args))
+            self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
 
@@ -56,7 +57,8 @@ class TestConductUnloadCommand(CliTestCase):
             args = self.default_args.copy()
             args.update({'verbose': True})
             logging_setup.configure_logging(MagicMock(**args), stdout)
-            conduct_unload.unload(MagicMock(**args))
+            result = conduct_unload.unload(MagicMock(**args))
+            self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
 
@@ -71,7 +73,8 @@ class TestConductUnloadCommand(CliTestCase):
             args = self.default_args.copy()
             args.update({'cli_parameters': cli_parameters})
             logging_setup.configure_logging(MagicMock(**args), stdout)
-            conduct_unload.unload(MagicMock(**args))
+            result = conduct_unload.unload(MagicMock(**args))
+            self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
 
@@ -85,7 +88,8 @@ class TestConductUnloadCommand(CliTestCase):
 
         with patch('requests.delete', http_method):
             logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
-            conduct_unload.unload(MagicMock(**self.default_args))
+            result = conduct_unload.unload(MagicMock(**self.default_args))
+            self.assertFalse(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
 
@@ -100,7 +104,8 @@ class TestConductUnloadCommand(CliTestCase):
 
         with patch('requests.delete', http_method):
             logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
-            conduct_unload.unload(MagicMock(**self.default_args))
+            result = conduct_unload.unload(MagicMock(**self.default_args))
+            self.assertFalse(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
 

--- a/conductr_cli/test/test_conduct_version.py
+++ b/conductr_cli/test/test_conduct_version.py
@@ -14,7 +14,8 @@ class TestConductVersionCommand(CliTestCase):
         stdout = MagicMock()
 
         logging_setup.configure_logging(args, stdout)
-        conduct_version.version(args)
+        result = conduct_version.version(args)
+        self.assertTrue(result)
 
         from conductr_cli import __version__
         self.assertEqual(

--- a/conductr_cli/validation.py
+++ b/conductr_cli/validation.py
@@ -40,6 +40,7 @@ def handle_connection_error(func):
         except ConnectionError as err:
             log = get_logger_for_func(func)
             connection_error(log, err, *args)
+            return False
 
     # Do not change the wrapped function name,
     # so argparse configuration can be tested.
@@ -57,6 +58,7 @@ def handle_http_error(func):
             log.error('{} {}'.format(err.response.status_code, err.response.reason))
             if err.response.text != '':
                 log.error(err.response.text)
+            return False
 
     # Do not change the wrapped function name,
     # so argparse configuration can be tested.
@@ -73,6 +75,7 @@ def handle_invalid_config(func):
             log = get_logger_for_func(func)
             log.error('Unable to parse bundle.conf.')
             log.error('{}.'.format(err.args[0]))
+            return False
 
     # Do not change the wrapped function name,
     # so argparse configuration can be tested.
@@ -88,9 +91,11 @@ def handle_no_file(func):
         except urllib.error.HTTPError as err:
             log = get_logger_for_func(func)
             log.error('Resource not found: {}'.format(err.url))
+            return False
         except URLError as err:
             log = get_logger_for_func(func)
             log.error('File not found: {}'.format(err.args[0]))
+            return False
 
     # Do not change the wrapped function name,
     # so argparse configuration can be tested.
@@ -106,6 +111,7 @@ def handle_bad_zip(func):
         except BadZipFile as err:
             log = get_logger_for_func(func)
             log.error('Problem with the bundle: {}'.format(err.args[0]))
+            return False
 
     # Do not change the wrapped function name,
     # so argparse configuration can be tested.
@@ -121,6 +127,7 @@ def handle_malformed_bundle(func):
         except MalformedBundleError as err:
             log = get_logger_for_func(func)
             log.error('Problem with the bundle: {}'.format(err.args[0]))
+            return False
 
     # Do not change the wrapped function name,
     # so argparse configuration can be tested.
@@ -136,6 +143,7 @@ def handle_bundle_resolution_error(func):
         except BundleResolutionError as err:
             log = get_logger_for_func(func)
             log.error('Bundle not found: {}'.format(err.args[0]))
+            return False
 
     # Do not change the wrapped function name,
     # so argparse configuration can be tested.


### PR DESCRIPTION
This is to ensure correct behaviour when scripting conductr cli in the shell script, i.e. ensure `set -e` works
