### PR TITLE
Support the new Docker for Mac and Windows

### DIFF
--- a/conductr_cli/host.py
+++ b/conductr_cli/host.py
@@ -8,15 +8,19 @@ from subprocess import CalledProcessError
 def resolve_default_ip():
     def resolve():
         try:
-            return with_docker_machine()
-        except validation.NOT_FOUND_ERROR:
+            terminal.docker_ps()
+            return '127.0.0.1'
+        except CalledProcessError:
             try:
-                return with_boot2docker()
+                return with_docker_machine()
             except validation.NOT_FOUND_ERROR:
                 try:
-                    return with_hostname()
+                    return with_boot2docker()
                 except validation.NOT_FOUND_ERROR:
-                    return '127.0.0.1'
+                    try:
+                        return with_hostname()
+                    except validation.NOT_FOUND_ERROR:
+                        return '127.0.0.1'
 
     return os.getenv('CONDUCTR_IP', resolve())
 


### PR DESCRIPTION
The new Docker for Mac and Windows environments use a local hypervisor instead of docker-machine/boot2docker. As such we now check whether we can run docker at all prior to docker-machine/boot2docker. If we can then we need not check any further, and can assume docker's IP to be the loopback address.

Fixes #135 
