### PR TITLE
Secure bundle and bundle configuration files

### DIFF
--- a/conductr_cli/exceptions.py
+++ b/conductr_cli/exceptions.py
@@ -46,6 +46,14 @@ class BintrayResolutionError(Exception):
         return repr(self.value)
 
 
+class InsecureFilePermissions(Exception):
+    def __init__(self, value):
+        self.value = value
+
+    def __str__(self):
+        return repr(self.value)
+
+
 class WaitTimeoutError(Exception):
     def __init__(self, value):
         self.value = value

--- a/conductr_cli/resolvers/test/test_uri_resolver.py
+++ b/conductr_cli/resolvers/test/test_uri_resolver.py
@@ -72,7 +72,7 @@ class TestResolveBundle(TestCase):
             call('/cache-dir'),
             call('/bundle-cached-path.tmp')
         ], os_path_exists_mock.call_args_list)
-        os_mkdirs_mock.assert_called_with('/cache-dir')
+        os_mkdirs_mock.assert_called_with('/cache-dir', mode=448)
         cache_path_mock.assert_called_with('/cache-dir', '/bundle-url')
         get_url_mock.assert_called_with('/bundle-url')
         urlretrieve_mock.assert_called_with('/bundle-url-resolved', '/bundle-cached-path.tmp')

--- a/conductr_cli/resolvers/uri_resolver.py
+++ b/conductr_cli/resolvers/uri_resolver.py
@@ -13,7 +13,7 @@ def resolve_bundle(cache_dir, uri, auth=None):
     log = logging.getLogger(__name__)
 
     if not os.path.exists(cache_dir):
-        os.makedirs(cache_dir)
+        os.makedirs(cache_dir, mode=0o700)
 
     try:
         bundle_name, bundle_url = get_url(uri)

--- a/conductr_cli/validation.py
+++ b/conductr_cli/validation.py
@@ -12,7 +12,7 @@ from urllib.error import URLError
 from zipfile import BadZipFile
 from conductr_cli import terminal, docker_machine
 from conductr_cli.exceptions import DockerMachineError, Boot2DockerError, MalformedBundleError, BundleResolutionError, \
-    WaitTimeoutError
+    WaitTimeoutError, InsecureFilePermissions
 from subprocess import CalledProcessError
 
 
@@ -178,6 +178,23 @@ def handle_conduct_load_read_timeout_error(func):
             log.error('Timed out waiting for response from the server: {}'.format(err.args[0]))
             log.error('One possible issue may be that there are not enough resources or machines with the roles '
                       'that your bundle requires')
+            return False
+
+    # Do not change the wrapped function name,
+    # so argparse configuration can be tested.
+    handler.__name__ = func.__name__
+
+    return handler
+
+
+def handle_insecure_file_permissions(func):
+    def handler(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except InsecureFilePermissions as err:
+            log = get_logger_for_func(func)
+            log.error('File permissions are not secure: {}'.format(err.args[0]))
+            log.error('Please choose a file where only the owner has access, e.g. 700')
             return False
 
     # Do not change the wrapped function name,


### PR DESCRIPTION
During bundle load the:
- Cache directory is now created with the permissions `700` instead of `755`
- The permissions of the specified cache directory are validated. Only the owner can have access to the directory.
- Bundle configuration is not cached anymore

Fixes https://github.com/typesafehub/conductr-cli/issues/160.
