### PR TITLE
Guard conditions

### DIFF
--- a/conductr_cli/host.py
+++ b/conductr_cli/host.py
@@ -6,7 +6,7 @@ from conductr_cli.docker import DockerVmType
 
 
 CONDUCTR_HOST = 'CONDUCTR_HOST'
-CONDUCTR_IP = 'CONDUCTR_HOST'
+CONDUCTR_IP = 'CONDUCTR_IP'
 
 
 def resolve_default_host():

--- a/conductr_cli/host.py
+++ b/conductr_cli/host.py
@@ -5,8 +5,12 @@ from subprocess import CalledProcessError
 from conductr_cli.docker import DockerVmType
 
 
+CONDUCTR_HOST = 'CONDUCTR_HOST'
+CONDUCTR_IP = 'CONDUCTR_HOST'
+
+
 def resolve_default_host():
-    return os.getenv('CONDUCTR_HOST', resolve_default_ip())
+    return os.getenv(CONDUCTR_HOST, resolve_default_ip())
 
 
 def resolve_default_ip():
@@ -14,7 +18,7 @@ def resolve_default_ip():
         vm_type = docker.vm_type()
         return resolve_ip_by_vm_type(vm_type)
 
-    return os.getenv('CONDUCTR_IP', resolve())
+    return os.getenv(CONDUCTR_IP, resolve())
 
 
 def resolve_ip_by_vm_type(vm_type):

--- a/conductr_cli/main_handler.py
+++ b/conductr_cli/main_handler.py
@@ -4,8 +4,13 @@ import os
 import sys
 
 
+# Needs to be Python 3.4 or above
+SUPPORTED_PYTHON_VERSION = (3, 4)
+
+
 def run(callback):
     try:
+        enforce_python_version()
         result = callback()
         return result
     except KeyboardInterrupt:
@@ -39,3 +44,13 @@ def run(callback):
         exception_log.error('Failure running the following command: {}'.format(sys.argv), exc_info=True)
 
         sys.exit(1)
+
+
+def enforce_python_version():
+    if sys.version_info < SUPPORTED_PYTHON_VERSION:
+        major, minor, micro, release_level, serial = sys.version_info
+        supported_major_version, supported_minor_version = SUPPORTED_PYTHON_VERSION
+        sys.exit('Unable to start CLI.\n'
+                 'Current python version is {}.{}.{}\n'
+                 'Please use python version {}.{} and above.'.format(major, minor, micro,
+                                                                     supported_major_version, supported_minor_version))

--- a/conductr_cli/test/test_host.py
+++ b/conductr_cli/test/test_host.py
@@ -1,0 +1,96 @@
+from unittest import TestCase
+from conductr_cli import host
+from conductr_cli.docker import DockerVmType
+from conductr_cli.exceptions import DockerMachineNotRunningError
+
+try:
+    from unittest.mock import patch, MagicMock  # 3.3 and beyond
+except ImportError:
+    from mock import patch, MagicMock
+
+
+class TestResolveDefaultHost(TestCase):
+    def test_resolve(self):
+        getenv_mock = MagicMock(return_value='test')
+        resolve_default_ip_mock = MagicMock(return_value='resolve_result')
+        with patch('os.getenv', getenv_mock), \
+                patch('conductr_cli.host.resolve_default_ip', resolve_default_ip_mock):
+            result = host.resolve_default_host()
+            self.assertEqual(result, 'test')
+
+        getenv_mock.assert_called_with('CONDUCTR_HOST', 'resolve_result')
+
+
+class TestResolveDefaultIp(TestCase):
+    def test_resolve(self):
+        getenv_mock = MagicMock(return_value='test')
+        vm_type_mock = MagicMock(return_value='vm_type')
+        resolve_ip_by_vm_type_mock = MagicMock(return_value='resolve_result')
+        with patch('os.getenv', getenv_mock), \
+                patch('conductr_cli.docker.vm_type', vm_type_mock), \
+                patch('conductr_cli.host.resolve_ip_by_vm_type', resolve_ip_by_vm_type_mock):
+            result = host.resolve_default_ip()
+            self.assertEqual(result, 'test')
+
+        getenv_mock.assert_called_with('CONDUCTR_IP', 'resolve_result')
+        vm_type_mock.assert_called_with()
+        resolve_ip_by_vm_type_mock.assert_called_with('vm_type')
+
+
+class TestResolveIpByVmType(TestCase):
+    def test_vm_type_none(self):
+        with_docker_machine_mock = MagicMock(return_value='result')
+        with patch('conductr_cli.host.with_docker_machine', with_docker_machine_mock):
+            result = host.resolve_ip_by_vm_type(DockerVmType.NONE)
+            self.assertEqual(result, '127.0.0.1')
+
+        with_docker_machine_mock.assert_not_called()
+
+    def test_vm_type_docker_engine(self):
+        with_docker_machine_mock = MagicMock(return_value='result')
+        with patch('conductr_cli.host.with_docker_machine', with_docker_machine_mock):
+            result = host.resolve_ip_by_vm_type(DockerVmType.DOCKER_ENGINE)
+            self.assertEqual(result, '127.0.0.1')
+
+        with_docker_machine_mock.assert_not_called()
+
+    def test_vm_type_docker_machine(self):
+        with_docker_machine_mock = MagicMock(return_value='result')
+        with patch('conductr_cli.host.with_docker_machine', with_docker_machine_mock):
+            result = host.resolve_ip_by_vm_type(DockerVmType.DOCKER_MACHINE)
+            self.assertEqual(result, 'result')
+
+        with_docker_machine_mock.assert_called_with()
+
+
+class TestWithDockerMachine(TestCase):
+    def test_success(self):
+        vm_name_mock = MagicMock(return_value='vm_name')
+        docker_machine_ip_mock = MagicMock(return_value='docker ip')
+        with patch('conductr_cli.docker_machine.vm_name', vm_name_mock), \
+                patch('conductr_cli.terminal.docker_machine_ip', docker_machine_ip_mock):
+            result = host.with_docker_machine()
+            self.assertEqual(result, 'docker ip')
+
+        vm_name_mock.assert_called_with()
+        docker_machine_ip_mock.assert_called_with('vm_name')
+
+    def test_docker_machine_not_running(self):
+        vm_name_mock = MagicMock(return_value='vm_name')
+        docker_machine_ip_mock = MagicMock(return_value='')
+        with patch('conductr_cli.docker_machine.vm_name', vm_name_mock), \
+                patch('conductr_cli.terminal.docker_machine_ip', docker_machine_ip_mock):
+            host.with_docker_machine()
+
+        vm_name_mock.assert_called_with()
+        docker_machine_ip_mock.assert_called_with('vm_name')
+
+    def test_called_process_error(self):
+        vm_name_mock = MagicMock(return_value='vm_name')
+        docker_machine_ip_mock = MagicMock(side_effect=DockerMachineNotRunningError('test only'))
+        with patch('conductr_cli.docker_machine.vm_name', vm_name_mock), \
+                patch('conductr_cli.terminal.docker_machine_ip', docker_machine_ip_mock):
+            host.with_docker_machine()
+
+        vm_name_mock.assert_called_with()
+        docker_machine_ip_mock.assert_called_with('vm_name')


### PR DESCRIPTION
- [x] Display error message if `CONDUCTR_HOST` or `CONDUCTR_IP` is specified as empty.
- [x] Fail if CLI is being invoked with unsupported Python version