### PR TITLE
Output docker stats

### DIFF
--- a/conductr_cli/conduct_load.py
+++ b/conductr_cli/conduct_load.py
@@ -40,7 +40,7 @@ def load(args):
 def load_v1(args):
     log = logging.getLogger(__name__)
 
-    log.info('Retrieving bundle...')
+    log.info('Retrieving bundle..')
     custom_settings = args.custom_settings
     resolve_cache_dir = args.resolve_cache_dir
 
@@ -50,7 +50,7 @@ def load_v1(args):
 
     configuration_file_name, configuration_file = (None, None)
     if args.configuration is not None:
-        log.info('Retrieving configuration...')
+        log.info('Retrieving configuration..')
         configuration_file_name, configuration_file = resolver.resolve_bundle_configuration(custom_settings,
                                                                                             resolve_cache_dir,
                                                                                             args.configuration)
@@ -73,7 +73,7 @@ def load_v1(args):
     # if configuration_file and os.path.exists(configuration_file):
     #    os.remove(configuration_file)
 
-    log.info('Loading bundle to ConductR...')
+    log.info('Loading bundle to ConductR..')
     multipart = create_multipart(log, files)
     response = conduct_request.post(args.dcos_mode, conductr_host(args), url,
                                     data=multipart,
@@ -140,7 +140,7 @@ def validate_cache_dir_permissions(cache_dir, log):
 def load_v2(args):
     log = logging.getLogger(__name__)
 
-    log.info('Retrieving bundle...')
+    log.info('Retrieving bundle..')
     custom_settings = args.custom_settings
     resolve_cache_dir = args.resolve_cache_dir
 
@@ -154,7 +154,7 @@ def load_v2(args):
     else:
         configuration_file_name, configuration_file, bundle_conf_overlay = (None, None, None)
         if args.configuration is not None:
-            log.info('Retrieving configuration...')
+            log.info('Retrieving configuration..')
             configuration_file_name, configuration_file = resolver.resolve_bundle_configuration(custom_settings,
                                                                                                 resolve_cache_dir,
                                                                                                 args.configuration)
@@ -176,7 +176,7 @@ def load_v2(args):
 
         url = conduct_url.url('bundles', args)
 
-        log.info('Loading bundle to ConductR...')
+        log.info('Loading bundle to ConductR..')
         multipart = create_multipart(log, files)
 
         response = conduct_request.post(args.dcos_mode, conductr_host(args), url,

--- a/conductr_cli/conduct_main.py
+++ b/conductr_cli/conduct_main.py
@@ -284,7 +284,7 @@ def build_parser(dcos_mode):
     # Sub-parser for `setup-dcos` sub-command
     dcos_parser = subparsers.add_parser('setup-dcos',
                                         help='setup integration with the DC/OS CLI '
-                                        'so that \'dcos conduct ...\' commands can '
+                                        'so that \'dcos conduct ..\' commands can '
                                         'be used to access ConductR via DC/OS')
     dcos_parser.set_defaults(func=conduct_dcos.setup)
 

--- a/conductr_cli/sandbox_features.py
+++ b/conductr_cli/sandbox_features.py
@@ -66,9 +66,9 @@ class MonitoringFeature:
 
     def start(self):
         log = logging.getLogger(__name__)
-        log.info('Starting monitoring feature...')
+        log.info('Starting monitoring feature..')
         grafana = self.grafana_bundle()
-        log.info('Running %s...' % grafana['bundle'])
+        log.info('Running %s..' % grafana['bundle'])
         conduct_main.run(['load', grafana['bundle']], configure_logging=False)
         conduct_main.run(['run', grafana['name']], configure_logging=False)
 

--- a/conductr_cli/sandbox_main.py
+++ b/conductr_cli/sandbox_main.py
@@ -160,7 +160,7 @@ def validate_docker_vm(vm_type):
         is_docker_machine_vm_installed = docker_machine.vm_install_check(docker_machine_vm_name)
         if not is_docker_machine_vm_installed:
             log.info('Creating Docker machine VM {}'.format(docker_machine_vm_name))
-            log.info('This will take a few minutes - please be patient...')
+            log.info('This will take a few minutes - please be patient..')
             terminal.docker_machine_create_vm(docker_machine_vm_name)
 
         is_docker_machine_started = docker_machine.running_check(docker_machine_vm_name)

--- a/conductr_cli/test/conduct_load_test_base.py
+++ b/conductr_cli/test/conduct_load_test_base.py
@@ -13,8 +13,8 @@ except ImportError:
 
 
 class ConductLoadTestBase(CliTestCase):
-    output_template = """|Retrieving bundle...
-                         |{downloading_configuration}Loading bundle to ConductR...
+    output_template = """|Retrieving bundle..
+                         |{downloading_configuration}Loading bundle to ConductR..
                          |{verbose}Bundle loaded.
                          |Start bundle with: {command} run{params} {bundle_id}
                          |Unload bundle with: {command} unload{params} {bundle_id}

--- a/conductr_cli/test/test_conduct_load_v1.py
+++ b/conductr_cli/test/test_conduct_load_v1.py
@@ -137,7 +137,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
                                        headers={'Content-Type': self.multipart_content_type, 'Host': '127.0.0.1'})
         wait_for_installation_mock.assert_called_with(self.bundle_id, input_args)
 
-        self.assertEqual(self.default_output(downloading_configuration='Retrieving configuration...\n'),
+        self.assertEqual(self.default_output(downloading_configuration='Retrieving configuration..\n'),
                          self.output(stdout))
 
     def test_success_no_wait(self):

--- a/conductr_cli/test/test_conduct_load_v2.py
+++ b/conductr_cli/test/test_conduct_load_v2.py
@@ -212,7 +212,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
 
         wait_for_installation_mock.assert_called_with(self.bundle_id, input_args)
 
-        self.assertEqual(self.default_output(downloading_configuration='Retrieving configuration...\n'),
+        self.assertEqual(self.default_output(downloading_configuration='Retrieving configuration..\n'),
                          self.output(stdout))
 
     def test_success_with_configuration_no_bundle_conf(self):
@@ -279,7 +279,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
 
         wait_for_installation_mock.assert_called_with(self.bundle_id, input_args)
 
-        self.assertEqual(self.default_output(downloading_configuration='Retrieving configuration...\n'),
+        self.assertEqual(self.default_output(downloading_configuration='Retrieving configuration..\n'),
                          self.output(stdout))
 
     def test_success_no_wait(self):

--- a/conductr_cli/test/test_sandbox_run.py
+++ b/conductr_cli/test/test_sandbox_run.py
@@ -56,9 +56,13 @@ class TestSandboxRunCommand(CliTestCase):
             sandbox_run.run(input_args)
 
         expected_stdout = strip_margin("""|Pulling down the ConductR development image..
-                                          |Starting ConductR nodes..
+                                          |Starting ConductR..
                                           |Starting container cond-0..
-                                          |ConductR has been started. Check current bundle status with: conduct info
+                                          |ConductR has been started
+                                          |Check current bundle status with:
+                                          |  conduct info
+                                          |Check resource consumption of Docker container that run the ConductR node with:
+                                          |  docker stats cond-0
                                           |""")
         expected_optional_args = self.default_general_args('cond-0') + self.default_env_args + self.default_port_args
         expected_image = '{}:{}'.format(CONDUCTR_DEV_IMAGE, LATEST_CONDUCTR_VERSION)
@@ -86,11 +90,15 @@ class TestSandboxRunCommand(CliTestCase):
             logging_setup.configure_logging(input_args, stdout)
             sandbox_run.run(input_args)
 
-        expected_stdout = strip_margin("""|Starting ConductR nodes..
+        expected_stdout = strip_margin("""|Starting ConductR..
                                           |Starting container cond-0..
                                           |Starting container cond-1..
                                           |Starting container cond-2..
-                                          |ConductR has been started. Check current bundle status with: conduct info
+                                          |ConductR has been started
+                                          |Check current bundle status with:
+                                          |  conduct info
+                                          |Check resource consumption of Docker containers that run the ConductR nodes with:
+                                          |  docker stats cond-0 cond-1 cond-2
                                           |""")
         expected_image = '{}:{}'.format(CONDUCTR_DEV_IMAGE, LATEST_CONDUCTR_VERSION)
 
@@ -159,9 +167,13 @@ class TestSandboxRunCommand(CliTestCase):
             logging_setup.configure_logging(input_args, stdout)
             sandbox_run.run(input_args)
 
-        expected_stdout = strip_margin("""|Starting ConductR nodes..
+        expected_stdout = strip_margin("""|Starting ConductR..
                                           |Starting container cond-0 exposing 127.0.0.1:3000, 127.0.0.1:3001, 127.0.0.1:5601, 127.0.0.1:9200, 127.0.0.1:9999..
-                                          |ConductR has been started. Check current bundle status with: conduct info
+                                          |ConductR has been started
+                                          |Check current bundle status with:
+                                          |  conduct info
+                                          |Check resource consumption of Docker container that run the ConductR node with:
+                                          |  docker stats cond-0
                                           |""")
 
         self.assertEqual(expected_stdout, self.output(stdout))
@@ -199,11 +211,15 @@ class TestSandboxRunCommand(CliTestCase):
             logging_setup.configure_logging(input_args, stdout)
             sandbox_run.run(input_args)
 
-        expected_stdout = strip_margin("""|Starting ConductR nodes..
+        expected_stdout = strip_margin("""|Starting ConductR..
                                           |Starting container cond-0..
                                           |Starting container cond-1..
                                           |Starting container cond-2..
-                                          |ConductR has been started. Check current bundle status with: conduct info
+                                          |ConductR has been started
+                                          |Check current bundle status with:
+                                          |  conduct info
+                                          |Check resource consumption of Docker containers that run the ConductR nodes with:
+                                          |  docker stats cond-0 cond-1 cond-2
                                           |""")
         expected_image = '{}:{}'.format(CONDUCTR_DEV_IMAGE, LATEST_CONDUCTR_VERSION)
 
@@ -259,9 +275,13 @@ class TestSandboxRunCommand(CliTestCase):
             sandbox_run.run(input_args)
 
         expected_stdout = strip_margin("""|Stopping ConductR..
-                                          |Starting ConductR nodes..
+                                          |Starting ConductR..
                                           |Starting container cond-0..
-                                          |ConductR has been started. Check current bundle status with: conduct info
+                                          |ConductR has been started
+                                          |Check current bundle status with:
+                                          |  conduct info
+                                          |Check resource consumption of Docker container that run the ConductR node with:
+                                          |  docker stats cond-0
                                           |""")
 
         self.assertEqual(expected_stdout, self.output(stdout))
@@ -290,9 +310,13 @@ class TestSandboxRunCommand(CliTestCase):
             sandbox_run.run(input_args)
 
         expected_stdout = strip_margin("""|Pulling down the ConductR development image..
-                                          |Starting ConductR nodes..
+                                          |Starting ConductR..
                                           |Starting container cond-0..
-                                          |ConductR has been started. Check current bundle status with: conduct info
+                                          |ConductR has been started
+                                          |Check current bundle status with:
+                                          |  conduct info
+                                          |Check resource consumption of Docker container that run the ConductR node with:
+                                          |  docker stats cond-0
                                           |""")
         expected_optional_args = self.default_general_args('cond-0') + self.default_env_args + self.default_port_args
         expected_image = '{}:{}'.format(CONDUCTR_DEV_IMAGE, LATEST_CONDUCTR_VERSION)
@@ -323,7 +347,7 @@ class TestSandboxRunCommand(CliTestCase):
             sandbox_run.run(input_args)
 
         expected_stdout = strip_margin("""|Pulling down the ConductR development image..
-                                          |Starting ConductR nodes..
+                                          |Starting ConductR..
                                           |Starting container cond-0..
                                           |""")
         expected_optional_args = self.default_general_args('cond-0') + self.default_env_args + self.default_port_args
@@ -361,9 +385,13 @@ class TestSandboxRunCommand(CliTestCase):
             sandbox_run.run(input_args)
 
         expected_stdout = strip_margin("""|Pulling down the ConductR development image..
-                                          |Starting ConductR nodes..
+                                          |Starting ConductR..
                                           |Starting container cond-0..
-                                          |ConductR has been started. Check current bundle status with: conduct info
+                                          |ConductR has been started
+                                          |Check current bundle status with:
+                                          |  conduct info
+                                          |Check resource consumption of Docker container that run the ConductR node with:
+                                          |  docker stats cond-0
                                           |""")
         expected_optional_args = self.default_general_args('cond-0') + self.default_env_args + self.default_port_args
         expected_image = '{}:{}'.format(CONDUCTR_DEV_IMAGE, LATEST_CONDUCTR_VERSION)


### PR DESCRIPTION
Once ConductR has been started we now print the `docker stats` command to the console to tell the user that he can check the Docker container resource consumption with it.

The ouput that ConductR has been successfully started or has timed out is also now printed to the console after the features have been started, i.e. at the end of the output.

The PR also harmonizes the waiting dots from `...` to `..`.