### PR TITLE
IPv6 support - explicitly specify the HTTP Host header

### DIFF
--- a/conductr_cli/bundle_scale.py
+++ b/conductr_cli/bundle_scale.py
@@ -9,7 +9,12 @@ import requests
 
 def get_scale(bundle_id, args):
     bundles_url = conduct_url.url('bundles', args)
-    response = requests.get(bundles_url)
+    # At the time when this comment is being written, we need to pass the Host header when making HTTP request due to
+    # a bug with requests python library not working properly when IPv6 address is supplied:
+    # https://github.com/kennethreitz/requests/issues/3002
+    # The workaround for this problem is to explicitly set the Host header when making HTTP request.
+    # This fix is benign and backward compatible as the library would do this when making HTTP request anyway.
+    response = requests.get(bundles_url, headers=conduct_url.request_headers(args))
     response.raise_for_status()
     bundles = json.loads(response.text)
     matching_bundles = [bundle for bundle in bundles if bundle['bundleId'] == bundle_id]
@@ -35,7 +40,7 @@ def wait_for_scale(bundle_id, expected_scale, args):
     else:
         log.info('Bundle {} waiting to reach expected scale {}'.format(bundle_id, expected_scale))
         bundle_events_url = conduct_url.url('bundles/events', args)
-        sse_events = sse_client.get_events(bundle_events_url)
+        sse_events = sse_client.get_events(bundle_events_url, headers=conduct_url.request_headers(args))
         for event in sse_events:
             elapsed = (datetime.now() - start_time).total_seconds()
             if elapsed > args.wait_timeout:

--- a/conductr_cli/conduct_acls.py
+++ b/conductr_cli/conduct_acls.py
@@ -20,7 +20,12 @@ def acls(args):
 
     log = logging.getLogger(__name__)
     url = conduct_url.url('bundles', args)
-    response = requests.get(url, timeout=DEFAULT_HTTP_TIMEOUT)
+    # At the time when this comment is being written, we need to pass the Host header when making HTTP request due to
+    # a bug with requests python library not working properly when IPv6 address is supplied:
+    # https://github.com/kennethreitz/requests/issues/3002
+    # The workaround for this problem is to explicitly set the Host header when making HTTP request.
+    # This fix is benign and backward compatible as the library would do this when making HTTP request anyway.
+    response = requests.get(url, timeout=DEFAULT_HTTP_TIMEOUT, headers=conduct_url.request_headers(args))
     validation.raise_for_status_inc_3xx(response)
 
     if log.is_verbose_enabled():

--- a/conductr_cli/conduct_events.py
+++ b/conductr_cli/conduct_events.py
@@ -13,7 +13,12 @@ def events(args):
 
     log = logging.getLogger(__name__)
     request_url = conduct_url.url('bundles/{}/events?count={}'.format(quote_plus(args.bundle), args.lines), args)
-    response = requests.get(request_url, timeout=DEFAULT_HTTP_TIMEOUT)
+    # At the time when this comment is being written, we need to pass the Host header when making HTTP request due to
+    # a bug with requests python library not working properly when IPv6 address is supplied:
+    # https://github.com/kennethreitz/requests/issues/3002
+    # The workaround for this problem is to explicitly set the Host header when making HTTP request.
+    # This fix is benign and backward compatible as the library would do this when making HTTP request anyway.
+    response = requests.get(request_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=conduct_url.request_headers(args))
     validation.raise_for_status_inc_3xx(response)
 
     data = [

--- a/conductr_cli/conduct_info.py
+++ b/conductr_cli/conduct_info.py
@@ -12,7 +12,12 @@ def info(args):
 
     log = logging.getLogger(__name__)
     url = conduct_url.url('bundles', args)
-    response = requests.get(url, timeout=DEFAULT_HTTP_TIMEOUT)
+    # At the time when this comment is being written, we need to pass the Host header when making HTTP request due to
+    # a bug with requests python library not working properly when IPv6 address is supplied:
+    # https://github.com/kennethreitz/requests/issues/3002
+    # The workaround for this problem is to explicitly set the Host header when making HTTP request.
+    # This fix is benign and backward compatible as the library would do this when making HTTP request anyway.
+    response = requests.get(url, timeout=DEFAULT_HTTP_TIMEOUT, headers=conduct_url.request_headers(args))
     validation.raise_for_status_inc_3xx(response)
 
     if log.is_verbose_enabled():

--- a/conductr_cli/conduct_load.py
+++ b/conductr_cli/conduct_load.py
@@ -54,7 +54,12 @@ def load_v1(args):
         files.append(('configuration', (configuration_name, open(configuration_file, 'rb'))))
 
     log.info('Loading bundle to ConductR...')
-    response = requests.post(url, files=files, timeout=LOAD_HTTP_TIMEOUT)
+    # At the time when this comment is being written, we need to pass the Host header when making HTTP request due to
+    # a bug with requests python library not working properly when IPv6 address is supplied:
+    # https://github.com/kennethreitz/requests/issues/3002
+    # The workaround for this problem is to explicitly set the Host header when making HTTP request.
+    # This fix is benign and backward compatible as the library would do this when making HTTP request anyway.
+    response = requests.post(url, files=files, timeout=LOAD_HTTP_TIMEOUT, headers=conduct_url.request_headers(args))
     validation.raise_for_status_inc_3xx(response)
 
     if log.is_verbose_enabled():
@@ -128,7 +133,12 @@ def load_v2(args):
         url = conduct_url.url('bundles', args)
 
         log.info('Loading bundle to ConductR...')
-        response = requests.post(url, files=files, timeout=LOAD_HTTP_TIMEOUT)
+        # At the time when this comment is being written, we need to pass the Host header when making HTTP request due
+        # to a bug with requests python library not working properly when IPv6 address is supplied:
+        # https://github.com/kennethreitz/requests/issues/3002
+        # The workaround for this problem is to explicitly set the Host header when making HTTP request.
+        # This fix is benign and backward compatible as the library would do this when making HTTP request anyway.
+        response = requests.post(url, files=files, timeout=LOAD_HTTP_TIMEOUT, headers=conduct_url.request_headers(args))
         validation.raise_for_status_inc_3xx(response)
 
         if log.is_verbose_enabled():

--- a/conductr_cli/conduct_logs.py
+++ b/conductr_cli/conduct_logs.py
@@ -13,7 +13,12 @@ def logs(args):
 
     log = logging.getLogger(__name__)
     request_url = conduct_url.url('bundles/{}/logs?count={}'.format(quote_plus(args.bundle), args.lines), args)
-    response = requests.get(request_url, timeout=DEFAULT_HTTP_TIMEOUT)
+    # At the time when this comment is being written, we need to pass the Host header when making HTTP request due to
+    # a bug with requests python library not working properly when IPv6 address is supplied:
+    # https://github.com/kennethreitz/requests/issues/3002
+    # The workaround for this problem is to explicitly set the Host header when making HTTP request.
+    # This fix is benign and backward compatible as the library would do this when making HTTP request anyway.
+    response = requests.get(request_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=conduct_url.request_headers(args))
     validation.raise_for_status_inc_3xx(response)
 
     data = [

--- a/conductr_cli/conduct_run.py
+++ b/conductr_cli/conduct_run.py
@@ -22,7 +22,12 @@ def run(args):
         path = 'bundles/{}?scale={}'.format(args.bundle, args.scale)
 
     url = conduct_url.url(path, args)
-    response = requests.put(url)
+    # At the time when this comment is being written, we need to pass the Host header when making HTTP request due to
+    # a bug with requests python library not working properly when IPv6 address is supplied:
+    # https://github.com/kennethreitz/requests/issues/3002
+    # The workaround for this problem is to explicitly set the Host header when making HTTP request.
+    # This fix is benign and backward compatible as the library would do this when making HTTP request anyway.
+    response = requests.put(url, headers=conduct_url.request_headers(args))
     validation.raise_for_status_inc_3xx(response)
 
     if log.is_verbose_enabled():

--- a/conductr_cli/conduct_services.py
+++ b/conductr_cli/conduct_services.py
@@ -13,7 +13,12 @@ def services(args):
 
     log = logging.getLogger(__name__)
     url = conduct_url.url('bundles', args)
-    response = requests.get(url, timeout=DEFAULT_HTTP_TIMEOUT)
+    # At the time when this comment is being written, we need to pass the Host header when making HTTP request due to
+    # a bug with requests python library not working properly when IPv6 address is supplied:
+    # https://github.com/kennethreitz/requests/issues/3002
+    # The workaround for this problem is to explicitly set the Host header when making HTTP request.
+    # This fix is benign and backward compatible as the library would do this when making HTTP request anyway.
+    response = requests.get(url, timeout=DEFAULT_HTTP_TIMEOUT, headers=conduct_url.request_headers(args))
     validation.raise_for_status_inc_3xx(response)
 
     if log.is_verbose_enabled():

--- a/conductr_cli/conduct_stop.py
+++ b/conductr_cli/conduct_stop.py
@@ -14,7 +14,12 @@ def stop(args):
     log = logging.getLogger(__name__)
     path = 'bundles/{}?scale=0'.format(args.bundle)
     url = conduct_url.url(path, args)
-    response = requests.put(url, timeout=DEFAULT_HTTP_TIMEOUT)
+    # At the time when this comment is being written, we need to pass the Host header when making HTTP request due to
+    # a bug with requests python library not working properly when IPv6 address is supplied:
+    # https://github.com/kennethreitz/requests/issues/3002
+    # The workaround for this problem is to explicitly set the Host header when making HTTP request.
+    # This fix is benign and backward compatible as the library would do this when making HTTP request anyway.
+    response = requests.put(url, timeout=DEFAULT_HTTP_TIMEOUT, headers=conduct_url.request_headers(args))
     validation.raise_for_status_inc_3xx(response)
 
     if log.is_verbose_enabled():

--- a/conductr_cli/conduct_unload.py
+++ b/conductr_cli/conduct_unload.py
@@ -13,7 +13,12 @@ def unload(args):
     log = logging.getLogger(__name__)
     path = 'bundles/{}'.format(args.bundle)
     url = conduct_url.url(path, args)
-    response = requests.delete(url, timeout=DEFAULT_HTTP_TIMEOUT)
+    # At the time when this comment is being written, we need to pass the Host header when making HTTP request due to
+    # a bug with requests python library not working properly when IPv6 address is supplied:
+    # https://github.com/kennethreitz/requests/issues/3002
+    # The workaround for this problem is to explicitly set the Host header when making HTTP request.
+    # This fix is benign and backward compatible as the library would do this when making HTTP request anyway.
+    response = requests.delete(url, timeout=DEFAULT_HTTP_TIMEOUT, headers=conduct_url.request_headers(args))
     validation.raise_for_status_inc_3xx(response)
 
     if log.is_verbose_enabled():

--- a/conductr_cli/conduct_url.py
+++ b/conductr_cli/conduct_url.py
@@ -9,3 +9,11 @@ def api_version_path(api_version):
         return ''
     else:
         return '/v{}'.format(api_version)
+
+
+def request_headers(args):
+    headers = {}
+    if args.ip:
+        headers.update({'Host': args.ip})
+
+    return headers if headers else None

--- a/conductr_cli/test/conduct_load_test_base.py
+++ b/conductr_cli/test/conduct_load_test_base.py
@@ -36,6 +36,7 @@ class ConductLoadTestBase(CliTestCase):
         self.roles = []
         self.custom_settings = None
         self.bundle_resolve_cache_dir = None
+        self.mock_headers = {'pretend': 'header'}
 
     @property
     def default_response(self):
@@ -52,6 +53,7 @@ class ConductLoadTestBase(CliTestCase):
             'verbose': verbose}))
 
     def base_test_success(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, self.bundle_file))
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
@@ -62,6 +64,7 @@ class ConductLoadTestBase(CliTestCase):
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_load.load(input_args)
@@ -69,12 +72,15 @@ class ConductLoadTestBase(CliTestCase):
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
-        http_method.assert_called_with(self.default_url, files=self.default_files, timeout=LOAD_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, files=self.default_files, timeout=LOAD_HTTP_TIMEOUT,
+                                       headers=self.mock_headers)
         wait_for_installation_mock.assert_called_with(self.bundle_id, input_args)
 
         self.assertEqual(self.default_output(), self.output(stdout))
 
     def base_test_success_verbose(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, self.bundle_file))
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
@@ -88,6 +94,7 @@ class ConductLoadTestBase(CliTestCase):
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_load.load(input_args)
@@ -95,12 +102,15 @@ class ConductLoadTestBase(CliTestCase):
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
-        http_method.assert_called_with(self.default_url, files=self.default_files, timeout=LOAD_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, files=self.default_files, timeout=LOAD_HTTP_TIMEOUT,
+                                       headers=self.mock_headers)
         wait_for_installation_mock.assert_called_with(self.bundle_id, input_args)
 
         self.assertEqual(self.default_output(verbose=self.default_response), self.output(stdout))
 
     def base_test_success_quiet(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, self.bundle_file))
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
@@ -114,6 +124,7 @@ class ConductLoadTestBase(CliTestCase):
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_load.load(input_args)
@@ -121,12 +132,15 @@ class ConductLoadTestBase(CliTestCase):
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
-        http_method.assert_called_with(self.default_url, files=self.default_files, timeout=LOAD_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, files=self.default_files, timeout=LOAD_HTTP_TIMEOUT,
+                                       headers=self.mock_headers)
         wait_for_installation_mock.assert_called_with(self.bundle_id, input_args)
 
         self.assertEqual('45e0c477d3e5ea92aa8d85c0d8f3e25c\n', self.output(stdout))
 
     def base_test_success_long_ids(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, self.bundle_file))
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
@@ -140,6 +154,7 @@ class ConductLoadTestBase(CliTestCase):
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_load.load(input_args)
@@ -147,12 +162,15 @@ class ConductLoadTestBase(CliTestCase):
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
-        http_method.assert_called_with(self.default_url, files=self.default_files, timeout=LOAD_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, files=self.default_files, timeout=LOAD_HTTP_TIMEOUT,
+                                       headers=self.mock_headers)
         wait_for_installation_mock.assert_called_with(self.bundle_id, input_args)
 
         self.assertEqual(self.default_output(bundle_id='45e0c477d3e5ea92aa8d85c0d8f3e25c'), self.output(stdout))
 
     def base_test_success_custom_ip_port(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, self.bundle_file))
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
@@ -167,6 +185,7 @@ class ConductLoadTestBase(CliTestCase):
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_load.load(input_args)
@@ -174,7 +193,9 @@ class ConductLoadTestBase(CliTestCase):
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
-        http_method.assert_called_with(self.default_url, files=self.default_files, timeout=LOAD_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, files=self.default_files, timeout=LOAD_HTTP_TIMEOUT,
+                                       headers=self.mock_headers)
         wait_for_installation_mock.assert_called_with(self.bundle_id, input_args)
 
         self.assertEqual(
@@ -182,6 +203,7 @@ class ConductLoadTestBase(CliTestCase):
             self.output(stdout))
 
     def base_test_success_no_wait(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, self.bundle_file))
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
@@ -192,6 +214,7 @@ class ConductLoadTestBase(CliTestCase):
         input_args = MagicMock(**args)
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock):
             logging_setup.configure_logging(input_args, stdout)
@@ -200,27 +223,34 @@ class ConductLoadTestBase(CliTestCase):
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
-        http_method.assert_called_with(self.default_url, files=self.default_files, timeout=LOAD_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, files=self.default_files, timeout=LOAD_HTTP_TIMEOUT,
+                                       headers=self.mock_headers)
 
         self.assertEqual(self.default_output(), self.output(stdout))
 
     def base_test_failure(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, self.bundle_file))
         http_method = self.respond_with(404)
         stdout = MagicMock()
         stderr = MagicMock()
         open_mock = MagicMock(return_value=1)
 
+        input_args = MagicMock(**self.default_args)
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock):
-            logging_setup.configure_logging(MagicMock(**self.default_args), stdout, stderr)
-            result = conduct_load.load(MagicMock(**self.default_args))
+            logging_setup.configure_logging(input_args, stdout, stderr)
+            result = conduct_load.load(input_args)
             self.assertFalse(result)
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
-        http_method.assert_called_with(self.default_url, files=self.default_files, timeout=LOAD_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, files=self.default_files, timeout=LOAD_HTTP_TIMEOUT,
+                                       headers=self.mock_headers)
 
         self.assertEqual(
             as_error(strip_margin("""|Error: 404 Not Found
@@ -228,44 +258,54 @@ class ConductLoadTestBase(CliTestCase):
             self.output(stderr))
 
     def base_test_failure_invalid_address(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, self.bundle_file))
         http_method = self.raise_connection_error('test reason', self.default_url)
         stdout = MagicMock()
         stderr = MagicMock()
         open_mock = MagicMock(return_value=1)
 
+        input_args = MagicMock(**self.default_args)
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock):
-            logging_setup.configure_logging(MagicMock(**self.default_args), stdout, stderr)
-            result = conduct_load.load(MagicMock(**self.default_args))
+            logging_setup.configure_logging(input_args, stdout, stderr)
+            result = conduct_load.load(input_args)
             self.assertFalse(result)
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
-        http_method.assert_called_with(self.default_url, files=self.default_files, timeout=LOAD_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, files=self.default_files, timeout=LOAD_HTTP_TIMEOUT,
+                                       headers=self.mock_headers)
 
         self.assertEqual(
             self.default_connection_error.format(self.default_url),
             self.output(stderr))
 
     def base_test_failure_no_response(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, self.bundle_file))
         http_method = self.raise_read_timeout_error('test reason', self.default_url)
         stdout = MagicMock()
         stderr = MagicMock()
         open_mock = MagicMock(return_value=1)
 
+        input_args = MagicMock(**self.default_args)
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock):
-            logging_setup.configure_logging(MagicMock(**self.default_args), stdout, stderr)
-            result = conduct_load.load(MagicMock(**self.default_args))
+            logging_setup.configure_logging(input_args, stdout, stderr)
+            result = conduct_load.load(input_args)
             self.assertFalse(result)
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
-        http_method.assert_called_with(self.default_url, files=self.default_files, timeout=LOAD_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, files=self.default_files, timeout=LOAD_HTTP_TIMEOUT,
+                                       headers=self.mock_headers)
 
         self.assertEqual(
             as_error(
@@ -372,6 +412,7 @@ class ConductLoadTestBase(CliTestCase):
             self.output(stderr))
 
     def base_test_failure_install_timeout(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, self.bundle_file))
         http_method = self.respond_with(200, self.default_response)
         stderr = MagicMock()
@@ -380,6 +421,7 @@ class ConductLoadTestBase(CliTestCase):
 
         input_args = MagicMock(**self.default_args)
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
@@ -389,7 +431,9 @@ class ConductLoadTestBase(CliTestCase):
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
-        http_method.assert_called_with(self.default_url, files=self.default_files, timeout=LOAD_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, files=self.default_files, timeout=LOAD_HTTP_TIMEOUT,
+                                       headers=self.mock_headers)
         wait_for_installation_mock.assert_called_with(self.bundle_id, input_args)
 
         self.assertEqual(

--- a/conductr_cli/test/conduct_run_test_base.py
+++ b/conductr_cli/test/conduct_run_test_base.py
@@ -18,6 +18,7 @@ class ConductRunTestBase(CliTestCase):
         self.default_args = {}
         self.default_url = None
         self.output_template = None
+        self.mock_headers = {'pretend': 'header'}
 
     @property
     def default_response(self):
@@ -30,6 +31,7 @@ class ConductRunTestBase(CliTestCase):
         return strip_margin(self.output_template.format(**{'params': params, 'bundle_id': bundle_id}))
 
     def base_test_success(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with(200, self.default_response)
         wait_for_scale_mock = MagicMock()
         stdout = MagicMock()
@@ -37,17 +39,20 @@ class ConductRunTestBase(CliTestCase):
         input_args = MagicMock(**self.default_args)
 
         with patch('requests.put', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock), \
                 patch('conductr_cli.bundle_scale.wait_for_scale', wait_for_scale_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_run.run(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, headers=self.mock_headers)
         wait_for_scale_mock.assert_called_with(self.bundle_id, self.scale, input_args)
 
         self.assertEqual(self.default_output(), self.output(stdout))
 
     def base_test_success_verbose(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with(200, self.default_response)
         wait_for_scale_mock = MagicMock()
         stdout = MagicMock()
@@ -57,17 +62,20 @@ class ConductRunTestBase(CliTestCase):
         input_args = MagicMock(**args)
 
         with patch('requests.put', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock), \
                 patch('conductr_cli.bundle_scale.wait_for_scale', wait_for_scale_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_run.run(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, headers=self.mock_headers)
         wait_for_scale_mock.assert_called_with(self.bundle_id, self.scale, input_args)
 
         self.assertEqual(self.default_response + self.default_output(), self.output(stdout))
 
     def base_test_success_long_ids(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with(200, self.default_response)
         wait_for_scale_mock = MagicMock()
         stdout = MagicMock()
@@ -77,17 +85,20 @@ class ConductRunTestBase(CliTestCase):
         input_args = MagicMock(**args)
 
         with patch('requests.put', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock), \
                 patch('conductr_cli.bundle_scale.wait_for_scale', wait_for_scale_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_run.run(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, headers=self.mock_headers)
         wait_for_scale_mock.assert_called_with(self.bundle_id, self.scale, input_args)
 
         self.assertEqual(self.default_output(bundle_id='45e0c477d3e5ea92aa8d85c0d8f3e25c'), self.output(stdout))
 
     def base_test_success_with_configuration(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with(200, self.default_response)
         wait_for_scale_mock = MagicMock()
         stdout = MagicMock()
@@ -98,12 +109,14 @@ class ConductRunTestBase(CliTestCase):
         input_args = MagicMock(**args)
 
         with patch('requests.put', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock), \
                 patch('conductr_cli.bundle_scale.wait_for_scale', wait_for_scale_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_run.run(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, headers=self.mock_headers)
         wait_for_scale_mock.assert_called_with(self.bundle_id, self.scale, input_args)
 
         self.assertEqual(
@@ -111,6 +124,7 @@ class ConductRunTestBase(CliTestCase):
             self.output(stdout))
 
     def base_test_success_no_wait(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
 
@@ -118,25 +132,31 @@ class ConductRunTestBase(CliTestCase):
         args.update({'no_wait': True})
         input_args = MagicMock(**args)
 
-        with patch('requests.put', http_method):
+        with patch('requests.put', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_run.run(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, headers=self.mock_headers)
 
         self.assertEqual(self.default_output(), self.output(stdout))
 
     def base_test_failure(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with(404)
         stderr = MagicMock()
 
-        with patch('requests.put', http_method):
-            logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
-            result = conduct_run.run(MagicMock(**self.default_args))
+        input_args = MagicMock(**self.default_args)
+        with patch('requests.put', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            logging_setup.configure_logging(input_args, err_output=stderr)
+            result = conduct_run.run(input_args)
             self.assertFalse(result)
 
-        http_method.assert_called_with(self.default_url)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, headers=self.mock_headers)
 
         self.assertEqual(
             as_error(strip_margin("""|Error: 404 Not Found
@@ -144,21 +164,26 @@ class ConductRunTestBase(CliTestCase):
             self.output(stderr))
 
     def base_test_failure_invalid_address(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.raise_connection_error('test reason', self.default_url)
         stderr = MagicMock()
 
-        with patch('requests.put', http_method):
-            logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
-            result = conduct_run.run(MagicMock(**self.default_args))
+        input_args = MagicMock(**self.default_args)
+        with patch('requests.put', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            logging_setup.configure_logging(input_args, err_output=stderr)
+            result = conduct_run.run(input_args)
             self.assertFalse(result)
 
-        http_method.assert_called_with(self.default_url)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, headers=self.mock_headers)
 
         self.assertEqual(
             self.default_connection_error.format(self.default_url),
             self.output(stderr))
 
     def base_test_failure_scale_timeout(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with(200, self.default_response)
         wait_for_scale_mock = MagicMock(side_effect=WaitTimeoutError('test wait timeout error'))
         stderr = MagicMock()
@@ -166,12 +191,14 @@ class ConductRunTestBase(CliTestCase):
         input_args = MagicMock(**self.default_args)
 
         with patch('requests.put', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock), \
                 patch('conductr_cli.bundle_scale.wait_for_scale', wait_for_scale_mock):
             logging_setup.configure_logging(input_args, err_output=stderr)
             result = conduct_run.run(input_args)
             self.assertFalse(result)
 
-        http_method.assert_called_with(self.default_url)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, headers=self.mock_headers)
         wait_for_scale_mock.assert_called_with(self.bundle_id, self.scale, input_args)
 
         self.assertEqual(

--- a/conductr_cli/test/test_bundle_installation.py
+++ b/conductr_cli/test/test_bundle_installation.py
@@ -15,7 +15,10 @@ def create_test_event(event_name):
 
 
 class TestCountInstallation(CliTestCase):
+    mock_headers = {'pretend': 'header'}
+
     def test_return_installation_count(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         bundles_endpoint_reply = """
             [{
                 "bundleId": "a101449418187d92c789d1adc240b6d6",
@@ -30,19 +33,23 @@ class TestCountInstallation(CliTestCase):
         """
         http_method = self.respond_with(text=bundles_endpoint_reply)
 
-        with patch('requests.get', http_method):
-            bundle_id = 'a101449418187d92c789d1adc240b6d6'
-            args = {
-                'ip': '127.0.0.1',
-                'port': '9005',
-                'api_version': '1'
-            }
-            result = bundle_installation.count_installations(bundle_id, MagicMock(**args))
+        bundle_id = 'a101449418187d92c789d1adc240b6d6'
+        args = {
+            'ip': '127.0.0.1',
+            'port': '9005',
+            'api_version': '1'
+        }
+        input_args = MagicMock(**args)
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            result = bundle_installation.count_installations(bundle_id, input_args)
             self.assertEqual(1, result)
 
-        http_method.assert_called_with('http://127.0.0.1:9005/bundles')
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with('http://127.0.0.1:9005/bundles', headers=self.mock_headers)
 
     def test_return_installation_count_v2(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         bundles_endpoint_reply = """
             [{
                 "bundleId": "a101449418187d92c789d1adc240b6d6",
@@ -57,49 +64,60 @@ class TestCountInstallation(CliTestCase):
         """
         http_method = self.respond_with(text=bundles_endpoint_reply)
 
-        with patch('requests.get', http_method):
-            bundle_id = 'a101449418187d92c789d1adc240b6d6'
-            args = {
-                'ip': '127.0.0.1',
-                'port': '9005',
-                'api_version': '2'
-            }
-            result = bundle_installation.count_installations(bundle_id, MagicMock(**args))
+        bundle_id = 'a101449418187d92c789d1adc240b6d6'
+        args = {
+            'ip': '127.0.0.1',
+            'port': '9005',
+            'api_version': '2'
+        }
+        input_args = MagicMock(**args)
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            result = bundle_installation.count_installations(bundle_id, input_args)
             self.assertEqual(1, result)
 
-        http_method.assert_called_with('http://127.0.0.1:9005/v2/bundles')
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with('http://127.0.0.1:9005/v2/bundles', headers=self.mock_headers)
 
     def test_return_zero_installation_count_v1(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         bundles_endpoint_reply = '[]'
         http_method = self.respond_with(text=bundles_endpoint_reply)
 
-        with patch('requests.get', http_method):
-            bundle_id = 'a101449418187d92c789d1adc240b6d6'
-            args = {
-                'ip': '127.0.0.1',
-                'port': '9005',
-                'api_version': '1'
-            }
-            result = bundle_installation.count_installations(bundle_id, MagicMock(**args))
+        bundle_id = 'a101449418187d92c789d1adc240b6d6'
+        args = {
+            'ip': '127.0.0.1',
+            'port': '9005',
+            'api_version': '1'
+        }
+        input_args = MagicMock(**args)
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            result = bundle_installation.count_installations(bundle_id, input_args)
             self.assertEqual(0, result)
 
-        http_method.assert_called_with('http://127.0.0.1:9005/bundles')
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with('http://127.0.0.1:9005/bundles', headers=self.mock_headers)
 
     def test_return_zero_installation_count_v2(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         bundles_endpoint_reply = '[]'
         http_method = self.respond_with(text=bundles_endpoint_reply)
 
-        with patch('requests.get', http_method):
-            bundle_id = 'a101449418187d92c789d1adc240b6d6'
-            args = {
-                'ip': '127.0.0.1',
-                'port': '9005',
-                'api_version': '2'
-            }
-            result = bundle_installation.count_installations(bundle_id, MagicMock(**args))
+        bundle_id = 'a101449418187d92c789d1adc240b6d6'
+        args = {
+            'ip': '127.0.0.1',
+            'port': '9005',
+            'api_version': '2'
+        }
+        input_args = MagicMock(**args)
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            result = bundle_installation.count_installations(bundle_id, input_args)
             self.assertEqual(0, result)
 
-        http_method.assert_called_with('http://127.0.0.1:9005/v2/bundles')
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with('http://127.0.0.1:9005/v2/bundles', headers=self.mock_headers)
 
 
 class TestWaitForInstallation(CliTestCase):

--- a/conductr_cli/test/test_bundle_scale.py
+++ b/conductr_cli/test/test_bundle_scale.py
@@ -9,7 +9,10 @@ except ImportError:
 
 
 class TestGetScale(CliTestCase):
+    mock_headers = {'pretend': 'header'}
+
     def test_return_scale_v1(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         bundles_endpoint_reply = """
             [{
                 "bundleId": "a101449418187d92c789d1adc240b6d6",
@@ -39,19 +42,23 @@ class TestGetScale(CliTestCase):
         """
         http_method = self.respond_with(text=bundles_endpoint_reply)
 
-        with patch('requests.get', http_method):
-            bundle_id = 'a101449418187d92c789d1adc240b6d6'
-            args = {
-                'ip': '127.0.0.1',
-                'port': '9005',
-                'api_version': '1'
-            }
-            result = bundle_scale.get_scale(bundle_id, MagicMock(**args))
+        bundle_id = 'a101449418187d92c789d1adc240b6d6'
+        args = {
+            'ip': '127.0.0.1',
+            'port': '9005',
+            'api_version': '1'
+        }
+        input_args = MagicMock(**args)
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            result = bundle_scale.get_scale(bundle_id, input_args)
             self.assertEqual(1, result)
 
-        http_method.assert_called_with('http://127.0.0.1:9005/bundles')
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with('http://127.0.0.1:9005/bundles', headers=self.mock_headers)
 
     def test_return_scale_v2(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         bundles_endpoint_reply = """
             [{
                 "bundleId": "a101449418187d92c789d1adc240b6d6",
@@ -81,49 +88,60 @@ class TestGetScale(CliTestCase):
         """
         http_method = self.respond_with(text=bundles_endpoint_reply)
 
-        with patch('requests.get', http_method):
-            bundle_id = 'a101449418187d92c789d1adc240b6d6'
-            args = {
-                'ip': '127.0.0.1',
-                'port': '9005',
-                'api_version': '2'
-            }
-            result = bundle_scale.get_scale(bundle_id, MagicMock(**args))
+        bundle_id = 'a101449418187d92c789d1adc240b6d6'
+        args = {
+            'ip': '127.0.0.1',
+            'port': '9005',
+            'api_version': '2'
+        }
+        input_args = MagicMock(**args)
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            result = bundle_scale.get_scale(bundle_id, input_args)
             self.assertEqual(1, result)
 
-        http_method.assert_called_with('http://127.0.0.1:9005/v2/bundles')
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with('http://127.0.0.1:9005/v2/bundles', headers=self.mock_headers)
 
     def test_return_zero_v1(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         bundles_endpoint_reply = '[]'
         http_method = self.respond_with(text=bundles_endpoint_reply)
 
-        with patch('requests.get', http_method):
-            bundle_id = 'a101449418187d92c789d1adc240b6d6'
-            args = {
-                'ip': '127.0.0.1',
-                'port': '9005',
-                'api_version': '1'
-            }
-            result = bundle_scale.get_scale(bundle_id, MagicMock(**args))
+        bundle_id = 'a101449418187d92c789d1adc240b6d6'
+        args = {
+            'ip': '127.0.0.1',
+            'port': '9005',
+            'api_version': '1'
+        }
+        input_args = MagicMock(**args)
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            result = bundle_scale.get_scale(bundle_id, input_args)
             self.assertEqual(0, result)
 
-        http_method.assert_called_with('http://127.0.0.1:9005/bundles')
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with('http://127.0.0.1:9005/bundles', headers=self.mock_headers)
 
     def test_return_zero_v2(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         bundles_endpoint_reply = '[]'
         http_method = self.respond_with(text=bundles_endpoint_reply)
 
-        with patch('requests.get', http_method):
-            bundle_id = 'a101449418187d92c789d1adc240b6d6'
-            args = {
-                'ip': '127.0.0.1',
-                'port': '9005',
-                'api_version': '2'
-            }
-            result = bundle_scale.get_scale(bundle_id, MagicMock(**args))
+        bundle_id = 'a101449418187d92c789d1adc240b6d6'
+        args = {
+            'ip': '127.0.0.1',
+            'port': '9005',
+            'api_version': '2'
+        }
+        input_args = MagicMock(**args)
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            result = bundle_scale.get_scale(bundle_id, input_args)
             self.assertEqual(0, result)
 
-        http_method.assert_called_with('http://127.0.0.1:9005/v2/bundles')
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with('http://127.0.0.1:9005/v2/bundles', headers=self.mock_headers)
 
 
 class TestWaitForScale(CliTestCase):

--- a/conductr_cli/test/test_conduct_acls.py
+++ b/conductr_cli/test/test_conduct_acls.py
@@ -19,17 +19,22 @@ class TestConductAclsCommandForHttp(CliTestCase):
     }
 
     default_url = 'http://127.0.0.1:9005/bundles'
+    mock_headers = {'pretend': 'header'}
 
     def test_display(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with_file_contents('data/bundle_with_acls/one_bundle_http.json')
         stdout = MagicMock()
 
-        with patch('requests.get', http_method):
-            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            result = conduct_acls.acls(MagicMock(**self.default_args))
+        input_args = MagicMock(**self.default_args)
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_acls.acls(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         self.assertEqual(
             strip_margin(
                 """|METHOD  PATH  REWRITE  SYSTEM                       SYSTEM VERSION  ENDPOINT NAME  BUNDLE ID  BUNDLE NAME                  STATUS
@@ -38,18 +43,22 @@ class TestConductAclsCommandForHttp(CliTestCase):
             self.output(stdout))
 
     def test_display_with_long_id(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with_file_contents('data/bundle_with_acls/one_bundle_http.json')
         stdout = MagicMock()
 
         args = self.default_args.copy()
         args.update({'long_ids': True})
 
-        with patch('requests.get', http_method):
-            logging_setup.configure_logging(MagicMock(**args), stdout)
-            result = conduct_acls.acls(MagicMock(**args))
+        input_args = MagicMock(**args)
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_acls.acls(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         self.assertEqual(
             strip_margin(
                 """|METHOD  PATH  REWRITE  SYSTEM                       SYSTEM VERSION  ENDPOINT NAME  BUNDLE ID                         BUNDLE NAME                  STATUS
@@ -58,15 +67,19 @@ class TestConductAclsCommandForHttp(CliTestCase):
             self.output(stdout))
 
     def test_multiple_acls_sorted(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with_file_contents('data/bundle_with_acls/multiple_bundles_http.json')
         stdout = MagicMock()
 
-        with patch('requests.get', http_method):
-            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            result = conduct_acls.acls(MagicMock(**self.default_args))
+        input_args = MagicMock(**self.default_args)
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_acls.acls(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         self.assertEqual(
             strip_margin(
                 """|METHOD  PATH                  REWRITE          SYSTEM                       SYSTEM VERSION  ENDPOINT NAME  BUNDLE ID  BUNDLE NAME                  STATUS
@@ -78,15 +91,19 @@ class TestConductAclsCommandForHttp(CliTestCase):
             self.output(stdout))
 
     def test_no_bundles(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with(200, '[]')
         stdout = MagicMock()
 
-        with patch('requests.get', http_method):
-            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            result = conduct_acls.acls(MagicMock(**self.default_args))
+        input_args = MagicMock(**self.default_args)
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_acls.acls(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         self.assertEqual(
             strip_margin(
                 """|METHOD  PATH  REWRITE  SYSTEM  SYSTEM VERSION  ENDPOINT NAME  BUNDLE ID  BUNDLE NAME  STATUS
@@ -94,15 +111,19 @@ class TestConductAclsCommandForHttp(CliTestCase):
             self.output(stdout))
 
     def test_no_acls(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with_file_contents('data/bundle_with_services/one_bundle_starting.json')
         stdout = MagicMock()
 
-        with patch('requests.get', http_method):
-            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            result = conduct_acls.acls(MagicMock(**self.default_args))
+        input_args = MagicMock(**self.default_args)
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_acls.acls(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         self.assertEqual(
             strip_margin(
                 """|METHOD  PATH  REWRITE  SYSTEM  SYSTEM VERSION  ENDPOINT NAME  BUNDLE ID  BUNDLE NAME  STATUS
@@ -110,15 +131,19 @@ class TestConductAclsCommandForHttp(CliTestCase):
             self.output(stdout))
 
     def test_duplicate_endpoints(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with_file_contents('data/bundle_with_acls/duplicate_endpoints_http.json')
         stdout = MagicMock()
 
-        with patch('requests.get', http_method):
-            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            result = conduct_acls.acls(MagicMock(**self.default_args))
+        input_args = MagicMock(**self.default_args)
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_acls.acls(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         self.assertEqual(
             as_warn(strip_margin(
                     """|METHOD  PATH         REWRITE  SYSTEM      SYSTEM VERSION  ENDPOINT NAME  BUNDLE ID  BUNDLE NAME   STATUS
@@ -144,16 +169,22 @@ class TestConductAclsCommandForTcp(CliTestCase):
 
     default_url = 'http://127.0.0.1:9005/bundles'
 
+    mock_headers = {'pretend': 'header'}
+
     def test_display(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with_file_contents('data/bundle_with_acls/one_bundle_tcp.json')
         stdout = MagicMock()
 
-        with patch('requests.get', http_method):
-            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            result = conduct_acls.acls(MagicMock(**self.default_args))
+        input_args = MagicMock(**self.default_args)
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_acls.acls(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         self.assertEqual(
             strip_margin(
                 """|TCP/PORT  SYSTEM                       SYSTEM VERSION  ENDPOINT NAME  BUNDLE ID  BUNDLE NAME                  STATUS
@@ -162,18 +193,23 @@ class TestConductAclsCommandForTcp(CliTestCase):
             self.output(stdout))
 
     def test_display_with_long_id(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with_file_contents('data/bundle_with_acls/one_bundle_tcp.json')
         stdout = MagicMock()
 
         args = self.default_args.copy()
         args.update({'long_ids': True})
 
-        with patch('requests.get', http_method):
-            logging_setup.configure_logging(MagicMock(**args), stdout)
-            result = conduct_acls.acls(MagicMock(**args))
+        input_args = MagicMock(**args)
+
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_acls.acls(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         self.assertEqual(
             strip_margin(
                 """|TCP/PORT  SYSTEM                       SYSTEM VERSION  ENDPOINT NAME  BUNDLE ID                         BUNDLE NAME                  STATUS
@@ -182,15 +218,20 @@ class TestConductAclsCommandForTcp(CliTestCase):
             self.output(stdout))
 
     def test_multiple_acls_sorted(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with_file_contents('data/bundle_with_acls/multiple_bundles_tcp.json')
         stdout = MagicMock()
 
-        with patch('requests.get', http_method):
-            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            result = conduct_acls.acls(MagicMock(**self.default_args))
+        input_args = MagicMock(**self.default_args)
+
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_acls.acls(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         self.assertEqual(
             strip_margin(
                 """|TCP/PORT  SYSTEM              SYSTEM VERSION  ENDPOINT NAME  BUNDLE ID  BUNDLE NAME         STATUS
@@ -201,15 +242,19 @@ class TestConductAclsCommandForTcp(CliTestCase):
             self.output(stdout))
 
     def test_no_bundles(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with(200, '[]')
         stdout = MagicMock()
 
-        with patch('requests.get', http_method):
-            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            result = conduct_acls.acls(MagicMock(**self.default_args))
+        input_args = MagicMock(**self.default_args)
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_acls.acls(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         self.assertEqual(
             strip_margin(
                 """|TCP/PORT  SYSTEM  SYSTEM VERSION  ENDPOINT NAME  BUNDLE ID  BUNDLE NAME  STATUS
@@ -217,15 +262,19 @@ class TestConductAclsCommandForTcp(CliTestCase):
             self.output(stdout))
 
     def test_no_acls(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with_file_contents('data/bundle_with_services/one_bundle_starting.json')
         stdout = MagicMock()
 
-        with patch('requests.get', http_method):
-            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            result = conduct_acls.acls(MagicMock(**self.default_args))
+        input_args = MagicMock(**self.default_args)
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_acls.acls(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         self.assertEqual(
             strip_margin(
                 """|TCP/PORT  SYSTEM  SYSTEM VERSION  ENDPOINT NAME  BUNDLE ID  BUNDLE NAME  STATUS
@@ -233,15 +282,19 @@ class TestConductAclsCommandForTcp(CliTestCase):
             self.output(stdout))
 
     def test_duplicate_endpoints(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with_file_contents('data/bundle_with_acls/duplicate_endpoints_tcp.json')
         stdout = MagicMock()
 
-        with patch('requests.get', http_method):
-            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            result = conduct_acls.acls(MagicMock(**self.default_args))
+        input_args = MagicMock(**self.default_args)
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_acls.acls(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         self.maxDiff = None
         self.assertEqual(
             as_warn(strip_margin(

--- a/conductr_cli/test/test_conduct_events.py
+++ b/conductr_cli/test/test_conduct_events.py
@@ -27,24 +27,31 @@ class TestConductEventsCommand(CliTestCase):
 
     default_url = 'http://127.0.0.1:9005/bundles/{}/events?count=1'.format(bundle_id_urlencoded)
 
+    mock_headers = {'pretend': 'header'}
+
     def test_no_events(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with(text='{}')
         quote_method = MagicMock(return_value=self.bundle_id_urlencoded)
         stdout = MagicMock()
 
+        input_args = MagicMock(**self.default_args)
         with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock), \
                 patch('urllib.parse.quote', quote_method):
-            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            result = conduct_events.events(MagicMock(**self.default_args))
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_events.events(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         self.assertEqual(
             strip_margin("""|TIME  EVENT  DESC
                             |"""),
             self.output(stdout))
 
     def test_multiple_events(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with(text="""[
             {
                 "timestamp":"2015-08-24T01:16:22.327Z",
@@ -60,13 +67,16 @@ class TestConductEventsCommand(CliTestCase):
         quote_method = MagicMock(return_value=self.bundle_id_urlencoded)
         stdout = MagicMock()
 
+        input_args = MagicMock(**self.default_args)
         with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock), \
                 patch('urllib.parse.quote', quote_method):
-            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            result = conduct_events.events(MagicMock(**self.default_args))
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_events.events(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         self.assertEqual(
             strip_margin("""|TIME                  EVENT                                       DESC
                             |2015-08-24T01:16:22Z  conductr.loadScheduler.loadBundleRequested  Load bundle requested: requestId=cba938cd-860e-41a4-9cbe-2c677feaca20, bundleName=visualizer
@@ -75,17 +85,21 @@ class TestConductEventsCommand(CliTestCase):
             self.output(stdout))
 
     def test_failure_invalid_address(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.raise_connection_error('test reason', self.default_url)
         quote_method = MagicMock(return_value=self.bundle_id_urlencoded)
         stderr = MagicMock()
 
+        input_args = MagicMock(**self.default_args)
         with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock), \
                 patch('urllib.parse.quote', quote_method):
-            logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
-            result = conduct_events.events(MagicMock(**self.default_args))
+            logging_setup.configure_logging(input_args, err_output=stderr)
+            result = conduct_events.events(input_args)
             self.assertFalse(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         self.assertEqual(
             self.default_connection_error.format(self.default_url),
             self.output(stderr))

--- a/conductr_cli/test/test_conduct_info.py
+++ b/conductr_cli/test/test_conduct_info.py
@@ -22,22 +22,29 @@ class TestConductInfoCommand(CliTestCase):
 
     default_url = 'http://127.0.0.1:9005/bundles'
 
+    mock_headers = {'pretend': 'header'}
+
     def test_no_bundles(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with(text='[]')
         stdout = MagicMock()
 
-        with patch('requests.get', http_method):
-            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            result = conduct_info.info(MagicMock(**self.default_args))
+        input_args = MagicMock(**self.default_args)
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_info.info(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         self.assertEqual(
             strip_margin("""|ID  NAME  #REP  #STR  #RUN
                             |"""),
             self.output(stdout))
 
     def test_stopped_bundle(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with(text="""[
             {
                 "attributes": { "bundleName": "test-bundle" },
@@ -48,12 +55,15 @@ class TestConductInfoCommand(CliTestCase):
         ]""")
         stdout = MagicMock()
 
-        with patch('requests.get', http_method):
-            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            result = conduct_info.info(MagicMock(**self.default_args))
+        input_args = MagicMock(**self.default_args)
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_info.info(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         self.assertEqual(
             strip_margin("""|ID       NAME         #REP  #STR  #RUN
                             |45e0c47  test-bundle     1     0     0
@@ -61,6 +71,7 @@ class TestConductInfoCommand(CliTestCase):
             self.output(stdout))
 
     def test_one_running_one_starting_one_stopped(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with(text="""[
             {
                 "attributes": { "bundleName": "test-bundle-1" },
@@ -83,12 +94,15 @@ class TestConductInfoCommand(CliTestCase):
         ]""")
         stdout = MagicMock()
 
-        with patch('requests.get', http_method):
-            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            result = conduct_info.info(MagicMock(**self.default_args))
+        input_args = MagicMock(**self.default_args)
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_info.info(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         self.assertEqual(
             strip_margin("""|ID               NAME           #REP  #STR  #RUN
                             |45e0c47          test-bundle-1     1     0     1
@@ -98,6 +112,7 @@ class TestConductInfoCommand(CliTestCase):
             self.output(stdout))
 
     def test_one_running_one_stopped_verbose(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with(text="""[
             {
                 "attributes": { "bundleName": "test-bundle-1" },
@@ -114,14 +129,18 @@ class TestConductInfoCommand(CliTestCase):
         ]""")
         stdout = MagicMock()
 
-        with patch('requests.get', http_method):
-            args = self.default_args.copy()
-            args.update({'verbose': True})
-            logging_setup.configure_logging(MagicMock(**args), stdout)
-            result = conduct_info.info(MagicMock(**args))
+        args = self.default_args.copy()
+        args.update({'verbose': True})
+        input_args = MagicMock(**args)
+
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_info.info(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         self.assertEqual(
             strip_margin("""|[
                             |  {
@@ -166,6 +185,7 @@ class TestConductInfoCommand(CliTestCase):
             self.output(stdout))
 
     def test_long_ids(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with(text="""[
             {
                 "attributes": { "bundleName": "test-bundle" },
@@ -176,14 +196,17 @@ class TestConductInfoCommand(CliTestCase):
         ]""")
         stdout = MagicMock()
 
-        with patch('requests.get', http_method):
-            args = self.default_args.copy()
-            args.update({'long_ids': True})
-            logging_setup.configure_logging(MagicMock(**args), stdout)
-            result = conduct_info.info(MagicMock(**args))
+        args = self.default_args.copy()
+        args.update({'long_ids': True})
+        input_args = MagicMock(**args)
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_info.info(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         self.assertEqual(
             strip_margin("""|ID                                NAME         #REP  #STR  #RUN
                             |45e0c477d3e5ea92aa8d85c0d8f3e25c  test-bundle     1     0     0
@@ -191,6 +214,7 @@ class TestConductInfoCommand(CliTestCase):
             self.output(stdout))
 
     def test_double_digits(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with(text="""[
             {
                 "attributes": { "bundleName": "test-bundle" },
@@ -201,12 +225,15 @@ class TestConductInfoCommand(CliTestCase):
         ]""")
         stdout = MagicMock()
 
-        with patch('requests.get', http_method):
-            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            result = conduct_info.info(MagicMock(**self.default_args))
+        input_args = MagicMock(**self.default_args)
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_info.info(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         self.assertEqual(
             strip_margin("""|ID       NAME         #REP  #STR  #RUN
                             |45e0c47  test-bundle    10     0     0
@@ -214,6 +241,7 @@ class TestConductInfoCommand(CliTestCase):
             self.output(stdout))
 
     def test_has_error(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with(text="""[
             {
                 "attributes": { "bundleName": "test-bundle" },
@@ -225,12 +253,15 @@ class TestConductInfoCommand(CliTestCase):
         ]""")
         stdout = MagicMock()
 
-        with patch('requests.get', http_method):
-            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            result = conduct_info.info(MagicMock(**self.default_args))
+        input_args = MagicMock(**self.default_args)
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_info.info(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         self.assertEqual(
             strip_margin("""|ID         NAME         #REP  #STR  #RUN
                             |! 45e0c47  test-bundle    10     0     0
@@ -239,15 +270,19 @@ class TestConductInfoCommand(CliTestCase):
             self.output(stdout))
 
     def test_failure_invalid_address(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.raise_connection_error('test reason', self.default_url)
         stderr = MagicMock()
 
-        with patch('requests.get', http_method):
-            logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
-            result = conduct_info.info(MagicMock(**self.default_args))
+        input_args = MagicMock(**self.default_args)
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            logging_setup.configure_logging(input_args, err_output=stderr)
+            result = conduct_info.info(input_args)
             self.assertFalse(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         self.assertEqual(
             self.default_connection_error.format(self.default_url),
             self.output(stderr))

--- a/conductr_cli/test/test_conduct_load_v2.py
+++ b/conductr_cli/test/test_conduct_load_v2.py
@@ -102,6 +102,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
             'config.sh': 'echo configuring'
         })
 
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         resolve_bundle_mock = MagicMock(side_effect=[(self.bundle_name, self.bundle_file), ('config.zip', config_file)])
         zip_entry_mock = MagicMock(side_effect=['mock bundle.conf', 'mock bundle.conf overlay'])
         http_method = self.respond_with(200, self.default_response)
@@ -115,6 +116,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.bundle_utils.zip_entry', zip_entry_mock), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
@@ -135,13 +137,15 @@ class TestConductLoadCommand(ConductLoadTestBase):
             [call(self.bundle_file, 'rb'), call(config_file, 'rb')]
         )
 
+        request_headers_mock.assert_called_with(input_args)
         expected_files = [
             ('bundleConf', ('bundle.conf', 'mock bundle.conf')),
             ('bundleConfOverlay', ('bundle.conf', 'mock bundle.conf overlay')),
             ('bundle', ('bundle.zip', 1)),
             ('configuration', ('config.zip', 1))
         ]
-        http_method.assert_called_with(self.default_url, files=expected_files, timeout=LOAD_HTTP_TIMEOUT)
+        http_method.assert_called_with(self.default_url, files=expected_files, timeout=LOAD_HTTP_TIMEOUT,
+                                       headers=self.mock_headers)
 
         wait_for_installation_mock.assert_called_with(self.bundle_id, input_args)
 
@@ -158,6 +162,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
             'config.sh': 'echo configuring'
         })
 
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         resolve_bundle_mock = MagicMock(side_effect=[(self.bundle_name, self.bundle_file), ('config.zip', config_file)])
         zip_entry_mock = MagicMock(side_effect=['mock bundle.conf', None])
         http_method = self.respond_with(200, self.default_response)
@@ -171,6 +176,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.bundle_utils.zip_entry', zip_entry_mock), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
@@ -191,12 +197,14 @@ class TestConductLoadCommand(ConductLoadTestBase):
             [call(self.bundle_file, 'rb'), call(config_file, 'rb')]
         )
 
+        request_headers_mock.assert_called_with(input_args)
         expected_files = [
             ('bundleConf', ('bundle.conf', 'mock bundle.conf')),
             ('bundle', ('bundle.zip', 1)),
             ('configuration', ('config.zip', 1))
         ]
-        http_method.assert_called_with(self.default_url, files=expected_files, timeout=LOAD_HTTP_TIMEOUT)
+        http_method.assert_called_with(self.default_url, files=expected_files, timeout=LOAD_HTTP_TIMEOUT,
+                                       headers=self.mock_headers)
 
         wait_for_installation_mock.assert_called_with(self.bundle_id, input_args)
 

--- a/conductr_cli/test/test_conduct_logs.py
+++ b/conductr_cli/test/test_conduct_logs.py
@@ -27,24 +27,31 @@ class TestConductLogsCommand(CliTestCase):
 
     default_url = 'http://127.0.0.1:9005/bundles/{}/logs?count=1'.format(bundle_id_urlencoded)
 
+    mock_headers = {'pretend': 'header'}
+
     def test_no_logs(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with(text='{}')
         quote_method = MagicMock(return_value=self.bundle_id_urlencoded)
         stdout = MagicMock()
 
+        input_args = MagicMock(**self.default_args)
         with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock), \
                 patch('urllib.parse.quote', quote_method):
-            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            result = conduct_logs.logs(MagicMock(**self.default_args))
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_logs.logs(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         self.assertEqual(
             strip_margin("""|TIME  HOST  LOG
                             |"""),
             self.output(stdout))
 
     def test_multiple_events(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with(text="""[
             {
                 "timestamp":"2015-08-24T01:16:22.327Z",
@@ -60,13 +67,16 @@ class TestConductLogsCommand(CliTestCase):
         quote_method = MagicMock(return_value=self.bundle_id_urlencoded)
         stdout = MagicMock()
 
+        input_args = MagicMock(**self.default_args)
         with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock), \
                 patch('urllib.parse.quote', quote_method):
-            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            result = conduct_logs.logs(MagicMock(**self.default_args))
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_logs.logs(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         self.assertEqual(
             strip_margin("""|TIME                  HOST        LOG
                             |2015-08-24T01:16:22Z  10.0.1.232  [WARN] [04/21/2015 12:54:30.079] [doc-renderer-cluster-1-akka.remote.default-remote-dispatcher-22] Association with remote system has failed.
@@ -75,17 +85,21 @@ class TestConductLogsCommand(CliTestCase):
             self.output(stdout))
 
     def test_failure_invalid_address(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.raise_connection_error('test reason', self.default_url)
         quote_method = MagicMock(return_value=self.bundle_id_urlencoded)
         stderr = MagicMock()
 
+        input_args = MagicMock(**self.default_args)
         with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock), \
                 patch('urllib.parse.quote', quote_method):
-            logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
-            result = conduct_logs.logs(MagicMock(**self.default_args))
+            logging_setup.configure_logging(input_args, err_output=stderr)
+            result = conduct_logs.logs(input_args)
             self.assertFalse(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         self.assertEqual(
             self.default_connection_error.format(self.default_url),
             self.output(stderr))

--- a/conductr_cli/test/test_conduct_run_v2.py
+++ b/conductr_cli/test/test_conduct_run_v2.py
@@ -77,18 +77,21 @@ class TestConductRunCommand(ConductRunTestBase):
         expected_url = \
             'http://127.0.0.1:9005/v2/bundles/45e0c477d3e5ea92aa8d85c0d8f3e25c?scale=3&affinity=other-bundle'
 
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with(200, self.default_response)
         wait_for_scale_mock = MagicMock()
         stdout = MagicMock()
 
         input_args = MagicMock(**args)
         with patch('requests.put', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock), \
                 patch('conductr_cli.bundle_scale.wait_for_scale', wait_for_scale_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_run.run(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(expected_url)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(expected_url, headers=self.mock_headers)
         wait_for_scale_mock.assert_called_with(self.bundle_id, self.scale, input_args)
 
         self.assertEqual(self.default_output(), self.output(stdout))

--- a/conductr_cli/test/test_conduct_services.py
+++ b/conductr_cli/test/test_conduct_services.py
@@ -21,31 +21,41 @@ class TestConductServicesCommand(CliTestCase):
 
     default_url = 'http://127.0.0.1:9005/bundles'
 
+    mock_headers = {'pretend': 'header'}
+
     def test_no_bundles(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with(200, '[]')
         stdout = MagicMock()
 
-        with patch('requests.get', http_method):
-            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            result = conduct_services.services(MagicMock(**self.default_args))
+        input_args = MagicMock(**self.default_args)
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_services.services(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         self.assertEqual(
             strip_margin("""|SERVICE  BUNDLE ID  BUNDLE NAME  STATUS
                             |"""),
             self.output(stdout))
 
     def test_two_bundles_mult_components_endpoints(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with_file_contents('data/bundle_with_services/two_bundles.json')
         stdout = MagicMock()
 
-        with patch('requests.get', http_method):
-            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            result = conduct_services.services(MagicMock(**self.default_args))
+        input_args = MagicMock(**self.default_args)
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_services.services(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         self.assertEqual(
             as_warn(strip_margin("""|SERVICE                   BUNDLE ID  BUNDLE NAME                   STATUS
                                     |http://:6011/comp2-endp2  6e4560e    multi2-comp-multi-endp-1.0.0  Running
@@ -63,15 +73,19 @@ class TestConductServicesCommand(CliTestCase):
             self.output(stdout))
 
     def test_two_bundles_mult_components_endpoints_no_path(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with_file_contents('data/bundle_with_services/two_bundles_no_path.json')
         stdout = MagicMock()
 
-        with patch('requests.get', http_method):
-            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            result = conduct_services.services(MagicMock(**self.default_args))
+        input_args = MagicMock(**self.default_args)
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_services.services(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         self.assertEqual(
             strip_margin("""|SERVICE                   BUNDLE ID  BUNDLE NAME                   STATUS
                             |http://:6011              6e4560e    multi2-comp-multi-endp-1.0.0  Running
@@ -86,15 +100,19 @@ class TestConductServicesCommand(CliTestCase):
             self.output(stdout))
 
     def test_one_bundle_starting(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with_file_contents('data/bundle_with_services/one_bundle_starting.json')
         stdout = MagicMock()
 
-        with patch('requests.get', http_method):
-            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            result = conduct_services.services(MagicMock(**self.default_args))
+        input_args = MagicMock(**self.default_args)
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_services.services(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         self.assertEqual(
             strip_margin("""|SERVICE                   BUNDLE ID  BUNDLE NAME                  STATUS
                             |http://:8010/comp1-endp1  f804d64    multi-comp-multi-endp-1.0.0  Starting
@@ -106,17 +124,21 @@ class TestConductServicesCommand(CliTestCase):
             self.output(stdout))
 
     def test_one_bundle_starting_long_ids(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with_file_contents('data/bundle_with_services/one_bundle_starting.json')
         stdout = MagicMock()
 
-        with patch('requests.get', http_method):
-            args = self.default_args.copy()
-            args.update({'long_ids': True})
-            logging_setup.configure_logging(MagicMock(**args), stdout)
-            result = conduct_services.services(MagicMock(**args))
+        args = self.default_args.copy()
+        args.update({'long_ids': True})
+        input_args = MagicMock(**args)
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_services.services(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         self.assertEqual(
             strip_margin(
                 """|SERVICE                   BUNDLE ID                         BUNDLE NAME                  STATUS
@@ -129,17 +151,21 @@ class TestConductServicesCommand(CliTestCase):
             self.output(stdout))
 
     def test_one_bundle_no_services(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with_file_contents('data/bundle_with_acls/one_bundle_tcp.json')
         stdout = MagicMock()
 
-        with patch('requests.get', http_method):
-            args = self.default_args.copy()
-            args.update({'long_ids': True})
-            logging_setup.configure_logging(MagicMock(**args), stdout)
-            result = conduct_services.services(MagicMock(**args))
+        args = self.default_args.copy()
+        args.update({'long_ids': True})
+        input_args = MagicMock(**args)
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_services.services(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         self.assertEqual(
             strip_margin("""|SERVICE  BUNDLE ID  BUNDLE NAME  STATUS
                         |"""),

--- a/conductr_cli/test/test_conduct_stop.py
+++ b/conductr_cli/test/test_conduct_stop.py
@@ -40,27 +40,33 @@ class TestConductStopCommand(CliTestCase):
                          |Print ConductR info with: conduct info{params}
                          |"""
 
+    mock_headers = {'pretend': 'header'}
+
     def default_output(self, params='', bundle_id='45e0c47'):
         return strip_margin(self.output_template.format(**{'params': params, 'bundle_id': bundle_id}))
 
     def test_success(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with(200, self.default_response)
         wait_for_scale_mock = MagicMock()
         stdout = MagicMock()
 
         input_args = MagicMock(**self.default_args)
         with patch('requests.put', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock), \
                 patch('conductr_cli.bundle_scale.wait_for_scale', wait_for_scale_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_stop.stop(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         wait_for_scale_mock.assert_called_with(self.bundle_id, 0, input_args)
 
         self.assertEqual(self.default_output(), self.output(stdout))
 
     def test_success_verbose(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with(200, self.default_response)
         wait_for_scale_mock = MagicMock()
         stdout = MagicMock()
@@ -69,17 +75,20 @@ class TestConductStopCommand(CliTestCase):
         args.update({'verbose': True})
         input_args = MagicMock(**args)
         with patch('requests.put', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock), \
                 patch('conductr_cli.bundle_scale.wait_for_scale', wait_for_scale_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_stop.stop(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         wait_for_scale_mock.assert_called_with(self.bundle_id, 0, input_args)
 
         self.assertEqual(self.default_response + self.default_output(), self.output(stdout))
 
     def test_success_long_ids(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with(200, self.default_response)
         wait_for_scale_mock = MagicMock()
         stdout = MagicMock()
@@ -88,17 +97,20 @@ class TestConductStopCommand(CliTestCase):
         args.update({'long_ids': True})
         input_args = MagicMock(**args)
         with patch('requests.put', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock), \
                 patch('conductr_cli.bundle_scale.wait_for_scale', wait_for_scale_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_stop.stop(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         wait_for_scale_mock.assert_called_with(self.bundle_id, 0, input_args)
 
         self.assertEqual(self.default_output(bundle_id='45e0c477d3e5ea92aa8d85c0d8f3e25c'), self.output(stdout))
 
     def test_success_with_configuration(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with(200, self.default_response)
         wait_for_scale_mock = MagicMock()
         stdout = MagicMock()
@@ -109,12 +121,14 @@ class TestConductStopCommand(CliTestCase):
         input_args = MagicMock(**args)
 
         with patch('requests.put', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock), \
                 patch('conductr_cli.bundle_scale.wait_for_scale', wait_for_scale_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_stop.stop(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         wait_for_scale_mock.assert_called_with(self.bundle_id, 0, input_args)
 
         self.assertEqual(
@@ -122,15 +136,19 @@ class TestConductStopCommand(CliTestCase):
             self.output(stdout))
 
     def test_failure(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with(404)
         stderr = MagicMock()
 
-        with patch('requests.put', http_method):
-            logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
-            result = conduct_stop.stop(MagicMock(**self.default_args))
+        input_args = MagicMock(**self.default_args)
+        with patch('requests.put', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            logging_setup.configure_logging(input_args, err_output=stderr)
+            result = conduct_stop.stop(input_args)
             self.assertFalse(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
 
         self.assertEqual(
             as_error(strip_margin("""|Error: 404 Not Found
@@ -138,33 +156,40 @@ class TestConductStopCommand(CliTestCase):
             self.output(stderr))
 
     def test_failure_invalid_address(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.raise_connection_error('test reason', self.default_url)
         stderr = MagicMock()
 
-        with patch('requests.put', http_method):
-            logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
-            result = conduct_stop.stop(MagicMock(**self.default_args))
+        input_args = MagicMock(**self.default_args)
+        with patch('requests.put', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            logging_setup.configure_logging(input_args, err_output=stderr)
+            result = conduct_stop.stop(input_args)
             self.assertFalse(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
 
         self.assertEqual(
             self.default_connection_error.format(self.default_url),
             self.output(stderr))
 
     def test_failure_stop_timeout(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with(200, self.default_response)
         wait_for_scale_mock = MagicMock(side_effect=WaitTimeoutError('test timeout error'))
         stderr = MagicMock()
 
         input_args = MagicMock(**self.default_args)
         with patch('requests.put', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock), \
                 patch('conductr_cli.bundle_scale.wait_for_scale', wait_for_scale_mock):
             logging_setup.configure_logging(input_args, err_output=stderr)
             result = conduct_stop.stop(input_args)
             self.assertFalse(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         wait_for_scale_mock.assert_called_with(self.bundle_id, 0, input_args)
 
         self.assertEqual(

--- a/conductr_cli/test/test_conduct_unload.py
+++ b/conductr_cli/test/test_conduct_unload.py
@@ -34,27 +34,33 @@ class TestConductUnloadCommand(CliTestCase):
                          |Print ConductR info with: conduct info{params}
                          |"""
 
+    mock_headers = {'pretend': 'header'}
+
     def default_output(self, params=''):
         return strip_margin(self.output_template.format(**{'params': params}))
 
     def test_success(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         wait_for_uninstallation_mock = MagicMock()
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
 
         input_args = MagicMock(**self.default_args)
         with patch('requests.delete', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_uninstallation', wait_for_uninstallation_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_unload.unload(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         wait_for_uninstallation_mock.assert_called_with('45e0c477d3e5ea92aa8d85c0d8f3e25c', input_args)
 
         self.assertEqual(self.default_output(), self.output(stdout))
 
     def test_success_verbose(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         wait_for_uninstallation_mock = MagicMock()
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
@@ -64,17 +70,20 @@ class TestConductUnloadCommand(CliTestCase):
         input_args = MagicMock(**args)
 
         with patch('requests.delete', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_uninstallation', wait_for_uninstallation_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_unload.unload(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         wait_for_uninstallation_mock.assert_called_with('45e0c477d3e5ea92aa8d85c0d8f3e25c', input_args)
 
         self.assertEqual(self.default_response + self.default_output(), self.output(stdout))
 
     def test_success_quiet(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         wait_for_uninstallation_mock = MagicMock()
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
@@ -84,17 +93,20 @@ class TestConductUnloadCommand(CliTestCase):
         input_args = MagicMock(**args)
 
         with patch('requests.delete', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_uninstallation', wait_for_uninstallation_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_unload.unload(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         wait_for_uninstallation_mock.assert_called_with('45e0c477d3e5ea92aa8d85c0d8f3e25c', input_args)
 
         self.assertEqual('45e0c477d3e5ea92aa8d85c0d8f3e25c\n', self.output(stdout))
 
     def test_success_with_configuration(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         wait_for_uninstallation_mock = MagicMock()
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
@@ -105,12 +117,14 @@ class TestConductUnloadCommand(CliTestCase):
         input_args = MagicMock(**args)
 
         with patch('requests.delete', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_uninstallation', wait_for_uninstallation_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_unload.unload(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
         wait_for_uninstallation_mock.assert_called_with('45e0c477d3e5ea92aa8d85c0d8f3e25c', input_args)
 
         self.assertEqual(
@@ -118,31 +132,38 @@ class TestConductUnloadCommand(CliTestCase):
             self.output(stdout))
 
     def test_success_no_wait(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
 
         args = self.default_args.copy()
         args.update({'no_wait': True})
         input_args = MagicMock(**args)
-        with patch('requests.delete', http_method):
+        with patch('requests.delete', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_unload.unload(input_args)
             self.assertTrue(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
 
         self.assertEqual(self.default_output(), self.output(stdout))
 
     def test_failure(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.respond_with(404)
         stderr = MagicMock()
 
-        with patch('requests.delete', http_method):
-            logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
-            result = conduct_unload.unload(MagicMock(**self.default_args))
+        input_args = MagicMock(**self.default_args)
+        with patch('requests.delete', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            logging_setup.configure_logging(input_args, err_output=stderr)
+            result = conduct_unload.unload(input_args)
             self.assertFalse(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
 
         self.assertEqual(
             as_error(strip_margin("""|Error: 404 Not Found
@@ -150,15 +171,19 @@ class TestConductUnloadCommand(CliTestCase):
             self.output(stderr))
 
     def test_failure_invalid_address(self):
+        request_headers_mock = MagicMock(return_value=self.mock_headers)
         http_method = self.raise_connection_error('test reason', self.default_url)
         stderr = MagicMock()
 
-        with patch('requests.delete', http_method):
-            logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
-            result = conduct_unload.unload(MagicMock(**self.default_args))
+        input_args = MagicMock(**self.default_args)
+        with patch('requests.delete', http_method), \
+                patch('conductr_cli.conduct_url.request_headers', request_headers_mock):
+            logging_setup.configure_logging(input_args, err_output=stderr)
+            result = conduct_unload.unload(input_args)
             self.assertFalse(result)
 
-        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        request_headers_mock.assert_called_with(input_args)
+        http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers=self.mock_headers)
 
         self.assertEqual(
             self.default_connection_error.format(self.default_url),

--- a/conductr_cli/test/test_conduct_url.py
+++ b/conductr_cli/test/test_conduct_url.py
@@ -24,3 +24,20 @@ class TestConductUrl(TestCase):
         args.api_version = '2'
         result = conduct_url.url('test', args)
         self.assertEqual('http://127.0.0.1:9005/v2/test', result)
+
+
+class TestRequestHeaders(TestCase):
+
+    def test_return_headers(self):
+        ip_address = "my-test-ip"
+        args = {'ip': ip_address}
+        input_args = MagicMock(**args)
+        result = conduct_url.request_headers(input_args)
+        expected_result = {'Host': ip_address}
+        self.assertEqual(result, expected_result)
+
+    def test_return_none(self):
+        args = {'ip': None}
+        input_args = MagicMock(**args)
+        result = conduct_url.request_headers(input_args)
+        self.assertIsNone(result)


### PR DESCRIPTION
Without doing this, the CLI will not work with ipv6. This is due to the following bug in the requests library:

https://github.com/kennethreitz/requests/issues/3002

The workaround is specified here:

https://github.com/kennethreitz/requests/issues/3037
