### PR TITLE
Reduce the Docker Machine check

### DIFF
--- a/conductr_cli/docker.py
+++ b/conductr_cli/docker.py
@@ -16,12 +16,9 @@ class DockerVmType:
 def vm_type():
     # TODO: Add Docker native check for Windows 10 Professional and Enterprise Edition
     docker_machine_name_env = os.getenv('DOCKER_MACHINE_NAME')
-    docker_host_env = os.getenv('DOCKER_HOST')
-    docker_tls_verify_env = os.getenv('DOCKER_TLS_VERIFY')
-    docker_cert_path_env = os.getenv('DOCKER_CERT_PATH')
 
     def docker_machine_envs_set():
-        if docker_machine_name_env or docker_host_env or docker_tls_verify_env or docker_cert_path_env:
+        if docker_machine_name_env:
             return True
         else:
             return False


### PR DESCRIPTION
The existing check for Docker Machine was perhaps too tight. It is a valid scenario to have a native Docker installed, along with DOCKER_HOST and others e.g. in the future when connecting the Docker API with ConductR.

The only check required for Docker Machine is the DOCKER_MACHINE_NAME environment variable.