### PR TITLE
Docker should not be required

### DIFF
--- a/conductr_cli/host.py
+++ b/conductr_cli/host.py
@@ -8,9 +8,9 @@ from subprocess import CalledProcessError
 def resolve_default_ip():
     def resolve():
         try:
-            terminal.docker_ps()
+            terminal.docker_info()
             return '127.0.0.1'
-        except CalledProcessError:
+        except (CalledProcessError, FileNotFoundError):
             try:
                 return with_docker_machine()
             except validation.NOT_FOUND_ERROR:


### PR DESCRIPTION
Removed a newly introduced requirement for Docker by catching a `FileNotFoundError` on resolving the default IP. We also use `docker_info` instead of `docker_ps` as it will be more efficient.
