### PR TITLE
Ensure clean sandbox startup

### DIFF
--- a/conductr_cli/terminal.py
+++ b/conductr_cli/terminal.py
@@ -15,7 +15,7 @@ def docker_pull(image):
 
 def docker_ps(ps_filter=None):
     ps_filter_arg = ['--filter', ps_filter] if ps_filter else []
-    cmd = ['docker', 'ps', '--quiet'] + ps_filter_arg
+    cmd = ['docker', 'ps', '--all', '--quiet'] + ps_filter_arg
     output = subprocess.check_output(cmd, universal_newlines=True, stderr=subprocess.DEVNULL).strip()
     return output.splitlines()
 

--- a/conductr_cli/test/test_terminal.py
+++ b/conductr_cli/test/test_terminal.py
@@ -55,7 +55,7 @@ class TestTerminal(CliTestCase):
             result = terminal.docker_ps(ps_filter)
 
         self.assertEqual(result, [image1, image2])
-        check_output_mock.assert_called_with(['docker', 'ps', '--quiet', '--filter', ps_filter],
+        check_output_mock.assert_called_with(['docker', 'ps', '--all', '--quiet', '--filter', ps_filter],
                                              universal_newlines=True, stderr=subprocess.DEVNULL)
 
     def test_docker_inspect(self):


### PR DESCRIPTION
So far the `sandbox run` command checked how many ConductR instances are already running. This made it possible to keep existing instances running and to scale down an existing cluster.

Also, to identify the currently running docker containers `docker ps` was used without the `--all` option.

Now, the `docker ps` command uses the `--all` option to also identify containers that have been crashed, e.g. due to a ConductR startup failure.

The "keep existing instances" and "scaling down" feature has been removed. Now, the `sandbox run` command stops all running containers before it starts a new ConductR cluster.

The reason behind this change is that users often had the problem that old `cond-` containers were still running when they were starting a new cluster, e.g. containers from a previous ConductR version or from an old cluster. The features "keep existing containers" and "scaling down" was hardly used. The new approach of stopping all containers before a new cluster is started ensures a clean state. This is similiar what we do in Lagom with the `install` command.

Fixes https://github.com/typesafehub/conductr-cli/issues/145.
