### PR TITLE
Various fixes in preparation for ConductR 2.0.0-RC1

### DIFF
--- a/conductr_cli/conduct_main.py
+++ b/conductr_cli/conduct_main.py
@@ -283,19 +283,18 @@ def build_parser(dcos_mode):
 
 def get_cli_parameters(args):
     parameters = ['']
-    if not args.dcos_mode:
-        arg = vars(args).get('scheme')
-        if arg and arg != DEFAULT_SCHEME:
-            parameters.append('--scheme {}'.format(args.scheme))
-        arg = vars(args).get('ip')
-        if arg and arg != host.resolve_default_ip():
-            parameters.append('--ip {}'.format(args.ip))
-        arg = vars(args).get('port', int(DEFAULT_PORT))
-        if arg and arg != int(DEFAULT_PORT):
-            parameters.append('--port {}'.format(args.port))
-        arg = vars(args).get('base_path', DEFAULT_BASE_PATH)
-        if arg and arg != DEFAULT_BASE_PATH:
-            parameters.append('--base-path {}'.format(args.base_path))
+    arg = vars(args).get('scheme')
+    if arg and arg != DEFAULT_SCHEME:
+        parameters.append('--scheme {}'.format(args.scheme))
+    arg = vars(args).get('ip')
+    if arg and arg != host.resolve_default_ip():
+        parameters.append('--ip {}'.format(args.ip))
+    arg = vars(args).get('port', int(DEFAULT_PORT))
+    if arg and arg != int(DEFAULT_PORT):
+        parameters.append('--port {}'.format(args.port))
+    arg = vars(args).get('base_path', DEFAULT_BASE_PATH)
+    if arg and arg != DEFAULT_BASE_PATH:
+        parameters.append('--base-path {}'.format(args.base_path))
     arg = vars(args).get('api_version', DEFAULT_API_VERSION)
     if arg and arg != DEFAULT_API_VERSION:
         parameters.append('--api-version {}'.format(args.api_version))
@@ -328,6 +327,7 @@ def run(_args=[]):
     parser = build_parser(dcos_mode)
     argcomplete.autocomplete(parser)
     args = parser.parse_args(_args[1:])
+    args.dcos_mode = dcos_mode
     if not vars(args).get('func'):
         if vars(args).get('dcos_info'):
             print('Lightbend ConductR sub commands. Type \'dcos conduct\' to see more.')
@@ -351,10 +351,8 @@ def run(_args=[]):
                 args.port = dcos_url.port if dcos_url.port else default_http_port
                 dcos_url_path = dcos_url.path if dcos_url.path else '/'
                 args.base_path = dcos_url_path + 'service/{}/'.format(DEFAULT_DCOS_SERVICE)
-                args.dcos_mode = True
             else:
                 args.command = 'conduct'
-                args.dcos_mode = False
 
             # Resolve default ip if the --ip argument hasn't been specified
             if not vars(args).get('ip'):
@@ -365,8 +363,9 @@ def run(_args=[]):
             else:
                 args.local_connection = False
 
-        args.cli_parameters = get_cli_parameters(args)
-        args.custom_settings = get_custom_settings(args)
+            args.cli_parameters = get_cli_parameters(args)
+            args.custom_settings = get_custom_settings(args)
+
         logging_setup.configure_logging(args)
 
         is_completed_without_error = args.func(args)

--- a/conductr_cli/main_handler.py
+++ b/conductr_cli/main_handler.py
@@ -1,5 +1,6 @@
 import logging
 import logging.handlers
+import os
 import sys
 
 
@@ -15,6 +16,10 @@ def run(callback):
         raise e
     except:
         from conductr_cli.constants import DEFAULT_ERROR_LOG_FILE
+
+        # Ensure log dir is present before errors are being logged
+        log_dir = os.path.abspath(os.path.join(DEFAULT_ERROR_LOG_FILE, '..'))
+        os.makedirs(log_dir)
 
         log = logging.getLogger('conductr_cli.main')
         log.error('Encountered unexpected error.')

--- a/conductr_cli/test/test_conduct_main.py
+++ b/conductr_cli/test/test_conduct_main.py
@@ -154,17 +154,17 @@ class TestConduct(TestCase):
         self.assertEqual(args.dcos_info, True)
 
     def test_get_cli_parameters(self):
-        args = Namespace(dcos_mode=False, scheme='http', ip='127.0.0.1', port=9005, api_version='2')
+        args = Namespace(scheme='http', ip='127.0.0.1', port=9005, api_version='2')
         self.assertEqual(get_cli_parameters(args), '')
 
-        args = Namespace(dcos_mode=False, scheme='http', ip='127.0.1.1', port=9005)
+        args = Namespace(scheme='http', ip='127.0.1.1', port=9005)
         self.assertEqual(get_cli_parameters(args), ' --ip 127.0.1.1')
 
-        args = Namespace(dcos_mode=False, scheme='http', ip='127.0.0.1', port=9006)
+        args = Namespace(scheme='http', ip='127.0.0.1', port=9006)
         self.assertEqual(get_cli_parameters(args), ' --port 9006')
 
-        args = Namespace(dcos_mode=False, scheme='http', ip='127.0.0.1', port=9005, api_version='1')
+        args = Namespace(scheme='http', ip='127.0.0.1', port=9005, api_version='1')
         self.assertEqual(get_cli_parameters(args), ' --api-version 1')
 
-        args = Namespace(dcos_mode=False, scheme='http', ip='127.0.1.1', port=9006, api_version='1')
+        args = Namespace(scheme='http', ip='127.0.1.1', port=9006, api_version='1')
         self.assertEqual(get_cli_parameters(args), ' --ip 127.0.1.1 --port 9006 --api-version 1')

--- a/conductr_cli/test/test_main_handler.py
+++ b/conductr_cli/test/test_main_handler.py
@@ -1,6 +1,6 @@
 from conductr_cli.test.cli_test_case import CliTestCase
 from conductr_cli import main_handler
-from conductr_cli.constants import DEFAULT_ERROR_LOG_FILE
+from conductr_cli.constants import DEFAULT_CLI_SETTINGS_DIR, DEFAULT_ERROR_LOG_FILE
 import sys
 
 
@@ -47,11 +47,16 @@ class TestMainHandler(CliTestCase):
         get_logger_mock = MagicMock(side_effect=[main_log, exception_log])
         sys_exit_mock = MagicMock()
 
+        makedirs_mock = MagicMock()
+
         with patch('logging.getLogger', get_logger_mock), \
                 patch('logging.Formatter', create_formatter_mock), \
                 patch('logging.handlers.RotatingFileHandler', create_rotating_file_handler_mock), \
+                patch('os.makedirs', makedirs_mock), \
                 patch('sys.exit', sys_exit_mock):
             main_handler.run(raise_unhandled_error)
+
+        makedirs_mock.assert_called_with(DEFAULT_CLI_SETTINGS_DIR)
 
         self.assertEqual(get_logger_mock.call_args_list, [
             call('conductr_cli.main'),


### PR DESCRIPTION
- Fix conduct version failing with object missing dcos_mode. This fixes issue https://github.com/typesafehub/conductr-cli/issues/179