### PR TITLE
RST validation of README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 |build_status| |latest_version|
 
 Command Line Interface (CLI) for Lightbend ConductR
---------------------------------------------------
+---------------------------------------------------
 
 Installation
 ~~~~~~~~~~~~

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34, py35, flake8
+envlist = py34, py35, flake8, rstcheck
 
 [testenv]
 deps = pytest
@@ -10,3 +10,7 @@ deps =
   flake8
   pep8-naming
 commands = flake8 --ignore=E501 .
+
+[testenv:rstcheck]
+deps = rstcheck
+commands = rstcheck {toxinidir}/README.rst


### PR DESCRIPTION
Adding RST validation during tox and CI testing to ensure that the `README.rst` is rendered correctly on Github and PyPi.

Also, correcting the format of the current `README.rst` to fix the render issue on PyPi.