### PR TITLE
Rename services to service-names

### DIFF
--- a/conductr_cli/conduct_main.py
+++ b/conductr_cli/conduct_main.py
@@ -1,7 +1,7 @@
 import argcomplete
 import argparse
 from conductr_cli import \
-    conduct_info, conduct_load, conduct_run, conduct_services,\
+    conduct_info, conduct_load, conduct_run, conduct_service_names,\
     conduct_stop, conduct_unload, conduct_version, conduct_logs,\
     conduct_events, conduct_acls, conduct_dcos, host, logging_setup
 from conductr_cli.constants import \
@@ -168,11 +168,11 @@ def build_parser(dcos_mode):
     add_default_arguments(info_parser, dcos_mode)
     info_parser.set_defaults(func=conduct_info.info)
 
-    # Sub-parser for `services` sub-command
-    services_parser = subparsers.add_parser('services',
-                                            help='print service information')
-    add_default_arguments(services_parser, dcos_mode)
-    services_parser.set_defaults(func=conduct_services.services)
+    # Sub-parser for `service-names` sub-command
+    service_names_parser = subparsers.add_parser('service-names',
+                                                 help='print the service names available to the service locator')
+    add_default_arguments(service_names_parser, dcos_mode)
+    service_names_parser.set_defaults(func=conduct_service_names.service_names)
 
     # Sub-parser for `acls` sub-command
     acls_parser = subparsers.add_parser('acls',

--- a/conductr_cli/conduct_service_names.py
+++ b/conductr_cli/conduct_service_names.py
@@ -7,8 +7,8 @@ from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
 
 @validation.handle_connection_error
 @validation.handle_http_error
-def services(args):
-    """`conduct services` command"""
+def service_names(args):
+    """`conduct service-names` command"""
 
     log = logging.getLogger(__name__)
     url = conduct_url.url('bundles', args)

--- a/conductr_cli/test/test_conduct_main.py
+++ b/conductr_cli/test/test_conduct_main.py
@@ -41,9 +41,9 @@ class TestConduct(TestCase):
         self.assertEqual(args.long_ids, False)
 
     def test_parser_services(self):
-        args = self.parser.parse_args('services'.split())
+        args = self.parser.parse_args('service-names'.split())
 
-        self.assertEqual(args.func.__name__, 'services')
+        self.assertEqual(args.func.__name__, 'service_names')
         self.assertEqual(args.ip, None)
         self.assertEqual(args.port, 9005)
         self.assertEqual(args.api_version, '2')

--- a/conductr_cli/test/test_conduct_service_names.py
+++ b/conductr_cli/test/test_conduct_service_names.py
@@ -1,5 +1,5 @@
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin, as_warn
-from conductr_cli import conduct_services, logging_setup
+from conductr_cli import conduct_service_names, logging_setup
 from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
 
 
@@ -9,7 +9,7 @@ except ImportError:
     from mock import patch, MagicMock
 
 
-class TestConductServicesCommand(CliTestCase):
+class TestConductServiceNamesCommand(CliTestCase):
 
     default_args = {
         'dcos_mode': False,
@@ -31,7 +31,7 @@ class TestConductServicesCommand(CliTestCase):
         input_args = MagicMock(**self.default_args)
         with patch('requests.get', http_method):
             logging_setup.configure_logging(input_args, stdout)
-            result = conduct_services.services(input_args)
+            result = conduct_service_names.service_names(input_args)
             self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers={'Host': '127.0.0.1'})
@@ -48,7 +48,7 @@ class TestConductServicesCommand(CliTestCase):
         input_args = MagicMock(**self.default_args)
         with patch('requests.get', http_method):
             logging_setup.configure_logging(input_args, stdout)
-            result = conduct_services.services(input_args)
+            result = conduct_service_names.service_names(input_args)
             self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers={'Host': '127.0.0.1'})
@@ -75,7 +75,7 @@ class TestConductServicesCommand(CliTestCase):
         input_args = MagicMock(**self.default_args)
         with patch('requests.get', http_method):
             logging_setup.configure_logging(input_args, stdout)
-            result = conduct_services.services(input_args)
+            result = conduct_service_names.service_names(input_args)
             self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers={'Host': '127.0.0.1'})
@@ -97,7 +97,7 @@ class TestConductServicesCommand(CliTestCase):
         input_args = MagicMock(**self.default_args)
         with patch('requests.get', http_method):
             logging_setup.configure_logging(input_args, stdout)
-            result = conduct_services.services(input_args)
+            result = conduct_service_names.service_names(input_args)
             self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers={'Host': '127.0.0.1'})
@@ -119,7 +119,7 @@ class TestConductServicesCommand(CliTestCase):
         input_args = MagicMock(**args)
         with patch('requests.get', http_method):
             logging_setup.configure_logging(input_args, stdout)
-            result = conduct_services.services(input_args)
+            result = conduct_service_names.service_names(input_args)
             self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers={'Host': '127.0.0.1'})
@@ -142,7 +142,7 @@ class TestConductServicesCommand(CliTestCase):
         input_args = MagicMock(**args)
         with patch('requests.get', http_method):
             logging_setup.configure_logging(input_args, stdout)
-            result = conduct_services.services(input_args)
+            result = conduct_service_names.service_names(input_args)
             self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers={'Host': '127.0.0.1'})
@@ -159,7 +159,7 @@ class TestConductServicesCommand(CliTestCase):
         input_args = MagicMock(**self.default_args)
         with patch('requests.get', http_method):
             logging_setup.configure_logging(input_args, stdout)
-            result = conduct_services.services(input_args)
+            result = conduct_service_names.service_names(input_args)
             self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers={'Host': '127.0.0.1'})
@@ -177,7 +177,7 @@ class TestConductServicesCommand(CliTestCase):
         input_args = MagicMock(**self.default_args)
         with patch('requests.get', http_method):
             logging_setup.configure_logging(input_args, stdout)
-            result = conduct_services.services(input_args)
+            result = conduct_service_names.service_names(input_args)
             self.assertTrue(result)
 
         http_method.assert_called_with(self.default_url, timeout=DEFAULT_HTTP_TIMEOUT, headers={'Host': '127.0.0.1'})


### PR DESCRIPTION
A number of customers reported confusion regarding why "conduct services" printed nothing, when in fact the command was doing the right thing. This commit renames the subcommand from "services" to "service-names" in order to clarify the intention of the command further.