### PR TITLE
Stronger file check

### DIFF
--- a/conductr_cli/resolvers/bintray_resolver.py
+++ b/conductr_cli/resolvers/bintray_resolver.py
@@ -31,8 +31,7 @@ def resolve_bundle(cache_dir, uri):
 
 def load_bundle_from_cache(cache_dir, uri):
     # When the supplied uri points to a local file, don't load from cache so file can be used as is.
-    parsed = urlparse(uri, scheme='file')
-    if parsed.scheme == 'file' and os.path.exists(uri):
+    if is_local_file(uri):
         return False, None, None
     else:
         log = logging.getLogger(__name__)
@@ -64,8 +63,7 @@ def resolve_bundle_configuration(cache_dir, uri):
 
 def load_bundle_configuration_from_cache(cache_dir, uri):
     # When the supplied uri points to a local file, don't load from cache so file can be used as is.
-    parsed = urlparse(uri, scheme='file')
-    if parsed.scheme == 'file' and os.path.exists(uri):
+    if is_local_file(uri):
         return False, None, None
     else:
         log = logging.getLogger(__name__)
@@ -82,6 +80,11 @@ def load_bundle_configuration_from_cache(cache_dir, uri):
             return False, None, None
         except HTTPError:
             return False, None, None
+
+
+def is_local_file(uri):
+    parsed = urlparse(uri, scheme='file')
+    return parsed.scheme == 'file' and parsed.path.endswith('.zip') and os.path.exists(uri)
 
 
 def bintray_download(cache_dir, org, repo, package_name, compatibility_version, digest):

--- a/conductr_cli/resolvers/test/test_bintray_resolver.py
+++ b/conductr_cli/resolvers/test/test_bintray_resolver.py
@@ -177,6 +177,17 @@ class TestLoadBundleFromCache(TestCase):
         exists_mock.assert_called_with('/tmp/bundle.zip')
         parse_bundle_mock.assert_not_called()
 
+    def test_bundle(self):
+        exists_mock = MagicMock(return_value=False)
+        bintray_download_det_mock = MagicMock(return_value=(None, None))
+
+        with patch('os.path.exists', exists_mock), \
+                patch('conductr_cli.resolvers.bintray_resolver.bintray_download_details', bintray_download_det_mock):
+            bintray_resolver.load_bundle_from_cache(
+                '/cache-dir', '/tmp/bundle')
+
+        exists_mock.assert_not_called()
+
     def test_bintray_version_found(self):
         exists_mock = MagicMock(return_value=False)
         load_bintray_credentials_mock = MagicMock(return_value=('username', 'password'))


### PR DESCRIPTION
This commit strengthens the check to determine whether a bundle exists on the file system by ensuring that it has a ".zip" extension. Prior to doing this the `load` sub command could yield a false-positive and cause the cache check to be avoided when a directory of the same name as the bundle existed. This problematic scenario would occur when using the load sub command from within the ConductR project itself given that there are directories for eslite, visualizer etc. CI would then also keep resolving bundles from bintray despite them possibly being cached from other tests.

Tested from within the ConductR project directory and outside of it. Also re-tested by uploading a file from the file system.

Fixes #225 