### PR TITLE
Display ansi colors on Windows correctly

### DIFF
--- a/conductr_cli/ansi_colors.py
+++ b/conductr_cli/ansi_colors.py
@@ -1,4 +1,9 @@
-RED = '\033[91m'
-YELLOW = '\033[93m'
+import colorama
+from colorama import Fore
+
+colorama.init()
+
+RED = Fore.RED
+YELLOW = Fore.YELLOW
 UNDERLINE = '\033[4m'
 ENDC = '\033[0m'

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ install_requires = [
     'requests-toolbelt>=0.7.0',
     'argcomplete>=0.8.1',
     'pyhocon==0.2.1',
-    'arrow>=0.6.0',
+    'arrow>=0.6.0'
+    'colorama>=0.3.7',
 
     # FIXME: Remove the following dependencies when dcos can be depended on
     'jsonschema==2.4',  # pin the exact version, jsonschema 2.5 broke py3

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires = [
     'requests-toolbelt>=0.7.0',
     'argcomplete>=0.8.1',
     'pyhocon==0.2.1',
-    'arrow>=0.6.0'
+    'arrow>=0.6.0',
     'colorama>=0.3.7',
 
     # FIXME: Remove the following dependencies when dcos can be depended on


### PR DESCRIPTION
The conductr-cli uses ansi colors to color code warning and error output. Ansi colors do not work on Windows :-(

This PR adds ansi color support to Windows by using the [colorama](https://pypi.python.org/pypi/colorama) library.

Tested on Windows and macOS.