### PR TITLE
Conduct Load/Run: Perform a more eager check

### DIFF
--- a/conductr_cli/bundle_installation.py
+++ b/conductr_cli/bundle_installation.py
@@ -45,7 +45,7 @@ def wait_for_condition(bundle_id, condition, condition_name, args):
             if elapsed > args.wait_timeout:
                 raise WaitTimeoutError('Bundle {} waiting to be {}'.format(bundle_id, condition_name))
 
-            if event.event and event.event.startswith('bundleInstallation'):
+            if event.event:
                 installed_bundles = count_installations(bundle_id, args)
                 if condition(installed_bundles):
                     log.info('Bundle {} {}'.format(bundle_id, condition_name))

--- a/conductr_cli/bundle_scale.py
+++ b/conductr_cli/bundle_scale.py
@@ -40,7 +40,7 @@ def wait_for_scale(bundle_id, expected_scale, args):
             if elapsed > args.wait_timeout:
                 raise WaitTimeoutError('Bundle {} waiting to reach expected scale {}'.format(bundle_id, expected_scale))
 
-            if event.event and event.event.startswith('bundleExecution'):
+            if event.event:
                 bundle_scale = get_scale(bundle_id, args)
                 if bundle_scale == expected_scale:
                     log.info('Bundle {} expected scale {} is met'.format(bundle_id, expected_scale))

--- a/conductr_cli/bundle_scale.py
+++ b/conductr_cli/bundle_scale.py
@@ -32,6 +32,8 @@ def wait_for_scale(bundle_id, expected_scale, args):
         log.info('Bundle {} expected scale {} is met'.format(bundle_id, expected_scale))
         return
     else:
+        sse_heartbeat_count_after_event = 0
+
         log.info('Bundle {} waiting to reach expected scale {}'.format(bundle_id, expected_scale))
         bundle_events_url = conduct_url.url('bundles/events', args)
         sse_events = sse_client.get_events(args.dcos_mode, args.ip, bundle_events_url)
@@ -40,7 +42,13 @@ def wait_for_scale(bundle_id, expected_scale, args):
             if elapsed > args.wait_timeout:
                 raise WaitTimeoutError('Bundle {} waiting to reach expected scale {}'.format(bundle_id, expected_scale))
 
-            if event.event:
+            # Check for bundle scale every 3 heartbeats from the last received event.
+            if event.event or (sse_heartbeat_count_after_event % 3 == 0):
+                if event.event:
+                    sse_heartbeat_count_after_event = 0
+                else:
+                    sse_heartbeat_count_after_event += 1
+
                 bundle_scale = get_scale(bundle_id, args)
                 if bundle_scale == expected_scale:
                     log.info('Bundle {} expected scale {} is met'.format(bundle_id, expected_scale))

--- a/conductr_cli/test/test_bundle_installation.py
+++ b/conductr_cli/test/test_bundle_installation.py
@@ -155,6 +155,43 @@ class TestWaitForInstallation(CliTestCase):
                                          |Bundle a101449418187d92c789d1adc240b6d6 installed
                                          |"""), self.output(stdout))
 
+    def test_wait_for_installation_periodic_check(self):
+        count_installations_mock = MagicMock(side_effect=[0, 0, 1])
+        url_mock = MagicMock(return_value='/bundle-events/endpoint')
+        get_events_mock = MagicMock(return_value=[
+            create_test_event(None),
+            create_test_event('bundleInstallationAdded'),
+            create_test_event(None),
+            create_test_event(None),
+            create_test_event(None),
+            create_test_event('bundleInstallationAdded')
+        ])
+
+        stdout = MagicMock()
+
+        bundle_id = 'a101449418187d92c789d1adc240b6d6'
+        args = MagicMock(**{
+            'wait_timeout': 10
+        })
+        with patch('conductr_cli.conduct_url.url', url_mock), \
+                patch('conductr_cli.bundle_installation.count_installations', count_installations_mock), \
+                patch('conductr_cli.sse_client.get_events', get_events_mock):
+            logging_setup.configure_logging(args, stdout)
+            bundle_installation.wait_for_installation(bundle_id, args)
+
+        self.assertEqual(count_installations_mock.call_args_list, [
+            call(bundle_id, args),
+            call(bundle_id, args),
+            call(bundle_id, args)
+        ])
+
+        url_mock.assert_called_with('bundles/events', args)
+
+        self.assertEqual(strip_margin("""|Bundle a101449418187d92c789d1adc240b6d6 waiting to be installed
+                                         |Bundle a101449418187d92c789d1adc240b6d6 still waiting to be installed
+                                         |Bundle a101449418187d92c789d1adc240b6d6 installed
+                                         |"""), self.output(stdout))
+
     def test_return_immediately_if_installed(self):
         count_installations_mock = MagicMock(side_effect=[3])
 

--- a/conductr_cli/test/test_bundle_installation.py
+++ b/conductr_cli/test/test_bundle_installation.py
@@ -121,11 +121,12 @@ class TestCountInstallation(CliTestCase):
 
 class TestWaitForInstallation(CliTestCase):
     def test_wait_for_installation(self):
-        count_installations_mock = MagicMock(side_effect=[0, 1])
+        count_installations_mock = MagicMock(side_effect=[0, 0, 1])
         url_mock = MagicMock(return_value='/bundle-events/endpoint')
         get_events_mock = MagicMock(return_value=[
             create_test_event(None),
             create_test_event('bundleInstallationAdded'),
+            create_test_event('otherEvent'),
             create_test_event('bundleInstallationAdded')
         ])
 
@@ -143,12 +144,14 @@ class TestWaitForInstallation(CliTestCase):
 
         self.assertEqual(count_installations_mock.call_args_list, [
             call(bundle_id, args),
+            call(bundle_id, args),
             call(bundle_id, args)
         ])
 
         url_mock.assert_called_with('bundles/events', args)
 
         self.assertEqual(strip_margin("""|Bundle a101449418187d92c789d1adc240b6d6 waiting to be installed
+                                         |Bundle a101449418187d92c789d1adc240b6d6 still waiting to be installed
                                          |Bundle a101449418187d92c789d1adc240b6d6 installed
                                          |"""), self.output(stdout))
 

--- a/conductr_cli/test/test_bundle_scale.py
+++ b/conductr_cli/test/test_bundle_scale.py
@@ -184,6 +184,51 @@ class TestWaitForScale(CliTestCase):
                                          |Bundle a101449418187d92c789d1adc240b6d6 expected scale 3 is met
                                          |"""), self.output(stdout))
 
+    def test_wait_for_scale_periodic_check(self):
+        get_scale_mock = MagicMock(side_effect=[0, 1, 2, 2, 2, 3])
+        url_mock = MagicMock(return_value='/bundle-events/endpoint')
+        get_events_mock = MagicMock(return_value=[
+            self.create_test_event(None),
+            self.create_test_event('bundleExecutionAdded'),
+            self.create_test_event('bundleExecutionAdded'),
+            self.create_test_event('otherEvent'),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event('bundleExecutionAdded')
+        ])
+
+        stdout = MagicMock()
+
+        bundle_id = 'a101449418187d92c789d1adc240b6d6'
+        args = MagicMock(**{
+            'wait_timeout': 10
+        })
+        with patch('conductr_cli.conduct_url.url', url_mock), \
+                patch('conductr_cli.bundle_scale.get_scale', get_scale_mock), \
+                patch('conductr_cli.sse_client.get_events', get_events_mock):
+            logging_setup.configure_logging(args, stdout)
+            bundle_scale.wait_for_scale(bundle_id, 3, args)
+
+        self.assertEqual(get_scale_mock.call_args_list, [
+            call(bundle_id, args),
+            call(bundle_id, args),
+            call(bundle_id, args),
+            call(bundle_id, args),
+            call(bundle_id, args),
+            call(bundle_id, args)
+        ])
+
+        url_mock.assert_called_with('bundles/events', args)
+
+        self.assertEqual(strip_margin("""|Bundle a101449418187d92c789d1adc240b6d6 waiting to reach expected scale 3
+                                         |Bundle a101449418187d92c789d1adc240b6d6 has scale 1, expected 3
+                                         |Bundle a101449418187d92c789d1adc240b6d6 has scale 2, expected 3
+                                         |Bundle a101449418187d92c789d1adc240b6d6 has scale 2, expected 3
+                                         |Bundle a101449418187d92c789d1adc240b6d6 has scale 2, expected 3
+                                         |Bundle a101449418187d92c789d1adc240b6d6 expected scale 3 is met
+                                         |"""), self.output(stdout))
+
     def test_return_immediately_if_scale_is_met(self):
         get_scale_mock = MagicMock(side_effect=[3])
 

--- a/conductr_cli/test/test_bundle_scale.py
+++ b/conductr_cli/test/test_bundle_scale.py
@@ -145,12 +145,13 @@ class TestGetScale(CliTestCase):
 
 class TestWaitForScale(CliTestCase):
     def test_wait_for_scale(self):
-        get_scale_mock = MagicMock(side_effect=[0, 1, 2, 3])
+        get_scale_mock = MagicMock(side_effect=[0, 1, 2, 2, 3])
         url_mock = MagicMock(return_value='/bundle-events/endpoint')
         get_events_mock = MagicMock(return_value=[
             self.create_test_event(None),
             self.create_test_event('bundleExecutionAdded'),
             self.create_test_event('bundleExecutionAdded'),
+            self.create_test_event('otherEvent'),
             self.create_test_event('bundleExecutionAdded')
         ])
 
@@ -170,6 +171,7 @@ class TestWaitForScale(CliTestCase):
             call(bundle_id, args),
             call(bundle_id, args),
             call(bundle_id, args),
+            call(bundle_id, args),
             call(bundle_id, args)
         ])
 
@@ -177,6 +179,7 @@ class TestWaitForScale(CliTestCase):
 
         self.assertEqual(strip_margin("""|Bundle a101449418187d92c789d1adc240b6d6 waiting to reach expected scale 3
                                          |Bundle a101449418187d92c789d1adc240b6d6 has scale 1, expected 3
+                                         |Bundle a101449418187d92c789d1adc240b6d6 has scale 2, expected 3
                                          |Bundle a101449418187d92c789d1adc240b6d6 has scale 2, expected 3
                                          |Bundle a101449418187d92c789d1adc240b6d6 expected scale 3 is met
                                          |"""), self.output(stdout))


### PR DESCRIPTION
Perform a more eager check for bundle installed during `conduct load`, or scale achieved during `conduct run` command.

- Conduct Load performs check regardless of events received (i.e. used to perform check only when events starting with `bundleInstallation` is received).
- Conduct Run performs check regardless of events received (i.e. used to perform check only when events starting with `bundleExecution` is received).
- Both Conduct Load and Conduct Run nows perform a check every 3 SSE heartbeats from the last event received.