### PR TITLE
Use command prefix when starting features

### DIFF
--- a/conductr_cli/conduct_main.py
+++ b/conductr_cli/conduct_main.py
@@ -321,22 +321,23 @@ def get_custom_settings(args):
 
 
 def run(_args=[]):
-    if not _args:
-        _args = sys.argv
     # If we're being invoked via DC/OS then route our http
     # calls via its extension to the requests library. In
-    # addition remove the dcos arg so that the conduct
+    # addition remove the 'conduct-dcos' and 'conduct' arg so that the conduct
     # sub-commands are positioned correctly, along with their
     # arguments.
-    if _args and Path(_args[0]).name == constants.DCOS_COMMAND_PREFIX + 'conduct':
-        _args = _args[1:]
+    if sys.argv and Path(sys.argv[0]).name == constants.DCOS_COMMAND_PREFIX + 'conduct':
         dcos_mode = True
+        _args = sys.argv[2:]
     else:
         dcos_mode = False
+        if not _args:
+            # Remove the 'conduct' arg so that we start with the sub command directly
+            _args = sys.argv[1:]
     # Parse arguments
     parser = build_parser(dcos_mode)
     argcomplete.autocomplete(parser)
-    args = parser.parse_args(_args[1:])
+    args = parser.parse_args(_args)
     args.dcos_mode = dcos_mode
     if not vars(args).get('func'):
         if vars(args).get('dcos_info'):


### PR DESCRIPTION
The `conduct_main.run` has arguments that can be used to tell it which `conduct` sub command it should run, e.g. `conduct info`.

This function is called in 3 different ways and they all prexi different number of command before the actual `conduct` sub command:
1. Programtically, from another python function: No prefix argument, e.g. `conduct info`
2. When the user submits a `conduct` command: 1 prefix argument, e.g. `/Users/mj/workspace/dcos-cli/cli/env/bin/conduct conduct info`
3. When the user submits a `dcos conduct` command: 2 prefix arguments, e.g. `/Users/mj/.dcos/subcommands/conductr/env/bin/dcos-conduct conduct info`

Before parsing the command, all prefix arguments need to be removed. The PR is fixing this logic. Prior to this, the first element of the `_args` array has been also removed if the function was called programatically (case 1)