### PR TITLE
Suppress stderr output from Docker commands where appropriate

### DIFF
--- a/conductr_cli/terminal.py
+++ b/conductr_cli/terminal.py
@@ -2,11 +2,11 @@ import subprocess
 
 
 def docker_info():
-    return subprocess.check_output(['docker', 'info']).strip()
+    return subprocess.check_output(['docker', 'info'], stderr=subprocess.DEVNULL).strip()
 
 
 def docker_images(image):
-    return subprocess.check_output(['docker', 'images', '--quiet', image]).strip()
+    return subprocess.check_output(['docker', 'images', '--quiet', image], stderr=subprocess.DEVNULL).strip()
 
 
 def docker_pull(image):
@@ -16,7 +16,7 @@ def docker_pull(image):
 def docker_ps(ps_filter=None):
     ps_filter_arg = ['--filter', ps_filter] if ps_filter else []
     cmd = ['docker', 'ps', '--quiet'] + ps_filter_arg
-    output = subprocess.check_output(cmd, universal_newlines=True).strip()
+    output = subprocess.check_output(cmd, universal_newlines=True, stderr=subprocess.DEVNULL).strip()
     return output.splitlines()
 
 

--- a/conductr_cli/test/test_terminal.py
+++ b/conductr_cli/test/test_terminal.py
@@ -1,3 +1,4 @@
+import subprocess
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
 from conductr_cli import terminal
 
@@ -10,6 +11,16 @@ except ImportError:
 
 class TestTerminal(CliTestCase):
 
+    def test_docker_info(self):
+        output = "test"
+        check_output_mock = MagicMock(return_value='{}\n'.format(output))
+
+        with patch('subprocess.check_output', check_output_mock):
+            result = terminal.docker_info()
+
+        self.assertEqual(result, output)
+        check_output_mock.assert_called_with(['docker', 'info'], stderr=subprocess.DEVNULL)
+
     def test_docker_images(self):
         image = 'my-image-id'
 
@@ -19,7 +30,7 @@ class TestTerminal(CliTestCase):
             result = terminal.docker_images(image)
 
         self.assertEqual(result, image)
-        check_output_mock.assert_called_with(['docker', 'images', '--quiet', image])
+        check_output_mock.assert_called_with(['docker', 'images', '--quiet', image], stderr=subprocess.DEVNULL)
 
     def test_docker_pull(self):
         image = 'image:version'
@@ -45,7 +56,7 @@ class TestTerminal(CliTestCase):
 
         self.assertEqual(result, [image1, image2])
         check_output_mock.assert_called_with(['docker', 'ps', '--quiet', '--filter', ps_filter],
-                                             universal_newlines=True)
+                                             universal_newlines=True, stderr=subprocess.DEVNULL)
 
     def test_docker_inspect(self):
         container_id = 'cond-0'


### PR DESCRIPTION
The stderr output will be displayed if running CLI from a terminal where Docker env is not available.

The suppressed stderr ouput are from Docker commands which are used for detection, i.e. `docker info` for detecting host address to be set for CONDUCTR_IP. It is benign the suppress the stderr for these commands, since there are actions to be taken should the commands fail.

An example of this scenario is running CLI from a bastion host where Docker is not installed against a remote ConductR core. Prior this change, docker related error will be displayed on the terminal which is not productive in this case.
