### PR TITLE
Wait for ConductR to be available on sandbox run

### DIFF
--- a/conductr_cli/sandbox_main.py
+++ b/conductr_cli/sandbox_main.py
@@ -83,6 +83,11 @@ def build_parser():
                                  'Available features: ' + ', '.join(features),
                             choices=features,
                             metavar='')
+    run_parser.add_argument('--no-wait',
+                            help='Disables waiting for ConductR to be started in the sandbox',
+                            default=False,
+                            dest='no_wait',
+                            action='store_true')
     run_parser.set_defaults(func=sandbox_run.run)
 
     # Sub-parser for `debug` sub-command


### PR DESCRIPTION
Wait for ConductR to available when starting up the sandbox, by making a request to ConductR `/members` in the same way that `conduct` commands are run, but with a retry policy. Add a `--no-wait` option to disable. Retry options are configurable via env vars.
