### PR TITLE
Resolve bundle configuration from a separate repository

### DIFF
--- a/conductr_cli/bundle_shorthand.py
+++ b/conductr_cli/bundle_shorthand.py
@@ -2,12 +2,20 @@ from conductr_cli.exceptions import MalformedBundleUriError
 
 
 DEFAULT_ORG = 'typesafe'
-DEFAULT_REPO = 'bundle'
+DEFAULT_REPO_BUNDLE = 'bundle'
+DEFAULT_REPO_BUNDLE_CONFIGURATION = 'bundle-configuration'
 
 
-def parse(uri):
+def parse_bundle(uri):
     urn, rest = split_to_urn_and_rest(uri)
-    org, repo, package = split_to_org_repo_package(rest)
+    org, repo, package = split_to_org_repo_package(rest, default_repo=DEFAULT_REPO_BUNDLE)
+    package_name, compatiblity_version, digest = split_package_to_parts(package)
+    return urn, org, repo, package_name, compatiblity_version, digest
+
+
+def parse_bundle_configuration(uri):
+    urn, rest = split_to_urn_and_rest(uri)
+    org, repo, package = split_to_org_repo_package(rest, default_repo=DEFAULT_REPO_BUNDLE_CONFIGURATION)
     package_name, compatiblity_version, digest = split_package_to_parts(package)
     return urn, org, repo, package_name, compatiblity_version, digest
 
@@ -22,14 +30,14 @@ def split_to_urn_and_rest(uri):
         return 'urn:x-bundle:', uri
 
 
-def split_to_org_repo_package(uri):
+def split_to_org_repo_package(uri, default_repo):
     parts = uri.split('/')
     if len(parts) == 3:
         return parts
     elif len(parts) == 2:
         return DEFAULT_ORG, parts[0], parts[1]
     elif len(parts) == 1:
-        return DEFAULT_ORG, DEFAULT_REPO, parts[0]
+        return DEFAULT_ORG, default_repo, parts[0]
     else:
         raise MalformedBundleUriError('{} is not a valid bundle uri'.format(uri))
 

--- a/conductr_cli/conduct_load.py
+++ b/conductr_cli/conduct_load.py
@@ -51,8 +51,9 @@ def load_v1(args):
     configuration_file_name, configuration_file = (None, None)
     if args.configuration is not None:
         log.info('Retrieving configuration...')
-        configuration_file_name, configuration_file = resolver.resolve_bundle(custom_settings, resolve_cache_dir,
-                                                                              args.configuration)
+        configuration_file_name, configuration_file = resolver.resolve_bundle_configuration(custom_settings,
+                                                                                            resolve_cache_dir,
+                                                                                            args.configuration)
 
     bundle_conf = ConfigFactory.parse_string(bundle_utils.conf(bundle_file))
     overlay_bundle_conf = None if configuration_file is None else \
@@ -154,8 +155,9 @@ def load_v2(args):
         configuration_file_name, configuration_file, bundle_conf_overlay = (None, None, None)
         if args.configuration is not None:
             log.info('Retrieving configuration...')
-            configuration_file_name, configuration_file = resolver.resolve_bundle(custom_settings, resolve_cache_dir,
-                                                                                  args.configuration)
+            configuration_file_name, configuration_file = resolver.resolve_bundle_configuration(custom_settings,
+                                                                                                resolve_cache_dir,
+                                                                                                args.configuration)
             bundle_conf_overlay = bundle_utils.conf(configuration_file)
 
         files = [('bundleConf', ('bundle.conf', string_io(bundle_conf)))]

--- a/conductr_cli/resolver.py
+++ b/conductr_cli/resolver.py
@@ -12,14 +12,32 @@ def resolve_bundle(custom_settings, cache_dir, uri):
     all_resolvers = resolver_chain(custom_settings)
 
     for resolver in all_resolvers:
-        is_cached, bundle_name, cached_bundle = resolver.load_from_cache(cache_dir, uri)
+        is_cached, bundle_file_name, cached_bundle = resolver.load_bundle_from_cache(cache_dir, uri)
         if is_cached:
-            return bundle_name, cached_bundle
+            return bundle_file_name, cached_bundle
 
     for resolver in all_resolvers:
-        is_resolved, bundle_name, bundle_file = resolver.resolve_bundle(cache_dir, uri)
+        is_resolved, bundle_file_name, bundle_file = resolver.resolve_bundle(cache_dir, uri)
         if is_resolved:
-            return bundle_name, bundle_file
+            return bundle_file_name, bundle_file
+
+    raise BundleResolutionError('Unable to resolve bundle using {}'.format(uri))
+
+
+def resolve_bundle_configuration(custom_settings, cache_dir, uri):
+    all_resolvers = resolver_chain(custom_settings)
+
+    for resolver in all_resolvers:
+        is_cached, bundle_configuration_file_name, cached_bundle = \
+            resolver.load_bundle_configuration_from_cache(cache_dir, uri)
+        if is_cached:
+            return bundle_configuration_file_name, cached_bundle
+
+    for resolver in all_resolvers:
+        is_resolved, bundle_configuration_file_name, bundle_configuration_file = \
+            resolver.resolve_bundle_configuration(cache_dir, uri)
+        if is_resolved:
+            return bundle_configuration_file_name, bundle_configuration_file
 
     raise BundleResolutionError('Unable to resolve bundle using {}'.format(uri))
 

--- a/conductr_cli/resolvers/uri_resolver.py
+++ b/conductr_cli/resolvers/uri_resolver.py
@@ -33,7 +33,7 @@ def resolve_bundle(cache_dir, uri, auth=None):
         return False, None, None
 
 
-def load_from_cache(cache_dir, uri):
+def load_bundle_from_cache(cache_dir, uri):
     # When the supplied uri is a local filesystem, don't load from cache so file can be used as is
     parsed = urlparse(uri, scheme='file')
     if parsed.scheme == 'file':
@@ -48,6 +48,14 @@ def load_from_cache(cache_dir, uri):
             return True, bundle_name, cached_file
         else:
             return False, None, None
+
+
+def resolve_bundle_configuration(cache_dir, uri, auth=None):
+    return resolve_bundle(cache_dir, uri, auth)
+
+
+def load_bundle_configuration_from_cache(cache_dir, uri):
+    return load_bundle_from_cache(cache_dir, uri)
 
 
 def get_url(uri):

--- a/conductr_cli/test/test_bundle_shorthand.py
+++ b/conductr_cli/test/test_bundle_shorthand.py
@@ -3,13 +3,13 @@ from conductr_cli import bundle_shorthand
 from conductr_cli.exceptions import MalformedBundleUriError
 
 
-class TestParse(TestCase):
+class TestParseBundle(TestCase):
     def test_full_address(self):
         uri = 'urn:x-bundle:typesafe/bundle/reactive-maps-frontend:v1-023f9da22'
         expected_result = ('urn:x-bundle:',
                            'typesafe', 'bundle', 'reactive-maps-frontend',
                            'v1', '023f9da22')
-        result = bundle_shorthand.parse(uri)
+        result = bundle_shorthand.parse_bundle(uri)
         self.assertEqual(expected_result, result)
 
     def test_no_urn(self):
@@ -17,7 +17,7 @@ class TestParse(TestCase):
         expected_result = ('urn:x-bundle:',
                            'typesafe', 'bundle', 'reactive-maps-frontend',
                            'v1', '023f9da22')
-        result = bundle_shorthand.parse(uri)
+        result = bundle_shorthand.parse_bundle(uri)
         self.assertEqual(expected_result, result)
 
     def test_no_org(self):
@@ -25,7 +25,7 @@ class TestParse(TestCase):
         expected_result = ('urn:x-bundle:',
                            'typesafe', 'bundle', 'reactive-maps-frontend',
                            'v1', '023f9da22')
-        result = bundle_shorthand.parse(uri)
+        result = bundle_shorthand.parse_bundle(uri)
         self.assertEqual(expected_result, result)
 
     def test_no_repos(self):
@@ -33,35 +33,99 @@ class TestParse(TestCase):
         expected_result = ('urn:x-bundle:',
                            'typesafe', 'bundle', 'reactive-maps-frontend',
                            'v1', '023f9da22')
-        result = bundle_shorthand.parse(uri)
+        result = bundle_shorthand.parse_bundle(uri)
         self.assertEqual(expected_result, result)
 
     def test_no_digest(self):
         uri = 'reactive-maps-frontend:v1'
         expected_result = ('urn:x-bundle:', 'typesafe', 'bundle', 'reactive-maps-frontend', 'v1', None)
-        result = bundle_shorthand.parse(uri)
+        result = bundle_shorthand.parse_bundle(uri)
         self.assertEqual(expected_result, result)
 
     def test_bundle_name_only(self):
         uri = 'reactive-maps-frontend'
         expected_result = ('urn:x-bundle:', 'typesafe', 'bundle', 'reactive-maps-frontend', None, None)
-        result = bundle_shorthand.parse(uri)
+        result = bundle_shorthand.parse_bundle(uri)
         self.assertEqual(expected_result, result)
 
 
-class TestParseWithMalformedExpression(TestCase):
+class TestParseBundleWithMalformedExpression(TestCase):
     def test_unsupported_urn(self):
         uri = 'urn:x-bananas:typesafe/bundle/reactive-maps-frontend:v1-023f9da22'
-        self.assertRaises(MalformedBundleUriError, bundle_shorthand.parse, uri)
+        self.assertRaises(MalformedBundleUriError, bundle_shorthand.parse_bundle, uri)
 
     def test_invalid_parts(self):
         uri = 'urn:x-bundle:typesafe/bundle/this/is/not/a/valid/path/reactive-maps-frontend:v1-023f9da22'
-        self.assertRaises(MalformedBundleUriError, bundle_shorthand.parse, uri)
+        self.assertRaises(MalformedBundleUriError, bundle_shorthand.parse_bundle, uri)
 
     def test_file_path_should_be_invalid(self):
         uri = '/home/user/workspace/my-project/target/bundle/my-project-v1-023f9da22.zip'
-        self.assertRaises(MalformedBundleUriError, bundle_shorthand.parse, uri)
+        self.assertRaises(MalformedBundleUriError, bundle_shorthand.parse_bundle, uri)
 
     def test_http_url_should_be_invalid(self):
         uri = 'http://some-url.com/dist/bundle/my-project-v1-023f9da22.zip'
-        self.assertRaises(MalformedBundleUriError, bundle_shorthand.parse, uri)
+        self.assertRaises(MalformedBundleUriError, bundle_shorthand.parse_bundle, uri)
+
+
+class TestParseBundleConfiguration(TestCase):
+    def test_full_address(self):
+        uri = 'urn:x-bundle:typesafe/bundle-configuration/conductr-haproxy-dev-mode:v1-023f9da22'
+        expected_result = ('urn:x-bundle:',
+                           'typesafe', 'bundle-configuration', 'conductr-haproxy-dev-mode',
+                           'v1', '023f9da22')
+        result = bundle_shorthand.parse_bundle_configuration(uri)
+        self.assertEqual(expected_result, result)
+
+    def test_no_urn(self):
+        uri = 'typesafe/bundle-configuration/conductr-haproxy-dev-mode:v1-023f9da22'
+        expected_result = ('urn:x-bundle:',
+                           'typesafe', 'bundle-configuration', 'conductr-haproxy-dev-mode',
+                           'v1', '023f9da22')
+        result = bundle_shorthand.parse_bundle_configuration(uri)
+        self.assertEqual(expected_result, result)
+
+    def test_no_org(self):
+        uri = 'bundle-configuration/conductr-haproxy-dev-mode:v1-023f9da22'
+        expected_result = ('urn:x-bundle:',
+                           'typesafe', 'bundle-configuration', 'conductr-haproxy-dev-mode',
+                           'v1', '023f9da22')
+        result = bundle_shorthand.parse_bundle_configuration(uri)
+        self.assertEqual(expected_result, result)
+
+    def test_no_repos(self):
+        uri = 'conductr-haproxy-dev-mode:v1-023f9da22'
+        expected_result = ('urn:x-bundle:',
+                           'typesafe', 'bundle-configuration', 'conductr-haproxy-dev-mode',
+                           'v1', '023f9da22')
+        result = bundle_shorthand.parse_bundle_configuration(uri)
+        self.assertEqual(expected_result, result)
+
+    def test_no_digest(self):
+        uri = 'conductr-haproxy-dev-mode:v1'
+        expected_result = ('urn:x-bundle:', 'typesafe', 'bundle-configuration', 'conductr-haproxy-dev-mode', 'v1', None)
+        result = bundle_shorthand.parse_bundle_configuration(uri)
+        self.assertEqual(expected_result, result)
+
+    def test_bundle_name_only(self):
+        uri = 'conductr-haproxy-dev-mode'
+        expected_result = ('urn:x-bundle:', 'typesafe', 'bundle-configuration', 'conductr-haproxy-dev-mode', None, None)
+        result = bundle_shorthand.parse_bundle_configuration(uri)
+        self.assertEqual(expected_result, result)
+
+
+class TestParseBundleConfigurationWithMalformedExpression(TestCase):
+    def test_unsupported_urn(self):
+        uri = 'urn:x-bananas:typesafe/bundle-configuration/conductr-haproxy-dev-mode:v1-023f9da22'
+        self.assertRaises(MalformedBundleUriError, bundle_shorthand.parse_bundle_configuration, uri)
+
+    def test_invalid_parts(self):
+        uri = 'urn:x-bundle:typesafe/bundle-configuration/this/is/not/a/valid/path/conductr-haproxy-dev-mode:v1-023f9da22'
+        self.assertRaises(MalformedBundleUriError, bundle_shorthand.parse_bundle_configuration, uri)
+
+    def test_file_path_should_be_invalid(self):
+        uri = '/home/user/workspace/my-project/target/configuration/my-project-v1-023f9da22.zip'
+        self.assertRaises(MalformedBundleUriError, bundle_shorthand.parse_bundle_configuration, uri)
+
+    def test_http_url_should_be_invalid(self):
+        uri = 'http://some-url.com/dist/bundle-configuration/my-project-v1-023f9da22.zip'
+        self.assertRaises(MalformedBundleUriError, bundle_shorthand.parse_bundle_configuration, uri)

--- a/conductr_cli/test/test_conduct_load_v2.py
+++ b/conductr_cli/test/test_conduct_load_v2.py
@@ -147,7 +147,8 @@ class TestConductLoadCommand(ConductLoadTestBase):
             'config.sh': 'echo configuring'
         })
 
-        resolve_bundle_mock = MagicMock(side_effect=[(self.bundle_file_name, self.bundle_file), ('config.zip', config_file)])
+        resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, self.bundle_file))
+        resolve_bundle_configuration_mock = MagicMock(return_value=('config.zip', config_file))
         conf_mock = MagicMock(side_effect=['mock bundle.conf', 'mock bundle.conf overlay'])
         string_io_mock = MagicMock(side_effect=['mock bundle.conf - string i/o',
                                                 'mock bundle.conf overlay - string i/o'])
@@ -162,6 +163,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
         input_args = MagicMock(**args)
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
+                patch('conductr_cli.resolver.resolve_bundle_configuration', resolve_bundle_configuration_mock), \
                 patch('conductr_cli.bundle_utils.conf', conf_mock), \
                 patch('conductr_cli.conduct_load.string_io', string_io_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
@@ -172,14 +174,9 @@ class TestConductLoadCommand(ConductLoadTestBase):
             result = conduct_load.load(input_args)
             self.assertTrue(result)
 
-        self.assertEqual(
-            resolve_bundle_mock.call_args_list,
-            [
-                call(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file),
-                call(self.custom_settings, self.bundle_resolve_cache_dir, config_file)
-            ]
-        )
-
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
+        resolve_bundle_configuration_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
+                                                             config_file)
         self.assertEqual(
             conf_mock.call_args_list,
             [
@@ -223,7 +220,8 @@ class TestConductLoadCommand(ConductLoadTestBase):
             'config.sh': 'echo configuring'
         })
 
-        resolve_bundle_mock = MagicMock(side_effect=[(self.bundle_file_name, self.bundle_file), ('config.zip', config_file)])
+        resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, self.bundle_file))
+        resolve_bundle_configuration_mock = MagicMock(return_value=('config.zip', config_file))
         conf_mock = MagicMock(side_effect=['mock bundle.conf', None])
         string_io_mock = MagicMock(return_value='mock bundle.conf - string i/o')
         create_multipart_mock = MagicMock(return_value=self.multipart_mock)
@@ -238,6 +236,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
         input_args = MagicMock(**args)
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
+                patch('conductr_cli.resolver.resolve_bundle_configuration', resolve_bundle_configuration_mock), \
                 patch('conductr_cli.bundle_utils.conf', conf_mock), \
                 patch('conductr_cli.conduct_load.string_io', string_io_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
@@ -248,13 +247,9 @@ class TestConductLoadCommand(ConductLoadTestBase):
             result = conduct_load.load(input_args)
             self.assertTrue(result)
 
-        self.assertEqual(
-            resolve_bundle_mock.call_args_list,
-            [
-                call(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file),
-                call(self.custom_settings, self.bundle_resolve_cache_dir, config_file)
-            ]
-        )
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
+        resolve_bundle_configuration_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
+                                                             config_file)
 
         self.assertEqual(
             conf_mock.call_args_list,

--- a/conductr_cli/test/test_resolver.py
+++ b/conductr_cli/test/test_resolver.py
@@ -12,15 +12,16 @@ except ImportError:
 
 
 class TestResolver(TestCase):
+
     def test_resolve_bundle_success(self):
         custom_settings = Mock()
 
         first_resolver_mock = Mock()
-        first_resolver_mock.load_from_cache = MagicMock(return_value=(False, None, None))
+        first_resolver_mock.load_bundle_from_cache = MagicMock(return_value=(False, None, None))
         first_resolver_mock.resolve_bundle = MagicMock(return_value=(False, None, None))
 
         second_resolver_mock = Mock()
-        second_resolver_mock.load_from_cache = MagicMock(return_value=(False, None, None))
+        second_resolver_mock.load_bundle_from_cache = MagicMock(return_value=(False, None, None))
         second_resolver_mock.resolve_bundle = MagicMock(return_value=(True, 'bundle_name', 'mock bundle_file'))
 
         resolver_chain_mock = MagicMock(return_value=[first_resolver_mock, second_resolver_mock])
@@ -42,7 +43,7 @@ class TestResolver(TestCase):
         custom_settings = Mock()
 
         first_resolver_mock = Mock()
-        first_resolver_mock.load_from_cache = MagicMock(return_value=(False, None, None))
+        first_resolver_mock.load_bundle_from_cache = MagicMock(return_value=(False, None, None))
         first_resolver_mock.resolve_bundle = MagicMock(return_value=(False, None, None))
 
         resolver_chain_mock = MagicMock(return_value=[first_resolver_mock])
@@ -59,7 +60,7 @@ class TestResolver(TestCase):
         custom_settings = Mock()
 
         first_resolver_mock = Mock()
-        first_resolver_mock.load_from_cache = MagicMock(return_value=(True, 'bundle_name', 'mock bundle_file'))
+        first_resolver_mock.load_bundle_from_cache = MagicMock(return_value=(True, 'bundle_name', 'mock bundle_file'))
 
         resolver_chain_mock = MagicMock(return_value=[first_resolver_mock])
         with patch('conductr_cli.resolver.resolver_chain', resolver_chain_mock):
@@ -71,6 +72,69 @@ class TestResolver(TestCase):
         resolver_chain_mock.assert_called_with(custom_settings)
 
         first_resolver_mock.load_from_cache('/some-cache-dir', '/some-bundle-path')
+
+    def test_resolve_bundle_configuration_success(self):
+        custom_settings = Mock()
+
+        first_resolver_mock = Mock()
+        first_resolver_mock.load_bundle_configuration_from_cache = MagicMock(return_value=(False, None, None))
+        first_resolver_mock.resolve_bundle_configuration = MagicMock(return_value=(False, None, None))
+
+        second_resolver_mock = Mock()
+        second_resolver_mock.load_bundle_configuration_from_cache = MagicMock(return_value=(False, None, None))
+        second_resolver_mock.resolve_bundle_configuration = MagicMock(return_value=(True, 'bundle_name',
+                                                                                    'mock bundle_file'))
+
+        resolver_chain_mock = MagicMock(return_value=[first_resolver_mock, second_resolver_mock])
+
+        with patch('conductr_cli.resolver.resolver_chain', resolver_chain_mock):
+            bundle_name, bundle_file = resolver.resolve_bundle_configuration(
+                custom_settings, '/some-cache-dir', '/some-bundle-path')
+            self.assertEqual('bundle_name', bundle_name)
+            self.assertEqual('mock bundle_file', bundle_file)
+
+        resolver_chain_mock.assert_called_with(custom_settings)
+
+        first_resolver_mock.load_bundle_configuration_from_cache('/some-cache-dir', '/some-bundle-path')
+        first_resolver_mock.resolve_bundle_configuration.assert_called_with('/some-cache-dir', '/some-bundle-path')
+
+        second_resolver_mock.load_bundle_configuration_from_cache('/some-cache-dir', '/some-bundle-path')
+        second_resolver_mock.resolve_bundle_configuration.assert_called_with('/some-cache-dir', '/some-bundle-path')
+
+    def test_resolve_bundle_configuration_failure(self):
+        custom_settings = Mock()
+
+        first_resolver_mock = Mock()
+        first_resolver_mock.load_bundle_configuration_from_cache = MagicMock(return_value=(False, None, None))
+        first_resolver_mock.resolve_bundle_configuration = MagicMock(return_value=(False, None, None))
+
+        resolver_chain_mock = MagicMock(return_value=[first_resolver_mock])
+        with patch('conductr_cli.resolver.resolver_chain', resolver_chain_mock):
+            self.assertRaises(BundleResolutionError, resolver.resolve_bundle_configuration, custom_settings,
+                              '/some-cache-dir', '/some-bundle-path')
+
+        resolver_chain_mock.assert_called_with(custom_settings)
+
+        first_resolver_mock.load_bundle_configuration_from_cache('/some-cache-dir', '/some-bundle-path')
+        first_resolver_mock.resolve_bundle_configuration.assert_called_with('/some-cache-dir', '/some-bundle-path')
+
+    def test_resolve_bundle_configuration_from_cache(self):
+        custom_settings = Mock()
+
+        first_resolver_mock = Mock()
+        first_resolver_mock.load_bundle_configuration_from_cache = MagicMock(return_value=(True, 'bundle_name',
+                                                                                           'mock bundle_file'))
+
+        resolver_chain_mock = MagicMock(return_value=[first_resolver_mock])
+        with patch('conductr_cli.resolver.resolver_chain', resolver_chain_mock):
+            bundle_name, bundle_file = resolver.resolve_bundle_configuration(custom_settings, '/some-cache-dir',
+                                                                             '/some-bundle-path')
+            self.assertEqual('bundle_name', bundle_name)
+            self.assertEqual('mock bundle_file', bundle_file)
+
+        resolver_chain_mock.assert_called_with(custom_settings)
+
+        first_resolver_mock.load_bundle_configuration_from_cache('/some-cache-dir', '/some-bundle-path')
 
 
 class TestResolverChain(TestCase):


### PR DESCRIPTION
Modify the resolvers such that:
- Bundles are resolved from `bundle` repository
- Bundle configurations are resolved from `bundle-configuration` repository

As such the resolver now provides separate method to resolve bundle and bundle configuration.