### PR TITLE
Increase sandbox run timeout to 60 seconds

### DIFF
--- a/conductr_cli/sandbox_run.py
+++ b/conductr_cli/sandbox_run.py
@@ -10,9 +10,9 @@ import os
 import time
 
 
-# Will retry 30 times, every second
+# Will retry 30 times, every two seconds
 DEFAULT_WAIT_RETRIES = 30
-DEFAULT_WAIT_RETRY_INTERVAL = 1.0
+DEFAULT_WAIT_RETRY_INTERVAL = 2.0
 
 
 # Arguments for conduct requests, such as waiting for ConductR to start in the sandbox


### PR DESCRIPTION
Some users ran into the default `sandbox run` timeout of 30 seconds. Especially when running the sandbox inside a VM, such as VirtualBox, this can occur.

Therefore, we increase the default timeout to 60 seconds.