### PR TITLE
Encode BundleId when issuing calls to Bundle events and logs endpoint

### DIFF
--- a/conductr_cli/conduct_events.py
+++ b/conductr_cli/conduct_events.py
@@ -3,6 +3,7 @@ import json
 import logging
 import requests
 from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
+from urllib.parse import quote_plus
 
 
 @validation.handle_connection_error
@@ -11,7 +12,7 @@ def events(args):
     """`conduct events` command"""
 
     log = logging.getLogger(__name__)
-    request_url = conduct_url.url('bundles/{}/events?count={}'.format(args.bundle, args.lines), args)
+    request_url = conduct_url.url('bundles/{}/events?count={}'.format(quote_plus(args.bundle), args.lines), args)
     response = requests.get(request_url, timeout=DEFAULT_HTTP_TIMEOUT)
     validation.raise_for_status_inc_3xx(response)
 

--- a/conductr_cli/conduct_logs.py
+++ b/conductr_cli/conduct_logs.py
@@ -3,6 +3,7 @@ import json
 import logging
 import requests
 from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
+from urllib.parse import quote_plus
 
 
 @validation.handle_connection_error
@@ -11,7 +12,7 @@ def logs(args):
     """`conduct logs` command"""
 
     log = logging.getLogger(__name__)
-    request_url = conduct_url.url('bundles/{}/logs?count={}'.format(args.bundle, args.lines), args)
+    request_url = conduct_url.url('bundles/{}/logs?count={}'.format(quote_plus(args.bundle), args.lines), args)
     response = requests.get(request_url, timeout=DEFAULT_HTTP_TIMEOUT)
     validation.raise_for_status_inc_3xx(response)
 

--- a/conductr_cli/test/test_conduct_events.py
+++ b/conductr_cli/test/test_conduct_events.py
@@ -11,23 +11,29 @@ except ImportError:
 
 class TestConductEventsCommand(CliTestCase):
 
+    bundle_id = 'ab8f513'
+
+    bundle_id_urlencoded = 'bundle+id'
+
     default_args = {
         'ip': '127.0.0.1',
         'port': '9005',
         'api_version': '1',
-        'bundle': 'ab8f513',
+        'bundle': bundle_id,
         'lines': 1,
         'date': True,
         'utc': True
     }
 
-    default_url = 'http://127.0.0.1:9005/bundles/ab8f513/events?count=1'
+    default_url = 'http://127.0.0.1:9005/bundles/{}/events?count=1'.format(bundle_id_urlencoded)
 
     def test_no_events(self):
         http_method = self.respond_with(text='{}')
+        quote_method = MagicMock(return_value=self.bundle_id_urlencoded)
         stdout = MagicMock()
 
-        with patch('requests.get', http_method):
+        with patch('requests.get', http_method), \
+                patch('urllib.parse.quote', quote_method):
             logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
             result = conduct_events.events(MagicMock(**self.default_args))
             self.assertTrue(result)
@@ -51,9 +57,11 @@ class TestConductEventsCommand(CliTestCase):
                 "description":"Bundle written: requestId=cba938cd-860e-41a4-9cbe-2c677feaca20, bundleName=visualizer"
             }
         ]""")
+        quote_method = MagicMock(return_value=self.bundle_id_urlencoded)
         stdout = MagicMock()
 
-        with patch('requests.get', http_method):
+        with patch('requests.get', http_method), \
+                patch('urllib.parse.quote', quote_method):
             logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
             result = conduct_events.events(MagicMock(**self.default_args))
             self.assertTrue(result)
@@ -68,9 +76,11 @@ class TestConductEventsCommand(CliTestCase):
 
     def test_failure_invalid_address(self):
         http_method = self.raise_connection_error('test reason', self.default_url)
+        quote_method = MagicMock(return_value=self.bundle_id_urlencoded)
         stderr = MagicMock()
 
-        with patch('requests.get', http_method):
+        with patch('requests.get', http_method), \
+                patch('urllib.parse.quote', quote_method):
             logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
             result = conduct_events.events(MagicMock(**self.default_args))
             self.assertFalse(result)

--- a/conductr_cli/test/test_conduct_logs.py
+++ b/conductr_cli/test/test_conduct_logs.py
@@ -11,23 +11,29 @@ except ImportError:
 
 class TestConductLogsCommand(CliTestCase):
 
+    bundle_id = 'ab8f513'
+
+    bundle_id_urlencoded = 'bundle+id'
+
     default_args = {
         'ip': '127.0.0.1',
         'port': '9005',
         'api_version': '1',
-        'bundle': 'ab8f513',
+        'bundle': bundle_id,
         'lines': 1,
         'date': True,
         'utc': True
     }
 
-    default_url = 'http://127.0.0.1:9005/bundles/ab8f513/logs?count=1'
+    default_url = 'http://127.0.0.1:9005/bundles/{}/logs?count=1'.format(bundle_id_urlencoded)
 
     def test_no_logs(self):
         http_method = self.respond_with(text='{}')
+        quote_method = MagicMock(return_value=self.bundle_id_urlencoded)
         stdout = MagicMock()
 
-        with patch('requests.get', http_method):
+        with patch('requests.get', http_method), \
+                patch('urllib.parse.quote', quote_method):
             logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
             result = conduct_logs.logs(MagicMock(**self.default_args))
             self.assertTrue(result)
@@ -51,9 +57,11 @@ class TestConductLogsCommand(CliTestCase):
                 "message":"[WARN] [04/21/2015 12:54:36.079] [doc-renderer-cluster-1-akka.remote.default-remote-dispatcher-26] Association with remote system has failed."
             }
         ]""")
+        quote_method = MagicMock(return_value=self.bundle_id_urlencoded)
         stdout = MagicMock()
 
-        with patch('requests.get', http_method):
+        with patch('requests.get', http_method), \
+                patch('urllib.parse.quote', quote_method):
             logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
             result = conduct_logs.logs(MagicMock(**self.default_args))
             self.assertTrue(result)
@@ -68,9 +76,11 @@ class TestConductLogsCommand(CliTestCase):
 
     def test_failure_invalid_address(self):
         http_method = self.raise_connection_error('test reason', self.default_url)
+        quote_method = MagicMock(return_value=self.bundle_id_urlencoded)
         stderr = MagicMock()
 
-        with patch('requests.get', http_method):
+        with patch('requests.get', http_method), \
+                patch('urllib.parse.quote', quote_method):
             logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
             result = conduct_logs.logs(MagicMock(**self.default_args))
             self.assertFalse(result)


### PR DESCRIPTION
This will ensure correct behaviour for `conduct events` and `conduct logs` endpoint despite invalid input (i.e. path to bundle file)
