### PR TITLE
Change memory unit from MiB to GiB

### DIFF
--- a/conductr_cli/sandbox_init.py
+++ b/conductr_cli/sandbox_init.py
@@ -19,7 +19,7 @@ def init(args):
 
         if not has_sufficient_ram or not has_sufficient_cpu:
             if not has_sufficient_ram:
-                log.warning('Docker has insufficient RAM of {} MiB - please increase to a minimum of {} MiB'
+                log.warning('Docker has insufficient RAM of {} GiB - please increase to a minimum of {} GiB'
                             .format(existing_ram, docker.DEFAULT_DOCKER_RAM_SIZE))
 
             if not has_sufficient_cpu:
@@ -50,8 +50,8 @@ def init(args):
 
         if not has_sufficient_ram or not has_sufficient_cpu:
             if not has_sufficient_ram:
-                log.warning('Docker machine VM {} has insufficient RAM of {} MiB - '
-                            'increasing to the minimum of {} MiB'
+                log.warning('Docker machine VM {} has insufficient RAM of {} MB - '
+                            'increasing to the minimum of {} MB'
                             .format(docker_machine_vm_name,
                                     existing_ram,
                                     docker_machine.DEFAULT_DOCKER_MACHINE_RAM_SIZE))

--- a/conductr_cli/test/test_sandbox_init.py
+++ b/conductr_cli/test/test_sandbox_init.py
@@ -28,7 +28,7 @@ class TestSandboxInitCommand(CliTestCase):
 
         docker_info_mock.assert_called_with()
         self.assertEqual(
-            as_warn('Warning: Docker has insufficient RAM of 2.0 MiB - please increase to a minimum of 3.8 MiB\n'
+            as_warn('Warning: Docker has insufficient RAM of 2.0 GiB - please increase to a minimum of 3.8 GiB\n'
                     'Sandbox initialization has successfully finished\n'),
             self.output(stdout_mock))
 


### PR DESCRIPTION
The Docker native command prints out the dedicated memory in GiB. We have displayed it as MiB so far.

The Docker machine command prints out the dedicated memory in MB. We have displayed it as MiB.

The PR is changing MiB to GiB for the Docker native output, and MiB to MB for the Docker machine output.