### PR TITLE
Ensure status check for `conduct load` and `conduct run` is performed at correct intervals

### DIFF
--- a/conductr_cli/conduct_main.py
+++ b/conductr_cli/conduct_main.py
@@ -323,7 +323,7 @@ def get_custom_settings(args):
         return None
 
 
-def run(_args=[]):
+def run(_args=[], configure_logging=True):
     # If we're being invoked via DC/OS then route our http
     # calls via its extension to the requests library. In
     # addition remove the 'conduct-dcos' and 'conduct' arg so that the conduct
@@ -388,7 +388,8 @@ def run(_args=[]):
             args.cli_parameters = get_cli_parameters(args)
             args.custom_settings = get_custom_settings(args)
 
-        logging_setup.configure_logging(args)
+        if configure_logging:
+            logging_setup.configure_logging(args)
 
         is_completed_without_error = args.func(args)
         if not is_completed_without_error:

--- a/conductr_cli/sandbox_features.py
+++ b/conductr_cli/sandbox_features.py
@@ -69,8 +69,8 @@ class MonitoringFeature:
         log.info('Starting monitoring feature...')
         grafana = self.grafana_bundle()
         log.info('Running %s...' % grafana['bundle'])
-        conduct_main.run(['load', grafana['bundle']])
-        conduct_main.run(['run', grafana['name']])
+        conduct_main.run(['load', grafana['bundle']], configure_logging=False)
+        conduct_main.run(['run', grafana['name']], configure_logging=False)
 
     def grafana_bundle(self):
         bundle_name = 'cinnamon-grafana'


### PR DESCRIPTION
- Replace `print` statements with Python's logging in `sandbox run` and `conduct load` commands.
- Ensure logging is initialized only once when feature is started as part of `sandbox run` - this will prevent multiple progress bar to displayed despite a single conduct load.