### PR TITLE
Test for DC/OS when formatting CLI params

### DIFF
--- a/conductr_cli/conduct_main.py
+++ b/conductr_cli/conduct_main.py
@@ -284,16 +284,16 @@ def build_parser(dcos_mode):
 def get_cli_parameters(args):
     parameters = ['']
     arg = vars(args).get('scheme')
-    if arg and arg != DEFAULT_SCHEME:
+    if not args.dcos_mode and arg and arg != DEFAULT_SCHEME:
         parameters.append('--scheme {}'.format(args.scheme))
     arg = vars(args).get('ip')
-    if arg and arg != host.resolve_default_ip():
+    if not args.dcos_mode and arg and arg != host.resolve_default_ip():
         parameters.append('--ip {}'.format(args.ip))
     arg = vars(args).get('port', int(DEFAULT_PORT))
-    if arg and arg != int(DEFAULT_PORT):
+    if not args.dcos_mode and arg and arg != int(DEFAULT_PORT):
         parameters.append('--port {}'.format(args.port))
     arg = vars(args).get('base_path', DEFAULT_BASE_PATH)
-    if arg and arg != DEFAULT_BASE_PATH:
+    if not args.dcos_mode and arg and arg != DEFAULT_BASE_PATH:
         parameters.append('--base-path {}'.format(args.base_path))
     arg = vars(args).get('api_version', DEFAULT_API_VERSION)
     if arg and arg != DEFAULT_API_VERSION:

--- a/conductr_cli/test/test_conduct_main.py
+++ b/conductr_cli/test/test_conduct_main.py
@@ -154,17 +154,17 @@ class TestConduct(TestCase):
         self.assertEqual(args.dcos_info, True)
 
     def test_get_cli_parameters(self):
-        args = Namespace(scheme='http', ip='127.0.0.1', port=9005, api_version='2')
+        args = Namespace(dcos_mode=False, scheme='http', ip='127.0.0.1', port=9005, api_version='2')
         self.assertEqual(get_cli_parameters(args), '')
 
-        args = Namespace(scheme='http', ip='127.0.1.1', port=9005)
+        args = Namespace(dcos_mode=False, scheme='http', ip='127.0.1.1', port=9005)
         self.assertEqual(get_cli_parameters(args), ' --ip 127.0.1.1')
 
-        args = Namespace(scheme='http', ip='127.0.0.1', port=9006)
+        args = Namespace(dcos_mode=False, scheme='http', ip='127.0.0.1', port=9006)
         self.assertEqual(get_cli_parameters(args), ' --port 9006')
 
-        args = Namespace(scheme='http', ip='127.0.0.1', port=9005, api_version='1')
+        args = Namespace(dcos_mode=False, scheme='http', ip='127.0.0.1', port=9005, api_version='1')
         self.assertEqual(get_cli_parameters(args), ' --api-version 1')
 
-        args = Namespace(scheme='http', ip='127.0.1.1', port=9006, api_version='1')
+        args = Namespace(dcos_mode=False, scheme='http', ip='127.0.1.1', port=9006, api_version='1')
         self.assertEqual(get_cli_parameters(args), ' --ip 127.0.1.1 --port 9006 --api-version 1')


### PR DESCRIPTION
We should not output connectivity information when in DC/OS mode as the defaults will always be different. When using the DC/OS CLI integration, connection information is derived from DC/OS configuration.