### PR TITLE
Add new monitoring feature using published grafana bundle

### DIFF
--- a/conductr_cli/conduct_main.py
+++ b/conductr_cli/conduct_main.py
@@ -269,11 +269,11 @@ def get_custom_settings(args):
         return None
 
 
-def run():
+def run(_args=[]):
     # Parse arguments
     parser = build_parser()
     argcomplete.autocomplete(parser)
-    args = parser.parse_args()
+    args = parser.parse_args(_args) if _args else parser.parse_args()
     if not vars(args).get('func'):
         parser.print_help()
     else:

--- a/conductr_cli/sandbox_features.py
+++ b/conductr_cli/sandbox_features.py
@@ -1,0 +1,132 @@
+"""Sandbox features.
+
+Features are specified on the command line with `-f/--feature NAME [ ARGS ... ]`.
+
+Any feature arguments will be passed to the feature class constructor.
+
+Feature attributes:
+    name (str): Feature name used for command line argument.
+    ports (list of int): Docker port mappings for the feature.
+    dependencies (list of str): Names of other features that should also be enabled.
+    bootstrap_features (list of str): Feature names to pass when ConductR is started in Docker.
+    start (method): Start the feature as needed. Called after the sandbox has started.
+"""
+
+from conductr_cli import conduct_main
+import logging
+
+
+class VisualizationFeature:
+    name = 'visualization'
+    ports = [9999]
+    dependencies = []
+    bootstrap_features = [name]
+
+    def __init__(self, args):
+        self.args = args
+
+    def start(self):
+        pass
+
+
+class LoggingFeature:
+    name = 'logging'
+    ports = [5601, 9200]
+    dependencies = []
+    bootstrap_features = [name]
+
+    def __init__(self, args):
+        self.args = args
+
+    def start(self):
+        pass
+
+
+class MonitoringFeature:
+    """Monitoring feature.
+
+    The monitoring feature depends on the logging feature.
+
+    On start, a Grafana bundle will be run. The version of the Grafana
+    bundle can also be configured using feature arguments. For example:
+
+        `-f monitoring`: default latest version of the Grafana bundle
+        `-f monitoring v2`: specify the compatibility version
+        `-f monitoring 2.1.0`: specify the full Cinnamon version
+        `-f monitoring snapshot 2.1.0-20161018-43bab24`: specify a snapshot version
+    """
+
+    name = 'monitoring'
+    ports = [3000]
+    dependencies = [LoggingFeature.name]
+    bootstrap_features = []
+
+    def __init__(self, args):
+        self.args = args
+
+    def start(self):
+        log = logging.getLogger(__name__)
+        log.info('Starting monitoring feature...')
+        grafana = self.grafana_bundle()
+        log.info('Running %s...' % grafana['bundle'])
+        conduct_main.run(['load', grafana['bundle']])
+        conduct_main.run(['run', grafana['name']])
+
+    def grafana_bundle(self):
+        bundle_name = 'cinnamon-grafana'
+        bundle_repo = ''  # default
+        bundle_version = ''  # latest
+        # parse args: [snapshot] [VERSION]
+        if self.args:
+            if self.args[0] == 'snapshot':
+                bundle_repo = 'lightbend/commercial-monitoring/'
+                if self.args[1:]:
+                    bundle_version = self.args[1]
+            else:
+                bundle_version = self.args[0]
+        # reformat version: dashes to dots and ensure 'v' prefix
+        if bundle_version:
+            bundle_version = bundle_version.replace('-', '.')
+            bundle_version = 'v' + bundle_version if not bundle_version.startswith('v') else bundle_version
+            bundle_version = ':' + bundle_version
+        bundle_expression = bundle_repo + bundle_name + bundle_version
+        return {'name': bundle_name, 'bundle': bundle_expression}
+
+
+feature_classes = [VisualizationFeature, LoggingFeature, MonitoringFeature]
+
+feature_names = [feature.name for feature in feature_classes]
+feature_lookup = {feature.name: feature for feature in feature_classes}
+
+
+def collect_features(cli_args):
+    """Collect all enabled features.
+
+    Collect features recursively with topological sort to include all dependencies in order.
+
+    Args:
+        cli_args (list of list of str): Command-line arguments for features.
+            Note that each feature has a list of arguments, the first is the feature name,
+            followed by optional arguments. For example: `[['logging'], ['monitoring', '2.1.0']]`.
+
+    Returns:
+        list of obj: All enabled features, initialised with feature arguments, in dependency order.
+    """
+
+    feature_names = [name for name, *args in cli_args]
+    feature_args = {name: args for name, *args in cli_args}
+
+    visited = set()
+    features = []
+
+    def visit(feature_names):
+        for feature_name in feature_names:
+            if feature_name not in visited:
+                visited.add(feature_name)
+                args = feature_args[feature_name] if feature_name in feature_args else []
+                feature = feature_lookup[feature_name](args)
+                visit(feature.dependencies)
+                features.append(feature)
+
+    visit(feature_names)
+    return features

--- a/conductr_cli/sandbox_main.py
+++ b/conductr_cli/sandbox_main.py
@@ -1,6 +1,7 @@
 import argcomplete
 import argparse
 from conductr_cli.sandbox_common import CONDUCTR_DEV_IMAGE
+from conductr_cli.sandbox_features import feature_names
 from conductr_cli import sandbox_run, sandbox_stop, sandbox_init, sandbox_common, logging_setup
 
 
@@ -74,14 +75,13 @@ def build_parser():
                             default=sandbox_common.bundle_http_port(),
                             help='Set default frontend port for proxying HTTP based request ACLs.',
                             metavar='')
-    features = ['visualization', 'logging', 'monitoring']
     run_parser.add_argument('-f', '--feature',
                             dest='features',
                             action='append',
+                            nargs='*',
                             default=[],
                             help='Features to be enabled.\n'
-                                 'Available features: ' + ', '.join(features),
-                            choices=features,
+                                 'Available features: ' + ', '.join(feature_names),
                             metavar='')
     run_parser.add_argument('--no-wait',
                             help='Disables waiting for ConductR to be started in the sandbox',
@@ -130,6 +130,13 @@ def run():
     parser = build_parser()
     argcomplete.autocomplete(parser)
     args = parser.parse_args()
+    # Check that all feature arguments are valid
+    if vars(args).get('func').__name__ == 'run':
+        invalid_features = [f for f, *a in args.features if f not in feature_names]
+        if invalid_features:
+            parser.exit('Invalid features: %s (choose from %s)' %
+                        (', '.join("'%s'" % f for f in invalid_features),
+                         ', '.join("'%s'" % f for f in feature_names)))
     # Print help or execute subparser function
     if vars(args).get('func') is None:
         parser.print_help()

--- a/conductr_cli/test/test_sandbox_features.py
+++ b/conductr_cli/test/test_sandbox_features.py
@@ -1,0 +1,47 @@
+from unittest import TestCase
+from conductr_cli.sandbox_features import VisualizationFeature, LoggingFeature, MonitoringFeature, collect_features
+
+
+class TestFeatures(TestCase):
+    def test_collect_features(self):
+        self.assertEqual([VisualizationFeature],
+                         [type(f) for f in collect_features([['visualization']])])
+
+        self.assertEqual([LoggingFeature],
+                         [type(f) for f in collect_features([['logging']])])
+
+        # enable dependencies
+        self.assertEqual([LoggingFeature, MonitoringFeature],
+                         [type(f) for f in collect_features([['monitoring']])])
+
+        # allow explicit listing of dependencies
+        self.assertEqual([LoggingFeature, MonitoringFeature],
+                         [type(f) for f in collect_features([['logging'], ['monitoring']])])
+
+        # topological ordering for dependencies
+        self.assertEqual([LoggingFeature, MonitoringFeature],
+                         [type(f) for f in collect_features([['monitoring'], ['logging']])])
+
+        # topological ordering and ignore duplicates
+        self.assertEqual([LoggingFeature, MonitoringFeature, VisualizationFeature],
+                         [type(f) for f in collect_features([['monitoring'], ['visualization'], ['logging'], ['monitoring']])])
+
+    def test_feature_args(self):
+        self.assertEqual([(LoggingFeature, []), (MonitoringFeature, ['2.1.0'])],
+                         [(type(f), f.args) for f in collect_features([['monitoring', '2.1.0']])])
+
+        self.assertEqual([(LoggingFeature, []), (MonitoringFeature, ['snapshot', '2.1.0-20161018-43bab24'])],
+                         [(type(f), f.args) for f in collect_features([['monitoring', 'snapshot', '2.1.0-20161018-43bab24']])])
+
+    def test_monitoring_grafana_bundle(self):
+        self.assertEqual('cinnamon-grafana', MonitoringFeature([]).grafana_bundle()['name'])
+        self.assertEqual('cinnamon-grafana', MonitoringFeature([]).grafana_bundle()['bundle'])
+
+        self.assertEqual('cinnamon-grafana', MonitoringFeature(['v2']).grafana_bundle()['name'])
+        self.assertEqual('cinnamon-grafana:v2', MonitoringFeature(['v2']).grafana_bundle()['bundle'])
+        self.assertEqual('cinnamon-grafana:v2.1', MonitoringFeature(['v2.1']).grafana_bundle()['bundle'])
+        self.assertEqual('cinnamon-grafana:v2.1.0', MonitoringFeature(['2.1.0']).grafana_bundle()['bundle'])
+        self.assertEqual('cinnamon-grafana:v2.1.0.RC2', MonitoringFeature(['2.1.0-RC2']).grafana_bundle()['bundle'])
+
+        self.assertEqual('lightbend/commercial-monitoring/cinnamon-grafana:v2.1.0.20161018.43bab24',
+                         MonitoringFeature(['snapshot', '2.1.0-20161018-43bab24']).grafana_bundle()['bundle'])

--- a/conductr_cli/test/test_sandbox_main.py
+++ b/conductr_cli/test/test_sandbox_main.py
@@ -37,7 +37,7 @@ class TestSandbox(TestCase):
                                       '--nr-of-containers 5 '
                                       '--port 1000 -p 1001 '
                                       '--bundle-http-port 7111 '
-                                      '--feature visualization -f logging'.split())
+                                      '--feature visualization -f logging -f monitoring 2.1.0'.split())
         self.assertEqual(args.func.__name__, 'run')
         self.assertEqual(args.image_version, '1.1.0')
         self.assertEqual(args.conductr_roles, [['role1', 'role2'], ['role3']])
@@ -46,7 +46,7 @@ class TestSandbox(TestCase):
         self.assertEqual(args.log_level, 'debug')
         self.assertEqual(args.nr_of_containers, 5)
         self.assertEqual(args.ports, [1000, 1001])
-        self.assertEqual(args.features, ['visualization', 'logging'])
+        self.assertEqual(args.features, [['visualization'], ['logging'], ['monitoring', '2.1.0']])
         self.assertEqual(args.local_connection, True)
         self.assertEqual(args.resolve_ip, True)
         self.assertEqual(args.bundle_http_port, 7111)

--- a/conductr_cli/test/test_sandbox_run.py
+++ b/conductr_cli/test/test_sandbox_run.py
@@ -126,7 +126,7 @@ class TestSandboxRunCommand(CliTestCase):
         log_level = 'debug'
         nr_of_containers = 1
         ports = [3000, 3001]
-        features = ['visualization', 'logging']
+        features = [['visualization'], ['logging']]
 
         with \
                 patch('conductr_cli.terminal.docker_images', return_value='some-image'), \


### PR DESCRIPTION
Includes some changes to the way features are organised. Could continue to be improved, but I think this covers everything we need for the monitoring feature.

Includes support for feature dependencies, and does a topological sort so that they can be started in dependency order if needed.

Updated feature argument parsing so that features can also optionally have their own arguments, in this form: `-f NAME [ARGS...]`.

Monitoring feature uses the arguments to configure the grafana bundle version, for when a specific version needs to be selected. For example, the following can be used:

```
-f monitoring
-f monitoring v2
-f monitoring 2.1.0-RC2
-f monitoring snapshot 2.1.0-20161018-43bab24
```

The grafana bundle is published to the default typesafe/bundle repository in the normal bundle format of `v2-sha` but additional bintray version attributes are also updated to make this possible. Monitoring snapshots are published to a separate repository (to avoid latest version updates in particular).
