### PR TITLE
Cleanup cached bundles after conduct load command

### DIFF
--- a/conductr_cli/conduct.py
+++ b/conductr_cli/conduct.py
@@ -9,5 +9,6 @@ def main_method():
 def run():
     main_handler.run(main_method)
 
+
 if __name__ == '__main__':
     run()

--- a/conductr_cli/sandbox.py
+++ b/conductr_cli/sandbox.py
@@ -9,5 +9,6 @@ def main_method():
 def run():
     main_handler.run(main_method)
 
+
 if __name__ == '__main__':
     run()

--- a/conductr_cli/shazar.py
+++ b/conductr_cli/shazar.py
@@ -9,5 +9,6 @@ def main_method():
 def run():
     main_handler.run(main_method)
 
+
 if __name__ == '__main__':
     run()

--- a/conductr_cli/test/conduct_load_test_base.py
+++ b/conductr_cli/test/conduct_load_test_base.py
@@ -25,7 +25,7 @@ class ConductLoadTestBase(CliTestCase):
         super().__init__(method_name)
 
         self.bundle_id = None
-        self.bundle_name = None
+        self.bundle_file_name = None
         self.bundle_file = None
         self.default_args = {}
         self.default_files = None
@@ -58,16 +58,18 @@ class ConductLoadTestBase(CliTestCase):
             'verbose': verbose}))
 
     def base_test_success(self):
-        resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, self.bundle_file))
+        resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, self.bundle_file))
         create_multipart_mock = MagicMock(return_value=self.multipart_mock)
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
         wait_for_installation_mock = MagicMock()
+        cleanup_old_bundles_mock = MagicMock()
 
         input_args = MagicMock(**self.default_args)
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
+                patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
@@ -82,6 +84,8 @@ class ConductLoadTestBase(CliTestCase):
                                        data=self.multipart_mock,
                                        headers={'Content-Type': self.multipart_content_type, 'Host': '127.0.0.1'})
         wait_for_installation_mock.assert_called_with(self.bundle_id, input_args)
+        cleanup_old_bundles_mock.assert_called_with(self.bundle_resolve_cache_dir, self.bundle_file_name,
+                                                    excluded=self.bundle_file)
 
         self.assertEqual(self.default_output(), self.output(stdout))
 
@@ -89,16 +93,18 @@ class ConductLoadTestBase(CliTestCase):
         self.default_args['dcos_mode'] = True
         self.default_args['command'] = 'dcos conduct'
 
-        resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, self.bundle_file))
+        resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, self.bundle_file))
         create_multipart_mock = MagicMock(return_value=self.multipart_mock)
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
         wait_for_installation_mock = MagicMock()
+        cleanup_old_bundles_mock = MagicMock()
 
         input_args = MagicMock(**self.default_args)
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
+                patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('dcos.http.post', http_method), \
                 patch('builtins.open', open_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
@@ -113,16 +119,19 @@ class ConductLoadTestBase(CliTestCase):
                                        data=self.multipart_mock,
                                        headers={'Content-Type': self.multipart_content_type, 'Host': '127.0.0.1'})
         wait_for_installation_mock.assert_called_with(self.bundle_id, input_args)
+        cleanup_old_bundles_mock.assert_called_with(self.bundle_resolve_cache_dir, self.bundle_file_name,
+                                                    excluded=self.bundle_file)
 
         self.assertEqual(self.default_output(command=self.default_args['command']), self.output(stdout))
 
     def base_test_success_verbose(self):
-        resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, self.bundle_file))
+        resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, self.bundle_file))
         create_multipart_mock = MagicMock(return_value=self.multipart_mock)
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
         wait_for_installation_mock = MagicMock()
+        cleanup_old_bundles_mock = MagicMock()
 
         args = self.default_args.copy()
         args.update({'verbose': True})
@@ -130,6 +139,7 @@ class ConductLoadTestBase(CliTestCase):
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
+                patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
@@ -144,16 +154,19 @@ class ConductLoadTestBase(CliTestCase):
                                        data=self.multipart_mock,
                                        headers={'Content-Type': self.multipart_content_type, 'Host': '127.0.0.1'})
         wait_for_installation_mock.assert_called_with(self.bundle_id, input_args)
+        cleanup_old_bundles_mock.assert_called_with(self.bundle_resolve_cache_dir, self.bundle_file_name,
+                                                    excluded=self.bundle_file)
 
         self.assertEqual(self.default_output(verbose=self.default_response), self.output(stdout))
 
     def base_test_success_quiet(self):
-        resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, self.bundle_file))
+        resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, self.bundle_file))
         create_multipart_mock = MagicMock(return_value=self.multipart_mock)
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
         wait_for_installation_mock = MagicMock()
+        cleanup_old_bundles_mock = MagicMock()
 
         args = self.default_args.copy()
         args.update({'quiet': True})
@@ -161,6 +174,7 @@ class ConductLoadTestBase(CliTestCase):
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
+                patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
@@ -175,16 +189,19 @@ class ConductLoadTestBase(CliTestCase):
                                        data=self.multipart_mock,
                                        headers={'Content-Type': self.multipart_content_type, 'Host': '127.0.0.1'})
         wait_for_installation_mock.assert_called_with(self.bundle_id, input_args)
+        cleanup_old_bundles_mock.assert_called_with(self.bundle_resolve_cache_dir, self.bundle_file_name,
+                                                    excluded=self.bundle_file)
 
         self.assertEqual('45e0c477d3e5ea92aa8d85c0d8f3e25c\n', self.output(stdout))
 
     def base_test_success_long_ids(self):
-        resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, self.bundle_file))
+        resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, self.bundle_file))
         create_multipart_mock = MagicMock(return_value=self.multipart_mock)
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
         wait_for_installation_mock = MagicMock()
+        cleanup_old_bundles_mock = MagicMock()
 
         args = self.default_args.copy()
         args.update({'long_ids': True})
@@ -192,6 +209,7 @@ class ConductLoadTestBase(CliTestCase):
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
+                patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
@@ -206,16 +224,19 @@ class ConductLoadTestBase(CliTestCase):
                                        data=self.multipart_mock,
                                        headers={'Content-Type': self.multipart_content_type, 'Host': '127.0.0.1'})
         wait_for_installation_mock.assert_called_with(self.bundle_id, input_args)
+        cleanup_old_bundles_mock.assert_called_with(self.bundle_resolve_cache_dir, self.bundle_file_name,
+                                                    excluded=self.bundle_file)
 
         self.assertEqual(self.default_output(bundle_id='45e0c477d3e5ea92aa8d85c0d8f3e25c'), self.output(stdout))
 
     def base_test_success_custom_ip_port(self):
-        resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, self.bundle_file))
+        resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, self.bundle_file))
         create_multipart_mock = MagicMock(return_value=self.multipart_mock)
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
         wait_for_installation_mock = MagicMock()
+        cleanup_old_bundles_mock = MagicMock()
 
         cli_parameters = ' --ip 127.0.1.1 --port 9006'
         args = self.default_args.copy()
@@ -224,6 +245,7 @@ class ConductLoadTestBase(CliTestCase):
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
+                patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
@@ -238,18 +260,21 @@ class ConductLoadTestBase(CliTestCase):
                                        data=self.multipart_mock,
                                        headers={'Content-Type': self.multipart_content_type, 'Host': '127.0.0.1'})
         wait_for_installation_mock.assert_called_with(self.bundle_id, input_args)
+        cleanup_old_bundles_mock.assert_called_with(self.bundle_resolve_cache_dir, self.bundle_file_name,
+                                                    excluded=self.bundle_file)
 
         self.assertEqual(
             self.default_output(params=cli_parameters),
             self.output(stdout))
 
     def base_test_success_custom_host_port(self):
-        resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, self.bundle_file))
+        resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, self.bundle_file))
         create_multipart_mock = MagicMock(return_value=self.multipart_mock)
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
         wait_for_installation_mock = MagicMock()
+        cleanup_old_bundles_mock = MagicMock()
 
         cli_parameters = ' --host 127.0.1.1 --port 9006'
         args = self.default_args.copy()
@@ -258,6 +283,7 @@ class ConductLoadTestBase(CliTestCase):
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
+                patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
@@ -272,6 +298,8 @@ class ConductLoadTestBase(CliTestCase):
                                        data=self.multipart_mock,
                                        headers={'Content-Type': self.multipart_content_type, 'Host': '127.0.0.1'})
         wait_for_installation_mock.assert_called_with(self.bundle_id, input_args)
+        cleanup_old_bundles_mock.assert_called_with(self.bundle_resolve_cache_dir, self.bundle_file_name,
+                                                    excluded=self.bundle_file)
 
         self.assertEqual(
             self.default_output(params=cli_parameters),
@@ -283,16 +311,18 @@ class ConductLoadTestBase(CliTestCase):
         args.pop('host')
         args.update({'ip': '127.0.0.1'})
 
-        resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, self.bundle_file))
+        resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, self.bundle_file))
         create_multipart_mock = MagicMock(return_value=self.multipart_mock)
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
         wait_for_installation_mock = MagicMock()
+        cleanup_old_bundles_mock = MagicMock()
 
         input_args = MagicMock(**args)
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
+                patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
@@ -307,15 +337,18 @@ class ConductLoadTestBase(CliTestCase):
                                        data=self.multipart_mock,
                                        headers={'Content-Type': self.multipart_content_type, 'Host': '127.0.0.1'})
         wait_for_installation_mock.assert_called_with(self.bundle_id, input_args)
+        cleanup_old_bundles_mock.assert_called_with(self.bundle_resolve_cache_dir, self.bundle_file_name,
+                                                    excluded=self.bundle_file)
 
         self.assertEqual(self.default_output(), self.output(stdout))
 
     def base_test_success_no_wait(self):
-        resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, self.bundle_file))
+        resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, self.bundle_file))
         create_multipart_mock = MagicMock(return_value=self.multipart_mock)
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
+        cleanup_old_bundles_mock = MagicMock()
 
         args = self.default_args.copy()
         args.update({'no_wait': True})
@@ -323,6 +356,7 @@ class ConductLoadTestBase(CliTestCase):
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
+                patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock):
             logging_setup.configure_logging(input_args, stdout)
@@ -335,11 +369,13 @@ class ConductLoadTestBase(CliTestCase):
         http_method.assert_called_with(self.default_url,
                                        data=self.multipart_mock,
                                        headers={'Content-Type': self.multipart_content_type, 'Host': '127.0.0.1'})
+        cleanup_old_bundles_mock.assert_called_with(self.bundle_resolve_cache_dir, self.bundle_file_name,
+                                                    excluded=self.bundle_file)
 
         self.assertEqual(self.default_output(), self.output(stdout))
 
     def base_test_failure(self):
-        resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, self.bundle_file))
+        resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, self.bundle_file))
         create_multipart_mock = MagicMock(return_value=self.multipart_mock)
         http_method = self.respond_with(404)
         stdout = MagicMock()
@@ -368,7 +404,7 @@ class ConductLoadTestBase(CliTestCase):
             self.output(stderr))
 
     def base_test_failure_invalid_address(self):
-        resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, self.bundle_file))
+        resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, self.bundle_file))
         create_multipart_mock = MagicMock(return_value=self.multipart_mock)
         http_method = self.raise_connection_error('test reason', self.default_url)
         stdout = MagicMock()
@@ -396,7 +432,7 @@ class ConductLoadTestBase(CliTestCase):
             self.output(stderr))
 
     def base_test_failure_no_response(self):
-        resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, self.bundle_file))
+        resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, self.bundle_file))
         create_multipart_mock = MagicMock(return_value=self.multipart_mock)
         http_method = self.raise_read_timeout_error('test reason', self.default_url)
         stdout = MagicMock()
@@ -446,7 +482,7 @@ class ConductLoadTestBase(CliTestCase):
             self.output(stderr))
 
     def base_test_failure_no_configuration(self):
-        resolve_bundle_mock = MagicMock(side_effect=[(self.bundle_name, self.bundle_file),
+        resolve_bundle_mock = MagicMock(side_effect=[(self.bundle_file_name, self.bundle_file),
                                                      BundleResolutionError('some message')])
         stdout = MagicMock()
         stderr = MagicMock()
@@ -472,7 +508,7 @@ class ConductLoadTestBase(CliTestCase):
             self.output(stderr))
 
     def base_test_failure_bad_zip(self):
-        resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, self.bundle_file))
+        resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, self.bundle_file))
         stderr = MagicMock()
         open_mock = MagicMock(side_effect=BadZipFile('test bad zip error'))
 
@@ -524,7 +560,7 @@ class ConductLoadTestBase(CliTestCase):
             self.output(stderr))
 
     def base_test_failure_install_timeout(self):
-        resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, self.bundle_file))
+        resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, self.bundle_file))
         create_multipart_mock = MagicMock(return_value=self.multipart_mock)
         http_method = self.respond_with(200, self.default_response)
         stderr = MagicMock()

--- a/conductr_cli/test/test_conduct_load_functions.py
+++ b/conductr_cli/test/test_conduct_load_functions.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 from conductr_cli import conduct_load
 from requests_toolbelt.multipart.encoder import MultipartEncoder, MultipartEncoderMonitor
 
+import datetime
 import io
 
 try:
@@ -73,3 +74,72 @@ class TestCommonFunctions(TestCase):
         result = conduct_load.string_io('input')
         self.assertIsInstance(result, io.StringIO)
         self.assertEqual(['input'], result.readlines())
+
+    def test_cleanup_old_bundles(self):
+        cache_dir = '/home/user/.conductr/cache'
+        recently_loaded_bundle = '{}/reactive-maps-frontend-v1-recent.zip'.format(cache_dir)
+        files_in_cache = [
+            '{}/reactive-maps-frontend-v1-oldest.zip'.format(cache_dir),
+            '{}/reactive-maps-frontend-v1-older.zip'.format(cache_dir),
+            '{}/reactive-maps-frontend-v1-old.zip'.format(cache_dir),
+            recently_loaded_bundle
+        ]
+        glob_mock = MagicMock(return_value=files_in_cache)
+        is_same_path_mock = MagicMock(side_effect=[False, False, False, True])
+        isfile_mock = MagicMock(return_value=True)
+
+        today = datetime.date.today()
+        yesterday = today - datetime.timedelta(1)
+        last_week = today - datetime.timedelta(7)
+        last_month = today - datetime.timedelta(30)
+        getmtime_mock = MagicMock(side_effect=[last_month, last_week, yesterday])
+
+        remove_mock = MagicMock()
+
+        with patch('glob.glob', glob_mock), \
+                patch('os.path.isfile', isfile_mock), \
+                patch('os.path.getmtime', getmtime_mock), \
+                patch('os.remove', remove_mock), \
+                patch('conductr_cli.conduct_load.is_same_path', is_same_path_mock):
+            conduct_load.cleanup_old_bundles(cache_dir, 'reactive-maps-frontend-v1-recent.zip',
+                                             excluded=recently_loaded_bundle)
+
+        glob_mock.assert_called_with('{}/*.zip'.format(cache_dir))
+        self.assertEqual(isfile_mock.call_args_list, [
+            call('{}/reactive-maps-frontend-v1-oldest.zip'.format(cache_dir)),
+            call('{}/reactive-maps-frontend-v1-older.zip'.format(cache_dir)),
+            call('{}/reactive-maps-frontend-v1-old.zip'.format(cache_dir)),
+            call(recently_loaded_bundle)
+        ])
+        self.assertEqual(is_same_path_mock.call_args_list, [
+            call('{}/reactive-maps-frontend-v1-oldest.zip'.format(cache_dir), recently_loaded_bundle),
+            call('{}/reactive-maps-frontend-v1-older.zip'.format(cache_dir), recently_loaded_bundle),
+            call('{}/reactive-maps-frontend-v1-old.zip'.format(cache_dir), recently_loaded_bundle),
+            call(recently_loaded_bundle, recently_loaded_bundle)
+        ])
+        self.assertEqual(getmtime_mock.call_args_list, [
+            call('{}/reactive-maps-frontend-v1-oldest.zip'.format(cache_dir)),
+            call('{}/reactive-maps-frontend-v1-older.zip'.format(cache_dir)),
+            call('{}/reactive-maps-frontend-v1-old.zip'.format(cache_dir))
+        ])
+        self.assertEqual(remove_mock.call_args_list, [
+            call('{}/reactive-maps-frontend-v1-oldest.zip'.format(cache_dir)),
+            call('{}/reactive-maps-frontend-v1-older.zip'.format(cache_dir))
+        ])
+
+    def test_is_same_path(self):
+        file_a = "path-a.zip"
+        file_b = "path-b.zip"
+        abs_path_mock = MagicMock(side_effect=[
+            "same-path", "same-path",
+            "different-path-a", "different-path-b"
+        ])
+
+        with patch('os.path.abspath', abs_path_mock):
+            self.assertTrue(conduct_load.is_same_path(file_a, file_b))
+            self.assertFalse(conduct_load.is_same_path(file_a, file_b))
+
+        self.assertEqual(abs_path_mock.call_args_list, [
+            call(file_a), call(file_b),
+            call(file_a), call(file_b)
+        ])

--- a/conductr_cli/test/test_conduct_load_v1.py
+++ b/conductr_cli/test/test_conduct_load_v1.py
@@ -20,7 +20,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
         self.memory = 200
         self.disk_space = 100
         self.roles = ['web-server']
-        self.bundle_name = 'bundle.zip'
+        self.bundle_file_name = 'bundle.zip'
         self.system = 'bundle'
         self.custom_settings = Mock()
         self.bundle_resolve_cache_dir = 'bundle-resolve-cache-dir'
@@ -36,7 +36,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
                                          self.memory,
                                          self.disk_space,
                                          ', '.join(self.roles),
-                                         self.bundle_name,
+                                         self.bundle_file_name,
                                          self.system))
         self.default_args = {
             'dcos_mode': False,
@@ -64,9 +64,9 @@ class TestConductLoadCommand(ConductLoadTestBase):
             ('memory', str(self.memory)),
             ('diskSpace', str(self.disk_space)),
             ('roles', ' '.join(self.roles)),
-            ('bundleName', self.bundle_name),
+            ('bundleName', self.bundle_file_name),
             ('system', self.system),
-            ('bundle', (self.bundle_name, 1))
+            ('bundle', (self.bundle_file_name, 1))
         ]
 
     def test_success(self):
@@ -99,7 +99,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
             'config.sh': 'echo configuring'
         })
 
-        resolve_bundle_mock = MagicMock(side_effect=[(self.bundle_name, self.bundle_file), ('config.zip', config_file)])
+        resolve_bundle_mock = MagicMock(side_effect=[(self.bundle_file_name, self.bundle_file), ('config.zip', config_file)])
         create_multipart_mock = MagicMock(return_value=self.multipart_mock)
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
@@ -169,7 +169,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
                             |roles      = [{}]
                             |""").format(self.memory, self.disk_space, ', '.join(self.roles)))
 
-        resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, bundle_file))
+        resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, bundle_file))
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
             args = self.default_args.copy()
             args.update({'bundle': bundle_file})
@@ -196,7 +196,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
                             |roles      = [{}]
                             |""").format(self.nr_of_cpus, self.disk_space, ', '.join(self.roles)))
 
-        resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, bundle_file))
+        resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, bundle_file))
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
             args = self.default_args.copy()
             args.update({'bundle': bundle_file})
@@ -223,7 +223,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
                             |roles      = [{}]
                             |""").format(self.nr_of_cpus, self.memory, ', '.join(self.roles)))
 
-        resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, bundle_file))
+        resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, bundle_file))
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
             args = self.default_args.copy()
             args.update({'bundle': bundle_file})
@@ -250,7 +250,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
                             |diskSpace  = {}
                             |""").format(self.nr_of_cpus, self.memory, self.disk_space))
 
-        resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, bundle_file))
+        resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, bundle_file))
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
             args = self.default_args.copy()
             args.update({'bundle': bundle_file})
@@ -278,7 +278,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
                             |roles      = {}
                             |""").format(self.nr_of_cpus, self.memory, self.disk_space, '-'.join(self.roles)))
 
-        resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, bundle_file))
+        resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, bundle_file))
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
             args = self.default_args.copy()
             args.update({'bundle': bundle_file})

--- a/conductr_cli/test/test_conduct_load_v2.py
+++ b/conductr_cli/test/test_conduct_load_v2.py
@@ -18,7 +18,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
         self.memory = 200
         self.disk_space = 100
         self.roles = ['web-server']
-        self.bundle_name = 'bundle.zip'
+        self.bundle_file_name = 'bundle.zip'
         self.system = 'bundle'
         self.system_version = '2.3'
         self.compatibility_version = '2.0'
@@ -38,7 +38,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
                                          self.memory,
                                          self.disk_space,
                                          ', '.join(self.roles),
-                                         self.bundle_name,
+                                         self.bundle_file_name,
                                          self.system,
                                          self.system_version,
                                          self.compatibility_version))
@@ -66,7 +66,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
 
         self.default_files = [
             ('bundleConf', ('bundle.conf', 'mock bundle.conf - string i/o')),
-            ('bundle', (self.bundle_name, 1))
+            ('bundle', (self.bundle_file_name, 1))
         ]
 
     def test_success(self):
@@ -147,7 +147,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
             'config.sh': 'echo configuring'
         })
 
-        resolve_bundle_mock = MagicMock(side_effect=[(self.bundle_name, self.bundle_file), ('config.zip', config_file)])
+        resolve_bundle_mock = MagicMock(side_effect=[(self.bundle_file_name, self.bundle_file), ('config.zip', config_file)])
         conf_mock = MagicMock(side_effect=['mock bundle.conf', 'mock bundle.conf overlay'])
         string_io_mock = MagicMock(side_effect=['mock bundle.conf - string i/o',
                                                 'mock bundle.conf overlay - string i/o'])
@@ -223,7 +223,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
             'config.sh': 'echo configuring'
         })
 
-        resolve_bundle_mock = MagicMock(side_effect=[(self.bundle_name, self.bundle_file), ('config.zip', config_file)])
+        resolve_bundle_mock = MagicMock(side_effect=[(self.bundle_file_name, self.bundle_file), ('config.zip', config_file)])
         conf_mock = MagicMock(side_effect=['mock bundle.conf', None])
         string_io_mock = MagicMock(return_value='mock bundle.conf - string i/o')
         create_multipart_mock = MagicMock(return_value=self.multipart_mock)
@@ -336,7 +336,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
         self.base_test_failure_no_file_url_error()
 
     def test_failure_no_bundle_conf(self):
-        resolve_bundle_mock = MagicMock(return_value=(self.bundle_name, self.bundle_file))
+        resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, self.bundle_file))
         conf_mock = MagicMock(return_value=None)
         stderr = MagicMock()
 

--- a/dcos/subcommand.py
+++ b/dcos/subcommand.py
@@ -391,6 +391,7 @@ def uninstall(package_name):
 
     return False
 
+
 BIN_DIRECTORY = 'Scripts' if util.is_windows_platform() else 'bin'
 
 

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ class Tox(test):
         errno = tox.cmdline(args=args)
         sys.exit(errno)
 
+
 setup(
     name='conductr-cli',
     version=__version__,


### PR DESCRIPTION
Cleanup will be based on the name and the compat version of the recently loaded bundle.

The following will be kept:
- The recently loaded bundle.
- The latest version of the bundle in the cache having the same name and compat version as the recently loaded bundle.

All other versions of the bundle having the same name and compat version will be removed.

The latest version is decided by the timestamp of the bundle file on the disk.