### PR TITLE
Use requests library >= 2.6.0 and < 2.12.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools.command.test import test
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 install_requires = [
-    'requests>=2.6.0',
+    'requests>=2.6.0, <2.12.0',
     'requests-toolbelt>=0.7.0',
     'argcomplete>=0.8.1',
     'pyhocon==0.2.1',


### PR DESCRIPTION
This is because the requests library `2.12.0` ships with the version of urllib which is not backward compatible shipped with prior release of requests `2.11.1` and below.