### PR TITLE
Fix incorrect invocation when CLI is installed via pip3

### DIFF
--- a/conductr_cli/conduct.py
+++ b/conductr_cli/conduct.py
@@ -5,5 +5,9 @@ def main_method():
     from conductr_cli import conduct_main
     conduct_main.run()
 
-if __name__ == '__main__':
+
+def run():
     main_handler.run(main_method)
+
+if __name__ == '__main__':
+    run()

--- a/conductr_cli/sandbox.py
+++ b/conductr_cli/sandbox.py
@@ -5,5 +5,9 @@ def main_method():
     from conductr_cli import sandbox_main
     sandbox_main.run()
 
-if __name__ == '__main__':
+
+def run():
     main_handler.run(main_method)
+
+if __name__ == '__main__':
+    run()

--- a/conductr_cli/shazar.py
+++ b/conductr_cli/shazar.py
@@ -5,5 +5,9 @@ def main_method():
     from conductr_cli import shazar_main
     shazar_main.run()
 
-if __name__ == '__main__':
+
+def run():
     main_handler.run(main_method)
+
+if __name__ == '__main__':
+    run()


### PR DESCRIPTION
When installed via pip3, the cli does not invoke the main entry point of the program via `__main__`.

Instead, it expects the following methods to be declared within `setup.py`:
- `conductr_cli.conduct:run`
- `conductr_cli.sandbox:run`
- `conductr_cli.shazar:run`

The change is to reinstate this behaviour correctly so the main files can be invoked from both `__main__` as well as pip3 installation.
