### PR TITLE
Ensure that credentials as used for url download

### DIFF
--- a/conductr_cli/resolvers/bintray_resolver.py
+++ b/conductr_cli/resolvers/bintray_resolver.py
@@ -10,6 +10,7 @@ import requests
 
 BINTRAY_API_BASE_URL = 'https://api.bintray.com'
 BINTRAY_DOWNLOAD_BASE_URL = 'https://dl.bintray.com'
+BINTRAY_DOWNLOAD_REALM = 'Bintray'
 BINTRAY_CREDENTIAL_FILE_PATH = '{}/.bintray/.credentials'.format(os.path.expanduser('~'))
 
 
@@ -22,7 +23,8 @@ def resolve_bundle(cache_dir, uri):
         bundle_download_url = bintray_download_url(bintray_username, bintray_password, org, repo, package_name,
                                                    compatibility_version, digest)
         if bundle_download_url:
-            return uri_resolver.resolve_bundle(cache_dir, bundle_download_url)
+            auth = (BINTRAY_DOWNLOAD_REALM, bintray_username, bintray_password) if bintray_username else None
+            return uri_resolver.resolve_bundle(cache_dir, bundle_download_url, auth)
         else:
             return False, None, None
     except MalformedBundleUriError:

--- a/conductr_cli/resolvers/test/test_bintray_resolver.py
+++ b/conductr_cli/resolvers/test/test_bintray_resolver.py
@@ -32,7 +32,8 @@ class TestResolveBundle(TestCase):
         parse_mock.assert_called_with('bundle-name:v1')
         bintray_download_url_mock.assert_called_with('username', 'password', 'typesafe', 'bundle', 'bundle-name', 'v1',
                                                      'digest')
-        resolve_bundle_mock.assert_called_with('/cache-dir', 'https://dl.bintray.com/download.zip')
+        resolve_bundle_mock.assert_called_with('/cache-dir', 'https://dl.bintray.com/download.zip',
+                                               ('Bintray', 'username', 'password'))
 
     def test_bintray_version_not_found(self):
         load_bintray_credentials_mock = MagicMock(return_value=('username', 'password'))


### PR DESCRIPTION
Private repos require credentials, and these were not being forwarded on to the uri resolver.

Fixes #108 
