### PR TITLE
Sandbox Run ACL Related Port Changes

### DIFF
--- a/conductr_cli/sandbox_common.py
+++ b/conductr_cli/sandbox_common.py
@@ -1,4 +1,5 @@
 from conductr_cli import host, terminal
+import os
 
 
 CONDUCTR_NAME_PREFIX = 'cond-'
@@ -6,7 +7,6 @@ CONDUCTR_PORTS = {5601,  # conductr-kibana bundle
                   9004,  # ConductR internal akka remoting
                   9005,  # ConductR controlServer
                   9006,  # ConductR bundleStreamServer
-                  9200,  # conductr-elasticsearch bundle
                   9999}  # visualizer bundle
 CONDUCTR_DEV_IMAGE = 'typesafe-docker-registry-for-subscribers-only.bintray.io/conductr/conductr'
 LATEST_CONDUCTR_VERSION = '1.0.12'
@@ -28,3 +28,8 @@ def resolve_running_docker_containers():
     container_ids = terminal.docker_ps(ps_filter='name={}'.format(CONDUCTR_NAME_PREFIX))
     container_names = [terminal.docker_inspect(container_id, '{{.Name}}')[1:] for container_id in container_ids]
     return sorted(container_names)
+
+
+def bundle_http_port():
+    """Returns ConductR default HAProxy Frontend port for HTTP based ACLs"""
+    return int(os.getenv('BUNDLE_HTTP_PORT', 9000))

--- a/conductr_cli/sandbox_main.py
+++ b/conductr_cli/sandbox_main.py
@@ -68,6 +68,12 @@ def build_parser():
                             default=[],
                             help='Set additional ports to be made public by each of the ConductR containers.',
                             metavar='')
+    run_parser.add_argument('--bundle-http-port',
+                            dest='bundle_http_port',
+                            type=int,
+                            default=sandbox_common.bundle_http_port(),
+                            help='Set default frontend port for proxying HTTP based request ACLs.',
+                            metavar='')
     features = ['visualization', 'logging', 'monitoring']
     run_parser.add_argument('-f', '--feature',
                             dest='features',

--- a/conductr_cli/test/test_sandbox_common.py
+++ b/conductr_cli/test/test_sandbox_common.py
@@ -1,0 +1,18 @@
+from conductr_cli.test.cli_test_case import CliTestCase
+from conductr_cli import sandbox_common
+
+try:
+    from unittest.mock import patch, MagicMock  # 3.3 and beyond
+except ImportError:
+    from mock import patch, MagicMock
+
+
+class TestSandboxCommon(CliTestCase):
+    def test_bundle_http_port(self):
+        port_number = 1111
+        getenv_mock = MagicMock(return_value=port_number)
+        with patch('os.getenv', getenv_mock):
+            result = sandbox_common.bundle_http_port()
+
+        self.assertEqual(result, port_number)
+        getenv_mock.assert_called_with('BUNDLE_HTTP_PORT', 9000)

--- a/conductr_cli/test/test_sandbox_main.py
+++ b/conductr_cli/test/test_sandbox_main.py
@@ -36,6 +36,7 @@ class TestSandbox(TestCase):
                                       '--log-level debug '
                                       '--nr-of-containers 5 '
                                       '--port 1000 -p 1001 '
+                                      '--bundle-http-port 7111 '
                                       '--feature visualization -f logging'.split())
         self.assertEqual(args.func.__name__, 'run')
         self.assertEqual(args.image_version, '1.1.0')
@@ -48,6 +49,7 @@ class TestSandbox(TestCase):
         self.assertEqual(args.features, ['visualization', 'logging'])
         self.assertEqual(args.local_connection, True)
         self.assertEqual(args.resolve_ip, True)
+        self.assertEqual(args.bundle_http_port, 7111)
 
     def test_parser_stop(self):
         args = self.parser.parse_args('stop'.split())

--- a/conductr_cli/test/test_sandbox_run.py
+++ b/conductr_cli/test/test_sandbox_run.py
@@ -19,6 +19,7 @@ class TestSandboxRunCommand(CliTestCase):
         'log_level': 'info',
         'nr_of_containers': 1,
         'ports': [],
+        'bundle_http_port': 9000,
         'features': [],
         'local_connection': True
     }
@@ -27,8 +28,8 @@ class TestSandboxRunCommand(CliTestCase):
         return ['-d', '--name', container_name]
 
     default_env_args = ['-e', 'AKKA_LOGLEVEL=info']
-    default_port_args = ['-p', '9200:9200',
-                         '-p', '5601:5601',
+    default_port_args = ['-p', '5601:5601',
+                         '-p', '9000:9000',
                          '-p', '9004:9004',
                          '-p', '9005:9005',
                          '-p', '9006:9006',
@@ -87,7 +88,7 @@ class TestSandboxRunCommand(CliTestCase):
         # Assert cond-0
         mock_docker_run.assert_any_call(
             ['-d', '--name', 'cond-0', '-e', 'AKKA_LOGLEVEL=info',
-             '-p', '9200:9200', '-p', '5601:5601', '-p', '9004:9004', '-p', '9005:9005', '-p', '9006:9006',
+             '-p', '5601:5601', '-p', '9000:9000', '-p', '9004:9004', '-p', '9005:9005', '-p', '9006:9006',
              '-p', '9999:9999'],
             expected_image,
             self.default_positional_args
@@ -95,7 +96,7 @@ class TestSandboxRunCommand(CliTestCase):
         # Assert cond-1
         mock_docker_run.assert_any_call(
             ['-d', '--name', 'cond-1', '-e', 'AKKA_LOGLEVEL=info', '-e', 'SYSLOG_IP=10.10.10.10',
-             '-p', '9210:9200', '-p', '5611:5601', '-p', '9014:9004', '-p', '9015:9005', '-p', '9016:9006',
+             '-p', '5611:5601', '-p', '9010:9000', '-p', '9014:9004', '-p', '9015:9005', '-p', '9016:9006',
              '-p', '9909:9999'],
             expected_image,
             self.default_positional_args + ['--seed', '10.10.10.10:9004']
@@ -103,7 +104,7 @@ class TestSandboxRunCommand(CliTestCase):
         # Assert cond-2
         mock_docker_run.assert_any_call(
             ['-d', '--name', 'cond-2', '-e', 'AKKA_LOGLEVEL=info', '-e', 'SYSLOG_IP=10.10.10.10',
-             '-p', '9220:9200', '-p', '5621:5601', '-p', '9024:9004', '-p', '9025:9005', '-p', '9026:9006',
+             '-p', '5621:5601', '-p', '9020:9000', '-p', '9024:9004', '-p', '9025:9005', '-p', '9026:9006',
              '-p', '9919:9999'],
             expected_image,
             self.default_positional_args + ['--seed', '10.10.10.10:9004']
@@ -136,21 +137,22 @@ class TestSandboxRunCommand(CliTestCase):
                 'log_level': log_level,
                 'nr_of_containers': nr_of_containers,
                 'ports': ports,
+                'bundle_http_port': 7222,
                 'features': features
             })
             logging_setup.configure_logging(MagicMock(**args), stdout)
             sandbox_run.run(MagicMock(**args))
 
         expected_stdout = strip_margin("""|Starting ConductR nodes..
-                                          |Starting container cond-0 exposing 192.168.99.100:3000, 192.168.99.100:3001, 192.168.99.100:5601, 192.168.99.100:9200, 192.168.99.100:9999..
+                                          |Starting container cond-0 exposing 192.168.99.100:3000, 192.168.99.100:3001, 192.168.99.100:5601, 192.168.99.100:9999..
                                           |""")
 
         self.assertEqual(expected_stdout, self.output(stdout))
         mock_docker_run.assert_called_once_with(
             ['-d', '--name', 'cond-0', '-e', 'key1=value1', '-e', 'key2=value2', '-e', 'AKKA_LOGLEVEL=debug',
              '-e', 'CONDUCTR_FEATURES=visualization,logging', '-e', 'CONDUCTR_ROLES=role1,role2',
-             '-p', '5601:5601', '-p', '9004:9004', '-p', '9005:9005', '-p', '9006:9006', '-p', '9999:9999',
-             '-p', '9200:9200', '-p', '3000:3000', '-p', '3001:3001'],
+             '-p', '5601:5601', '-p', '9004:9004', '-p', '9005:9005', '-p', '9006:9006',
+             '-p', '9999:9999', '-p', '7222:7222', '-p', '3000:3000', '-p', '3001:3001'],
             '{}:{}'.format(image, image_version),
             self.default_positional_args
         )
@@ -186,7 +188,7 @@ class TestSandboxRunCommand(CliTestCase):
         # Assert cond-0
         mock_docker_run.assert_any_call(
             ['-d', '--name', 'cond-0', '-e', 'AKKA_LOGLEVEL=info', '-e', 'CONDUCTR_ROLES=role1,role2',
-             '-p', '9200:9200', '-p', '5601:5601', '-p', '9004:9004', '-p', '9005:9005', '-p', '9006:9006',
+             '-p', '5601:5601', '-p', '9000:9000', '-p', '9004:9004', '-p', '9005:9005', '-p', '9006:9006',
              '-p', '9999:9999'],
             expected_image,
             self.default_positional_args
@@ -195,7 +197,7 @@ class TestSandboxRunCommand(CliTestCase):
         mock_docker_run.assert_any_call(
             ['-d', '--name', 'cond-1', '-e', 'AKKA_LOGLEVEL=info', '-e', 'SYSLOG_IP=10.10.10.10',
              '-e', 'CONDUCTR_ROLES=role3',
-             '-p', '9210:9200', '-p', '5611:5601', '-p', '9014:9004', '-p', '9015:9005', '-p', '9016:9006',
+             '-p', '5611:5601', '-p', '9010:9000', '-p', '9014:9004', '-p', '9015:9005', '-p', '9016:9006',
              '-p', '9909:9999'],
             expected_image,
             self.default_positional_args + ['--seed', '10.10.10.10:9004']
@@ -204,7 +206,7 @@ class TestSandboxRunCommand(CliTestCase):
         mock_docker_run.assert_any_call(
             ['-d', '--name', 'cond-2', '-e', 'AKKA_LOGLEVEL=info', '-e', 'SYSLOG_IP=10.10.10.10',
              '-e', 'CONDUCTR_ROLES=role1,role2',
-             '-p', '9220:9200', '-p', '5621:5601', '-p', '9024:9004', '-p', '9025:9005', '-p', '9026:9006',
+             '-p', '5621:5601', '-p', '9020:9000', '-p', '9024:9004', '-p', '9025:9005', '-p', '9026:9006',
              '-p', '9919:9999'],
             expected_image,
             self.default_positional_args + ['--seed', '10.10.10.10:9004']


### PR DESCRIPTION
Due to ACL work that is taking place within ConductR, the following port changes are necessary:
- Expose default bundle HTTP port of 9000 when starting sandbox via docker run command
- Remove ES port 9200
