### PR TITLE
Improve Docker validation

### DIFF
--- a/conductr_cli/conduct_main.py
+++ b/conductr_cli/conduct_main.py
@@ -277,19 +277,20 @@ def run(_args=[]):
     if not vars(args).get('func'):
         parser.print_help()
     else:
-        # Add custom plugin dir to import path
-        custom_plugins_dir = vars(args).get('custom_plugins_dir')
-        if custom_plugins_dir:
-            sys.path.append(custom_plugins_dir)
+        if not vars(args).get('func').__name__ == 'version':
+            # Add custom plugin dir to import path
+            custom_plugins_dir = vars(args).get('custom_plugins_dir')
+            if custom_plugins_dir:
+                sys.path.append(custom_plugins_dir)
 
-        # Resolve default ip if the --ip argument hasn't been specified
-        if not vars(args).get('ip'):
-            # Returns None if an error has occurred
-            args.ip = host.resolve_default_ip()
-            if not args.ip:
-                return
-        else:
-            args.local_connection = False
+            # Resolve default ip if the --ip argument hasn't been specified
+            if not vars(args).get('ip'):
+                # Returns None if an error has occurred
+                args.ip = host.resolve_default_ip()
+                if not args.ip:
+                    exit(1)
+            else:
+                args.local_connection = False
 
         args.cli_parameters = get_cli_parameters(args)
         args.custom_settings = get_custom_settings(args)

--- a/conductr_cli/docker.py
+++ b/conductr_cli/docker.py
@@ -36,4 +36,3 @@ def vm_type():
         return DockerVmType.DOCKER_MACHINE
     else:
         return DockerVmType.NONE
-

--- a/conductr_cli/docker.py
+++ b/conductr_cli/docker.py
@@ -1,2 +1,39 @@
+import os.path
+from conductr_cli.exceptions import AmbiguousDockerVmError
+from conductr_cli import validation
+
 DEFAULT_DOCKER_RAM_SIZE = 3.8
 DEFAULT_DOCKER_CPU_COUNT = 4
+
+
+class DockerVmType:
+    DOCKER_ENGINE = 1
+    DOCKER_MACHINE = 2
+    NONE = 3
+
+
+@validation.handle_ambiguous_vm_error
+def vm_type():
+    # TODO: Add Docker native check for Windows 10 Professional and Enterprise Edition
+    docker_machine_name_env = os.getenv('DOCKER_MACHINE_NAME')
+    docker_host_env = os.getenv('DOCKER_HOST')
+    docker_tls_verify_env = os.getenv('DOCKER_TLS_VERIFY')
+    docker_cert_path_env = os.getenv('DOCKER_CERT_PATH')
+
+    def docker_machine_envs_set():
+        if docker_machine_name_env or docker_host_env or docker_tls_verify_env or docker_cert_path_env:
+            return True
+        else:
+            return False
+
+    if os.path.exists('/var/run/docker.sock'):
+        if docker_machine_envs_set():
+            raise AmbiguousDockerVmError(
+                'Native docker is installed and docker-machine environment variables are set.')
+        else:
+            return DockerVmType.DOCKER_ENGINE
+    elif docker_machine_envs_set():
+        return DockerVmType.DOCKER_MACHINE
+    else:
+        return DockerVmType.NONE
+

--- a/conductr_cli/docker_machine.py
+++ b/conductr_cli/docker_machine.py
@@ -1,4 +1,8 @@
 import os
+import logging
+
+from conductr_cli import terminal
+from conductr_cli.exceptions import NOT_FOUND_ERROR
 
 DEFAULT_DOCKER_MACHINE_NAME = 'default'
 DEFAULT_DOCKER_MACHINE_RAM_SIZE = '4096'
@@ -7,3 +11,24 @@ DEFAULT_DOCKER_MACHINE_CPU_COUNT = '4'
 
 def vm_name():
     return os.getenv('DOCKER_MACHINE_NAME', DEFAULT_DOCKER_MACHINE_NAME)
+
+
+def envs(docker_machine_vm_name):
+    def resolve_env(line):
+        key = line.partition(' ')[-1].partition('=')[0]
+        value = line.partition(' ')[-1].partition('=')[2].strip('"')
+        return key, value
+
+    try:
+        env_lines = terminal.docker_machine_env(docker_machine_vm_name)
+        log = logging.getLogger(__name__)
+        log.info('Retrieved docker environment variables with: docker-machine env {}'.format(docker_machine_vm_name))
+    except NOT_FOUND_ERROR:
+        return []
+    return [resolve_env(line) for line in env_lines if line.startswith('export') or line.startswith('SET')]
+
+
+def set_env(key, value):
+    log = logging.getLogger(__name__)
+    log.info('Set environment variable: {}="{}"'.format(key, value))
+    os.environ[key] = value

--- a/conductr_cli/exceptions.py
+++ b/conductr_cli/exceptions.py
@@ -1,4 +1,8 @@
-class DockerMachineError(Exception):
+# FileNotFoundError is only available on > python 3.3
+NOT_FOUND_ERROR = getattr(__builtins__, 'FileNotFoundError', OSError)
+
+
+class AmbiguousDockerVmError(Exception):
     def __init__(self, value):
         self.value = value
 
@@ -6,7 +10,23 @@ class DockerMachineError(Exception):
         return repr(self.value)
 
 
-class Boot2DockerError(Exception):
+class DockerMachineNotRunningError(Exception):
+    def __init__(self, value):
+        self.value = value
+
+    def __str__(self):
+        return repr(self.value)
+
+
+class DockerMachineCannotConnectToDockerError(Exception):
+    def __init__(self, value):
+        self.value = value
+
+    def __str__(self):
+        return repr(self.value)
+
+
+class VBoxManageNotFoundError(Exception):
     def __init__(self, value):
         self.value = value
 

--- a/conductr_cli/sandbox_common.py
+++ b/conductr_cli/sandbox_common.py
@@ -1,4 +1,4 @@
-from conductr_cli import host, terminal
+from conductr_cli import terminal
 import os
 
 
@@ -8,16 +8,6 @@ CONDUCTR_PORTS = {9004,  # ConductR internal akka remoting
                   9006}  # ConductR bundleStreamServer
 CONDUCTR_DEV_IMAGE = 'typesafe-docker-registry-for-subscribers-only.bintray.io/conductr/conductr'
 LATEST_CONDUCTR_VERSION = '1.1.9'
-
-
-host_ip = None
-
-
-def resolve_host_ip():
-    global host_ip
-    if not host_ip:
-        host_ip = host.resolve_default_ip()
-    return host_ip
 
 
 def resolve_running_docker_containers():

--- a/conductr_cli/sandbox_run.py
+++ b/conductr_cli/sandbox_run.py
@@ -1,4 +1,4 @@
-from conductr_cli import conduct_url, sandbox_common, terminal, validation, sandbox_stop
+from conductr_cli import conduct_url, terminal, validation, sandbox_stop, host
 from conductr_cli.constants import DEFAULT_PORT, DEFAULT_API_VERSION
 from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
 from conductr_cli.sandbox_common import CONDUCTR_NAME_PREFIX, CONDUCTR_DEV_IMAGE, CONDUCTR_PORTS
@@ -18,12 +18,14 @@ DEFAULT_WAIT_RETRY_INTERVAL = 1.0
 
 # Arguments for conduct requests, such as waiting for ConductR to start in the sandbox
 class ConductArgs:
-    ip = sandbox_common.resolve_host_ip()
+
+    def __init__(self, vm_type):
+        self.ip = host.resolve_ip_by_vm_type(vm_type)
+
     port = DEFAULT_PORT
     api_version = DEFAULT_API_VERSION
 
 
-@validation.handle_docker_errors
 @validation.handle_connection_error
 @validation.handle_http_error
 def run(args):
@@ -76,7 +78,7 @@ def start_nodes(args, ports, features):
         # Display the ports on the command line. Only if the user specifies a certain feature, then
         # the corresponding port will be displayed when running 'sandbox run' or 'sandbox debug'
         if ports:
-            host_ip = sandbox_common.resolve_host_ip()
+            host_ip = host.resolve_host_ip()
             ports_desc = ' exposing ' + ', '.join(['{}:{}'.format(host_ip, map_port(i, port))
                                                    for port in sorted(ports)])
         else:
@@ -185,7 +187,7 @@ def wait_for_start(args):
         print('Waiting for ConductR to start', end='', flush=True)
         retries = int(os.getenv('CONDUCTR_SANDBOX_WAIT_RETRIES', DEFAULT_WAIT_RETRIES))
         interval = float(os.getenv('CONDUCTR_SANDBOX_WAIT_RETRY_INTERVAL', DEFAULT_WAIT_RETRY_INTERVAL))
-        is_started = wait_for_conductr(0, retries, interval)
+        is_started = wait_for_conductr(args, 0, retries, interval)
         print('')
         if is_started:
             log.info('ConductR has been started. Check current bundle status with: conduct info')
@@ -194,11 +196,11 @@ def wait_for_start(args):
             log.error('Try to increase the CONDUCTR_SANDBOX_WAIT_RETRY_INTERVAL.')
 
 
-def wait_for_conductr(current_retry, max_retries, interval):
+def wait_for_conductr(args, current_retry, max_retries, interval):
     for attempt in range(0, max_retries):
         time.sleep(interval)
         print('.', end='', flush=True)
-        conduct_args = ConductArgs()
+        conduct_args = ConductArgs(args.vm_type)
         url = conduct_url.url('members', conduct_args)
         try:
             requests.get(url, timeout=DEFAULT_HTTP_TIMEOUT, headers=conduct_url.request_headers(conduct_args))

--- a/conductr_cli/sandbox_run.py
+++ b/conductr_cli/sandbox_run.py
@@ -78,7 +78,7 @@ def start_nodes(args, ports, features):
         # Display the ports on the command line. Only if the user specifies a certain feature, then
         # the corresponding port will be displayed when running 'sandbox run' or 'sandbox debug'
         if ports:
-            host_ip = host.resolve_host_ip()
+            host_ip = host.resolve_ip_by_vm_type(args.vm_type)
             ports_desc = ' exposing ' + ', '.join(['{}:{}'.format(host_ip, map_port(i, port))
                                                    for port in sorted(ports)])
         else:

--- a/conductr_cli/sandbox_stop.py
+++ b/conductr_cli/sandbox_stop.py
@@ -1,8 +1,7 @@
-from conductr_cli import sandbox_common, terminal, validation
+from conductr_cli import sandbox_common, terminal
 import logging
 
 
-@validation.handle_docker_errors
 def stop(args):
     """`sandbox stop` command"""
 

--- a/conductr_cli/terminal.py
+++ b/conductr_cli/terminal.py
@@ -122,4 +122,4 @@ def vbox_manage_cmd():
             vbox_cmd = vbox_32_path
         elif os.path.exists(vbox_64_path):
             vbox_cmd = vbox_64_path
-    return vbox_cmd        
+    return vbox_cmd

--- a/conductr_cli/terminal.py
+++ b/conductr_cli/terminal.py
@@ -1,4 +1,6 @@
 import subprocess
+import os
+from conductr_cli.exceptions import NOT_FOUND_ERROR, VBoxManageNotFoundError
 
 
 def docker_info():
@@ -71,20 +73,12 @@ def docker_machine_help():
     return subprocess.check_output(cmd, universal_newlines=True).strip()
 
 
-def boot2docker_shellinit():
-    cmd = ['boot2docker', 'shellinit']
-    output = subprocess.check_output(cmd, universal_newlines=True)
-    return [line.strip() for line in output.splitlines()]
-
-
-def boot2docker_ip():
-    cmd = ['boot2docker', 'ip']
-    return subprocess.check_output(cmd, universal_newlines=True).strip()
-
-
 def vbox_manage_increase_ram(vm_name, ram_size):
-    cmd = ['VBoxManage', 'modifyvm', vm_name, '--memory', ram_size]
-    return subprocess.check_output(cmd, universal_newlines=True).strip()
+    try:
+        cmd = [vbox_manage_cmd(), 'modifyvm', vm_name, '--memory', ram_size]
+        return subprocess.check_output(cmd, universal_newlines=True).strip()
+    except NOT_FOUND_ERROR:
+        raise VBoxManageNotFoundError('VBoxManage command not found')
 
 
 def vbox_manage_get_ram_size(vm_name):
@@ -93,8 +87,11 @@ def vbox_manage_get_ram_size(vm_name):
 
 
 def vbox_manage_increase_cpu(vm_name, no_of_cpu):
-    cmd = ['VBoxManage', 'modifyvm', vm_name, '--cpus', no_of_cpu]
-    return subprocess.check_output(cmd, universal_newlines=True).strip()
+    try:
+        cmd = [vbox_manage_cmd(), 'modifyvm', vm_name, '--cpus', no_of_cpu]
+        return subprocess.check_output(cmd, universal_newlines=True).strip()
+    except NOT_FOUND_ERROR:
+        raise VBoxManageNotFoundError('VBoxManage command not found')
 
 
 def vbox_manage_get_cpu_count(vm_name):
@@ -103,15 +100,26 @@ def vbox_manage_get_cpu_count(vm_name):
 
 
 def vbox_manage_get_info(vm_name, vm_property):
-    cmd = ['VBoxManage', 'showvminfo', vm_name]
-    output = subprocess.check_output(cmd, universal_newlines=True).strip()
-    matching_lines = [line for line in output.split('\n') if line.startswith('{}:'.format(vm_property))]
-    if matching_lines:
-        key, value = matching_lines[0].split(':')
-        return value.strip()
-    else:
-        return None
+    try:
+        cmd = [vbox_manage_cmd(), 'showvminfo', vm_name]
+        output = subprocess.check_output(cmd, universal_newlines=True).strip()
+        matching_lines = [line for line in output.split('\n') if line.startswith('{}:'.format(vm_property))]
+        if matching_lines:
+            key, value = matching_lines[0].split(':')
+            return value.strip()
+        else:
+            return None
+    except NOT_FOUND_ERROR:
+        raise VBoxManageNotFoundError('VBoxManage command not found')
 
 
-def hostname():
-    return subprocess.check_output(['hostname'], universal_newlines=True).strip()
+def vbox_manage_cmd():
+    vbox_cmd = 'VBoxManage'
+    if os.name == 'nt':
+        vbox_32_path = 'C:\Program Files\Oracle\VirtualBox\VBoxManage.exe'
+        vbox_64_path = 'C:\Program Files (x86)\Oracle\VirtualBox\VBoxManage.exe'
+        if os.path.exists(vbox_32_path):
+            vbox_cmd = vbox_32_path
+        elif os.path.exists(vbox_64_path):
+            vbox_cmd = vbox_64_path
+    return vbox_cmd        

--- a/conductr_cli/test/test_sandbox_main.py
+++ b/conductr_cli/test/test_sandbox_main.py
@@ -3,16 +3,9 @@ from conductr_cli import sandbox_main
 from conductr_cli.sandbox_common import LATEST_CONDUCTR_VERSION, CONDUCTR_DEV_IMAGE
 
 
-try:
-    from unittest.mock import patch  # 3.3 and beyond
-except ImportError:
-    from mock import patch
-
-
 class TestSandbox(TestCase):
 
-    with patch('conductr_cli.sandbox_common.resolve_host_ip', '127.0.0.1'):
-        parser = sandbox_main.build_parser()
+    parser = sandbox_main.build_parser()
 
     def test_parser_run_default_args(self):
         args = self.parser.parse_args('run {}'.format(LATEST_CONDUCTR_VERSION).split())

--- a/conductr_cli/test/test_terminal.py
+++ b/conductr_cli/test/test_terminal.py
@@ -189,39 +189,6 @@ class TestTerminal(CliTestCase):
         self.assertEqual(result, mock_output)
         check_output_mock.assert_called_with(['docker-machine', 'help'], universal_newlines=True)
 
-    def test_boot2docker_shellinit(self):
-        output = strip_margin("""|Writing /Users/mj/.boot2docker/certs/boot2docker-vm/ca.pem
-                                 |Writing /Users/mj/.boot2docker/certs/boot2docker-vm/cert.pem
-                                 |Writing /Users/mj/.boot2docker/certs/boot2docker-vm/key.pem
-                                 |    export DOCKER_HOST=tcp://192.168.59.103:2376
-                                 |    export DOCKER_CERT_PATH=/Users/mj/.boot2docker/certs/boot2docker-vm
-                                 |    export DOCKER_TLS_VERIFY=1
-                                 |""")
-        check_output_mock = MagicMock(return_value=output)
-
-        with patch('subprocess.check_output', check_output_mock):
-            result = terminal.boot2docker_shellinit()
-
-        expected_result = ['Writing /Users/mj/.boot2docker/certs/boot2docker-vm/ca.pem',
-                           'Writing /Users/mj/.boot2docker/certs/boot2docker-vm/cert.pem',
-                           'Writing /Users/mj/.boot2docker/certs/boot2docker-vm/key.pem',
-                           'export DOCKER_HOST=tcp://192.168.59.103:2376',
-                           'export DOCKER_CERT_PATH=/Users/mj/.boot2docker/certs/boot2docker-vm',
-                           'export DOCKER_TLS_VERIFY=1']
-
-        self.assertEqual(result, expected_result)
-        check_output_mock.assert_called_with(['boot2docker', 'shellinit'], universal_newlines=True)
-
-    def test_boot2docker_ip(self):
-        ip = '192.168.99.100'
-        check_output_mock = MagicMock(return_value='{}\n'.format(ip))
-
-        with patch('subprocess.check_output', check_output_mock):
-            result = terminal.boot2docker_ip()
-
-        self.assertEqual(result, ip)
-        check_output_mock.assert_called_with(['boot2docker', 'ip'], universal_newlines=True)
-
     def test_vbox_manage_increase_ram(self):
         vm_name = 'default'
         ram_size = '2048'
@@ -267,13 +234,3 @@ class TestTerminal(CliTestCase):
 
         self.assertEqual(result, 2)
         check_output_mock.assert_called_with(['VBoxManage', 'showvminfo', vm_name], universal_newlines=True)
-
-    def test_hostname(self):
-        hostname = 'my-hostname'
-        check_output_mock = MagicMock(return_value='{}\n'.format(hostname))
-
-        with patch('subprocess.check_output', check_output_mock):
-            result = terminal.hostname()
-
-        self.assertEqual(result, hostname)
-        check_output_mock.assert_called_with(['hostname'], universal_newlines=True)

--- a/conductr_cli/validation.py
+++ b/conductr_cli/validation.py
@@ -295,7 +295,7 @@ def handle_vbox_manage_not_found_error(func):
     # so argparse configuration can be tested.
     handler.__name__ = func.__name__
 
-    return handler    
+    return handler
 
 
 def format_timestamp(timestamp, args):


### PR DESCRIPTION
Improving the Docker and Docker VM validation.

**Improvements / Fixes**
- Docker is not a required for the `conduct` command anymore. If Docker is not installed, then the default IP address is `127.0.0.1`. Otherwise, the default IP is either `127.0.0.1` when Docker native is used or `192.x.x.x` when docker-machine is used (as before). Fixes https://github.com/typesafehub/conductr-cli/issues/148
- sandbox init now also works under Linux. Fixes https://github.com/typesafehub/conductr-cli/issues/146
- On Windows, the `sandbox init` command didn't work if the VirtualBox directory was not added to the PATH. Installing VirtualBox didn't add the directory to the PATH. Now, before giving up we try to find the VBoxManage.exe in the default installation directories so that `sandbox init` succeeds on Windows.
- Fixes Docker native vs docker-machine confusion. In the past, several corner cases exists where conductr-cli was not picking the correct Docker VM and therefore failed. These have been fixed. More details in the _Docker VM Decision Tree_ section.
- The error messages in regards to missing Docker dependencies or misconfigured Docker VMs have been greatly improved. More details in the _New error messages_ section.

**Docker VM Decision Tree**
_conduct commands_

For the `conduct` command Docker has not required anymore. We still do check if a certain Docker VM is installed to resolve the IP address accordingly:
- No Docker native AND no Docker-machine: `127.0.0.1`
- Docker native: `127.0.0.1`
- docker-machine: `192.x.x.x`
- Docker native AND docker-machine: AmbiguousDockerVmError

_sandbox commands_
The Docker VM validation is now performed equally for all sandbox commands to provide consistent error messages and to notify the user about a misconfiguration as early as possible. Before, most of the validation was performed only with the `sandbox init` command. The validation for all sandbox commands is now as follows:
- No Docker native AND no Docker-machine: NoDockerVMError
- Docker native installed but not running: DockerNativeNotRunningError
- Docker machine envs set but Docker machine VM default not installed:
  - sandbox init: Install default VM
  - sandbox others: DockerMachineVMNotInstalledError
- Docker machine envs set but Docker machine VM default not running:
  - sandbox init: Start default VM
  - sandbox others: DockerMachineVMNotRunningError
- Docker machine VM started but Docker machine cannot connect to Docker:
  - conductr_cli is setting Docker machine VM envs and retries the connection to Docker. If the connection fails again then the error DockerVMCannotConnectToDockerError is displayed.
- Docker native AND docker-machine: AmbiguousDockerVmError

**New error messages**
_NoDockerVMError_

```
Error: Neither Docker native is installed, nor the Docker machine environment variables are set.
Error: We recommend to use one of following the Docker distributions depending on your OS:
Error:   Linux:                                         Docker Engine
Error:   MacOS:                                         Docker for Mac
Error:   Windows 10+ Professional or Enterprise 64-bit: Docker for Windows
Error:   Other Windows:                                 Docker machine via Docker Toolbox
Error: For more information checkout: https://www.docker.com/products/overview
```

_DockerNativeNotRunningError_

```
Error: Docker native is installed but not running.
Error: Please start Docker with one of the Docker flavors based on your OS:
Error:   Linux:   Docker service
Error:   MacOS:   Docker for Mac
Error:   Windows: Docker for Windows
Error: A successful Docker startup can be verified with: docker info
```

_DockerMachineVMNotInstalledError_

```
Error: Docker machine VM default does not exist
Error: Please use the following command to start the Docker machine VM: sandbox init
```

_DockerMachineVMNotRunningError_

```
Error: Docker machine VM default is not started
Error: Please use the following command to start the Docker machine VM: sandbox init
```

_DockerVMCannotConnectToDockerError_

```
Error: Docker still cannot connect to the Docker machine VM.
Error: Please set the docker environment variables.
Error: Afterwards verify that docker is up and running with: docker info
```

_AmbiguousDockerVmError_

```
Error: Docker native is installed and Docker machine environment variables are set.
Error: It is uncertain which Docker VM should be used.
Error: If Docker native should be used please unset the Docker machine environment variables:
Error:  DOCKER_CERT_PATH
Error:  DOCKER_HOST
Error:  DOCKER_MACHINE_NAME
Error:  DOCKER_TLS_VERIFY
Error:  If Docker machine should be used please uninstall Docker native
```

**Successful Integration Tests**
- All scenarios (see decision tree) on macOS
- Windows 10 Home Edition without Docker
- Windows 10 Home Edition with docker-machine enabled

**ToDo**
- Unit tests
- Integration test on Linux
