### PR TITLE
Opens up the ES port (9200) when using monitoring so that ES can be p…

### DIFF
--- a/conductr_cli/sandbox_run.py
+++ b/conductr_cli/sandbox_run.py
@@ -29,7 +29,7 @@ def collect_ports(args):
         elif feature_name == 'logging':
             return {'name': feature_name, 'ports': [5601]}
         elif feature_name == 'monitoring':
-            return {'name': feature_name, 'ports': [3000]}
+            return {'name': feature_name, 'ports': [3000, 9200]}
 
     all_feature_ports = [to_feature(feature_name)['ports'] for feature_name in args.features]
     return set(args.ports + [port for feature_ports in all_feature_ports for port in feature_ports])


### PR DESCRIPTION
…opulated from demo apps outside of ConductR.

@huntc are you okay with this? It would make our user experience a bit smoother (not having to add the `--port 9200` when starting sandbox with `--feature monitoring`).
