### PR TITLE
Support Akka SSE empty heartbeat lines

### DIFF
--- a/conductr_cli/sse_client.py
+++ b/conductr_cli/sse_client.py
@@ -21,11 +21,12 @@ def parse_event(raw_sse_string):
     event, data = None, None
     lines = raw_sse_string.split('\n')
     for line in lines:
-        key, value = line.split(':')
-        if key == 'event':
-            event = value
-        elif key == 'data':
-            data = value
+        if line.rstrip():
+            key, value = line.split(':')
+            if key == 'event':
+                event = value
+            elif key == 'data':
+                data = value
     return Event(event, data)
 
 


### PR DESCRIPTION
In 1.7.6 [akka-sse](https://github.com/hseeberger/akka-sse) changed the way how to sent heartbeat events. Instead of sending `data:` it is now sending an empty lines.

The akka-sse client in `conductr-cli` has been updated to support both the old and the new format.
