### PR TITLE
Revert requests issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ install:
   - pip install tox
 script:
   - tox
-before_deploy: "pip install requests==2.11.1"
 deploy:
   provider: pypi
   user: typesafehub

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,10 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 install_requires = [
     'requests>=2.6.0, <2.12.0',
-    'requests-toolbelt==0.7.0',
-    'argcomplete>=0.8.1, <=1.6.0',
+    'requests-toolbelt>=0.7.0',
+    'argcomplete>=0.8.1',
     'pyhocon==0.2.1',
-    'arrow>=0.6.0, <=0.8.0',
+    'arrow>=0.6.0',
 
     # FIXME: Remove the following dependencies when dcos can be depended on
     'jsonschema==2.4',  # pin the exact version, jsonschema 2.5 broke py3

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools.command.test import test
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 install_requires = [
-    'requests>=2.6.0, <2.12.0',
+    'requests>=2.6.0',
     'requests-toolbelt>=0.7.0',
     'argcomplete>=0.8.1',
     'pyhocon==0.2.1',


### PR DESCRIPTION
The requests vendor has just release 2.12.1 which fixes up the problem we had - however we must now revert the upper bound check as our CLI can’t make use of it.

