### PR TITLE
Disallow option combination --no-wait and --feature

### DIFF
--- a/conductr_cli/sandbox_main.py
+++ b/conductr_cli/sandbox_main.py
@@ -255,6 +255,8 @@ def run():
         logging_setup.configure_logging(args)
         # Check that all feature arguments are valid
         if vars(args).get('func').__name__ == 'run':
+            if args.features and args.no_wait:
+                parser.exit('Option --no-wait is not allowed when starting ConductR with option --feature')
             invalid_features = [f for f, *a in args.features if f not in feature_names]
             if invalid_features:
                 parser.exit('Invalid features: %s (choose from %s)' %

--- a/conductr_cli/sandbox_run.py
+++ b/conductr_cli/sandbox_run.py
@@ -38,8 +38,9 @@ def run(args):
     bootstrap_features = collect_bootstrap_features(features)
     container_names = scale_cluster(args, ports, bootstrap_features)
     is_started, wait_timeout = wait_for_start(args)
-    for feature in features:
-        feature.start()
+    if is_started:
+        for feature in features:
+            feature.start()
     print_result(container_names, is_started, args.no_wait, wait_timeout)
 
 


### PR DESCRIPTION
When ConductR is started with features, the feature startup is depend on waiting that ConductR has been started. Otherwise, the feature startup will fail.

Therefore, this PR is adding a check that the options `--no-wait` and `--feature` are not set together. If that is the case, `sandbox run` will abort with an error message.