### PR TITLE
Windows Unit Test fixes

### DIFF
--- a/conductr_cli/resolvers/test/test_uri_resolver.py
+++ b/conductr_cli/resolvers/test/test_uri_resolver.py
@@ -163,9 +163,12 @@ class TestGetUrl(TestCase):
             'bundle-1.0-e78ed07d4a895e14595a21aef1bf616b1b0e4d886f3265bc7b152acf93d259b5.zip')
         self.assertEqual(
             'bundle-1.0-e78ed07d4a895e14595a21aef1bf616b1b0e4d886f3265bc7b152acf93d259b5.zip', filename)
+        # os.getcwd() does not return path starting with '/' on windows - additional '/' will be required to form a
+        # correct file uri on windows
+        base_uri = 'file://' + os.getcwd() if os.getcwd().startswith('/') else 'file:///' + os.getcwd()
         self.assertEqual(
-            'file://' + os.getcwd() +
-            '/bundle-1.0-e78ed07d4a895e14595a21aef1bf616b1b0e4d886f3265bc7b152acf93d259b5.zip', url)
+            base_uri + os.sep +
+            'bundle-1.0-e78ed07d4a895e14595a21aef1bf616b1b0e4d886f3265bc7b152acf93d259b5.zip', url)
 
 
 class TestCachePath(TestCase):

--- a/conductr_cli/resolvers/uri_resolver.py
+++ b/conductr_cli/resolvers/uri_resolver.py
@@ -54,7 +54,7 @@ def get_url(uri):
     op = Path(uri)
     np = str(op.cwd() / op if parsed.scheme == 'file' and op.root == '' else parsed.path)
     url = urlunparse(ParseResult(parsed.scheme, parsed.netloc, np, parsed.params, parsed.query, parsed.fragment))
-    return url.split('/')[-1], url
+    return os.path.basename(url), url
 
 
 def cache_path(cache_dir, uri):

--- a/conductr_cli/shazar.py
+++ b/conductr_cli/shazar.py
@@ -34,9 +34,12 @@ def build_parser():
 def shazar(args):
     log = logging.getLogger(__name__)
     source_base_name = os.path.basename(args.source.rstrip('\\/'))
-    temp_file = tempfile.NamedTemporaryFile(suffix='.zip', delete=False).name
+    # Create an empty tempfile
+    temp_file = tempfile.NamedTemporaryFile(suffix='.zip', delete=False)
+    temp_file.close()
+    temp_file_name = temp_file.name
 
-    with zipfile.ZipFile(temp_file, 'w') as zip_file:
+    with zipfile.ZipFile(temp_file_name, 'w') as zip_file:
         if os.path.isdir(args.source):
             for (dir_path, dir_names, file_names) in os.walk(args.source):
                 for file_name in file_names:
@@ -46,8 +49,8 @@ def shazar(args):
         else:
             zip_file.write(args.source, source_base_name)
 
-    dest = os.path.join(args.output_dir, '{}-{}.zip'.format(source_base_name, create_digest(temp_file)))
-    shutil.move(temp_file, dest)
+    dest = os.path.join(args.output_dir, '{}-{}.zip'.format(source_base_name, create_digest(temp_file_name)))
+    shutil.move(temp_file_name, dest)
     log.info('Created digested ZIP archive at {}'.format(dest))
 
 

--- a/conductr_cli/test/test_bundle_installation.py
+++ b/conductr_cli/test/test_bundle_installation.py
@@ -169,7 +169,7 @@ class TestWaitForInstallation(CliTestCase):
         bundle_id = 'a101449418187d92c789d1adc240b6d6'
         args = MagicMock(**{
             # Purposely set no timeout to invoke the error
-            'wait_timeout': 0
+            'wait_timeout': -1
         })
         with patch('conductr_cli.conduct_url.url', url_mock), \
                 patch('conductr_cli.bundle_installation.count_installations', count_installations_mock), \
@@ -290,7 +290,7 @@ class TestWaitForUninstallation(CliTestCase):
         bundle_id = 'a101449418187d92c789d1adc240b6d6'
         args = MagicMock(**{
             # Purposely set no timeout to invoke the error
-            'wait_timeout': 0
+            'wait_timeout': -1
         })
         with patch('conductr_cli.conduct_url.url', url_mock), \
                 patch('conductr_cli.bundle_installation.count_installations', count_installations_mock), \

--- a/conductr_cli/test/test_bundle_scale.py
+++ b/conductr_cli/test/test_bundle_scale.py
@@ -198,7 +198,7 @@ class TestWaitForScale(CliTestCase):
         bundle_id = 'a101449418187d92c789d1adc240b6d6'
         args = MagicMock(**{
             # Purposely set no timeout to invoke the error
-            'wait_timeout': 0
+            'wait_timeout': -1
         })
         with patch('conductr_cli.conduct_url.url', url_mock), \
                 patch('conductr_cli.bundle_scale.get_scale', get_scale_mock), \

--- a/conductr_cli/test/test_conduct_load_v1.py
+++ b/conductr_cli/test/test_conduct_load_v1.py
@@ -27,12 +27,12 @@ class TestConductLoadCommand(ConductLoadTestBase):
         self.bundle_resolve_cache_dir = 'bundle-resolve-cache-dir'
 
         self.tmpdir, self.bundle_file = create_temp_bundle(
-            strip_margin("""|nrOfCpus   = {}
-                            |memory     = {}
-                            |diskSpace  = {}
-                            |roles      = [{}]
-                            |name       = {}
-                            |system     = {}
+            strip_margin("""|nrOfCpus   = {},
+                            |memory     = {},
+                            |diskSpace  = {},
+                            |roles      = [{}],
+                            |name       = {},
+                            |system     = {},
                             |""").format(self.nr_of_cpus,
                                          self.memory,
                                          self.disk_space,


### PR DESCRIPTION
- Cater for windows file separator `\` as well as unix based `/`
- Ensure tempfiles are being closed in the shazar command as well as in the test
- Ensure bundle conf generated in the test has each key-value pair ending with `,` to prevent line break differences causing incorrect config value being read
- Modify timeout values in the timeout related tests to ensure timeouts do get triggered in these tests as expected
