### PR TITLE
Read DOCKER_MACHINE_NAME environment variable before falling back to default VM name

### DIFF
--- a/conductr_cli/docker_machine.py
+++ b/conductr_cli/docker_machine.py
@@ -1,0 +1,7 @@
+import os
+
+DEFAULT_DOCKER_MACHINE_NAME = 'default'
+
+
+def vm_name():
+    return os.getenv('DOCKER_MACHINE_NAME', DEFAULT_DOCKER_MACHINE_NAME)

--- a/conductr_cli/host.py
+++ b/conductr_cli/host.py
@@ -1,5 +1,5 @@
 import os
-from conductr_cli import terminal, validation
+from conductr_cli import terminal, validation, docker_machine
 from conductr_cli.exceptions import DockerMachineError, Boot2DockerError
 from subprocess import CalledProcessError
 
@@ -23,7 +23,8 @@ def resolve_default_ip():
 
 def with_docker_machine():
     try:
-        output = terminal.docker_machine_ip('default')
+        vm_name = docker_machine.vm_name()
+        output = terminal.docker_machine_ip(vm_name)
         if output:
             return output
         else:


### PR DESCRIPTION
This will allow cli users to specify different VM name apart from default.

Fixes #79.
