### PR TITLE
Remove sandbox debug command

### DIFF
--- a/conductr_cli/sandbox_main.py
+++ b/conductr_cli/sandbox_main.py
@@ -99,12 +99,6 @@ def build_parser():
                             action='store_true')
     run_parser.set_defaults(func=sandbox_run.run)
 
-    # Sub-parser for `debug` sub-command
-    debug_parser = subparsers.add_parser('debug',
-                                         help='Not supported. Use \'sbt-conductr\' instead.')
-    add_resolve_ip(debug_parser, False)
-    debug_parser.set_defaults(func='debug')
-
     # Sub-parser for `stop` sub-command
     stop_parser = subparsers.add_parser('stop',
                                         help='Stop ConductR sandbox cluster')
@@ -238,10 +232,6 @@ def run():
     # Print help or execute subparser function
     if not vars(args).get('func'):
         parser.print_help()
-    # Exit with sandbox debug error message
-    elif vars(args).get('func') == 'debug':
-        parser.exit('Debugging a ConductR cluster is not supported by the \'conductr-cli\'.\n'
-                    'Use the sbt plugin \'sbt-conductr\' instead.')
     # Validate image_version
     elif vars(args).get('func').__name__ == 'run' and not args.image_version:
         parser.exit('The version of the ConductR Docker image must be set.\n'

--- a/conductr_cli/test/test_sandbox_main.py
+++ b/conductr_cli/test/test_sandbox_main.py
@@ -57,10 +57,9 @@ class TestSandbox(CliTestCase):
         self.assertEqual(args.local_connection, True)
         self.assertEqual(args.resolve_ip, True)
 
-    def test_parser_debug(self):
-        args = self.parser.parse_args('debug'.split())
-        self.assertEqual(args.func, 'debug')
-        self.assertEqual(args.resolve_ip, False)
+    def test_parser_version(self):
+        args = self.parser.parse_args('version'.split())
+        self.assertEqual(args.func.__name__, 'version')
 
     def test_docker_not_running(self):
         stdout_mock = MagicMock()


### PR DESCRIPTION
The `sandbox debug` command is not supported by `sbt-conductr` anymore. Therefore, this PR is removing the `debug` command from the parser.