### PR TITLE
Implement Conduct Deploy command

### DIFF
--- a/conductr_cli/bundle_deploy.py
+++ b/conductr_cli/bundle_deploy.py
@@ -1,0 +1,144 @@
+from conductr_cli import bundle_utils, conduct_request, conduct_url, sse_client
+from conductr_cli.exceptions import ContinuousDeliveryError, WaitTimeoutError
+from datetime import datetime
+
+import hmac
+import json
+import logging
+import base64
+
+STRING_ENCODING = 'UTF-8'
+HMAC_DIGEST_MOD = 'MD5'
+
+
+def generate_hmac_signature(secret_key, text):
+    secret_key_bytes = bytes(secret_key, encoding=STRING_ENCODING)
+    text_bytes = bytes(text, encoding=STRING_ENCODING)
+    hmac_generator = hmac.new(secret_key_bytes, msg=text_bytes, digestmod=HMAC_DIGEST_MOD)
+    signature = hmac_generator.digest()
+    return base64.b64encode(signature).decode(STRING_ENCODING)
+
+
+def get_deployment_state(deployment_id, args):
+    deployment_state_url = conduct_url.url('deployments/{}'.format(deployment_id), args)
+    response = conduct_request.get(args.dcos_mode, conduct_url.conductr_host(args), deployment_state_url,
+                                   auth=args.conductr_auth, verify=args.server_verification_file)
+    if response.status_code == 404:
+        return None
+    else:
+        response.raise_for_status()
+        deployment_state = json.loads(response.text)
+        return deployment_state
+
+
+def wait_for_deployment_complete(deployment_id, resolved_version, args):
+    log = logging.getLogger(__name__)
+    start_time = datetime.now()
+
+    def display_bundle_id(bundle_id):
+        return bundle_id if args.long_ids else bundle_utils.short_id(bundle_id)
+
+    def is_completed_with_success(deployment_state):
+        return deployment_state['eventType'] == "deploymentSuccess"
+
+    def is_completed_with_failure(deployment_state):
+        return deployment_state['eventType'] == "deploymentFailure"
+
+    def log_message(deployment_state):
+        event_type = deployment_state['eventType']
+        if event_type == 'deploymentStarted':
+            return 'Deployment started'
+
+        elif event_type == 'bundleDownload':
+            return 'Downloading bundle'
+
+        elif event_type == 'configDownload':
+            compatible_bundle_id = display_bundle_id(deployment_state['compatibleBundleId'])
+            return 'Downloading config from bundle {}'.format(compatible_bundle_id)
+
+        elif event_type == 'load':
+            return 'Loading bundle with config' if 'configFileName' in deployment_state else 'Loading bundle'
+
+        elif event_type == 'deploy':
+            bundle_old = deployment_state['bundleOld']
+            bundle_new = deployment_state['bundleNew']
+            deploy_progress = 'Deploying - {} old instance vs {} new instance'.format(bundle_old['scale'],
+                                                                                      bundle_new['scale'])
+            return deploy_progress
+
+        elif event_type == 'deploymentSuccess':
+            return 'Success'
+
+        elif event_type == 'deploymentFailure':
+            return 'Failure: {}'.format(deployment_state['failure'])
+
+        else:
+            return 'Unknown deployment state {}'.format(deployment_state)
+
+    package_name = resolved_version['package_name']
+    compatibility_version = resolved_version['compatibility_version']
+    bundle_id = display_bundle_id(resolved_version['digest'])
+    bundle_shorthand = '{}:{}-{}'.format(package_name, compatibility_version, bundle_id)
+
+    log.info('Deploying {}'.format(bundle_shorthand))
+
+    deployment_state = get_deployment_state(deployment_id, args)
+
+    if deployment_state and is_completed_with_success(deployment_state):
+        log.info(log_message(deployment_state))
+        return
+    elif deployment_state and is_completed_with_failure(deployment_state):
+        raise ContinuousDeliveryError('Unable to deploy {} - {}'.format(bundle_shorthand,
+                                                                        log_message(deployment_state)))
+    else:
+        sse_heartbeat_count_after_event = 0
+
+        deployment_events_url = conduct_url.url('deployments/events', args)
+        sse_events = sse_client.get_events(args.dcos_mode, conduct_url.conductr_host(args), deployment_events_url,
+                                           auth=args.conductr_auth, verify=args.server_verification_file)
+        last_deployment_state = None
+        last_log_message = None
+        for event in sse_events:
+            sse_heartbeat_count_after_event += 1
+
+            elapsed = (datetime.now() - start_time).total_seconds()
+            if elapsed > args.wait_timeout:
+                raise WaitTimeoutError('Deployment is still waiting to be completed')
+
+            # Check for deployment state every 3 heartbeats from the last received event.
+            if event.event or (sse_heartbeat_count_after_event % 3 == 0):
+                if event.event:
+                    sse_heartbeat_count_after_event = 0
+
+                deployment_state = get_deployment_state(deployment_id, args)
+
+                if is_completed_with_success(deployment_state):
+                    # Reprint previous message with flush to go to next line
+                    if last_log_message:
+                        log.progress(last_log_message, flush=True)
+
+                    log.info(log_message(deployment_state))
+                    return
+
+                elif is_completed_with_failure(deployment_state):
+                    # Reprint previous message with flush to go to next line
+                    if last_log_message:
+                        log.progress(last_log_message, flush=True)
+
+                    raise ContinuousDeliveryError('Unable to deploy {} - {}'.format(bundle_shorthand,
+                                                                                    log_message(deployment_state)))
+                else:
+                    if deployment_state != last_deployment_state:
+                        last_deployment_state = deployment_state
+
+                        # Reprint previous message with flush to go to next line
+                        if last_log_message:
+                            log.progress(last_log_message, flush=True)
+
+                        last_log_message = log_message(deployment_state)
+                        log.progress(last_log_message, flush=False)
+                    else:
+                        last_log_message = '{}.'.format(last_log_message)
+                        log.progress(last_log_message, flush=False)
+
+        raise WaitTimeoutError('Deployment for {} is still waiting to be completed')

--- a/conductr_cli/conduct_deploy.py
+++ b/conductr_cli/conduct_deploy.py
@@ -1,0 +1,83 @@
+from conductr_cli import bundle_deploy, bundle_utils, conduct_request, conduct_url, validation, custom_settings, \
+    resolver
+from conductr_cli.conduct_url import conductr_host
+
+import logging
+
+
+DEFAULT_WAIT_TIMEOUT = 180  # seconds
+
+
+@validation.handle_connection_error
+@validation.handle_http_error
+@validation.handle_wait_timeout_error
+def deploy(args):
+    """`conduct deploy` command"""
+
+    log = logging.getLogger(__name__)
+
+    bintray_webhook_secret = custom_settings.load_bintray_webhook_secret(args)
+    if not bintray_webhook_secret:
+        log.error('The deploy command requires bintray webhook secret to be configured')
+        log.error('Add the following configuration to the '
+                  'custom settings file {}'.format(vars(args).get('custom_settings_file')))
+        log.error('  conductr.continuous-delivery.bintray-webhook-secret = "configured-continuous-delivery-secret"')
+        return
+
+    resolved_version = resolver.resolve_bundle_version(args.custom_settings, args.bundle)
+    if not resolved_version:
+        log.error('Unable to resolve bundle {}'.format(args.bundle))
+        return
+
+    # Build Continuous Delivery URL using our resolver mechanism
+    deploy_uri = resolver.continuous_delivery_uri(args.custom_settings, resolved_version)
+    if not deploy_uri:
+        log.error('Unable to form Continuous Delivery uri for {}'.format(args.bundle))
+        return
+
+    # Confirm with the user unless auto deploy is enabled
+    accepted = True if args.auto_deploy else request_deploy_confirmation(resolved_version, args)
+    if not accepted:
+        log.info('Abort')
+        return
+
+    url = conduct_url.url(deploy_uri, args)
+
+    # JSON Payload for deployment request
+    payload = {
+        'package': resolved_version['package_name'],
+        'version': '{}-{}'.format(resolved_version['compatibility_version'], resolved_version['digest'])
+    }
+
+    # HTTP headers required for deployment request
+    hmac_digest = bundle_deploy.generate_hmac_signature(bintray_webhook_secret, resolved_version['package_name'])
+    headers = {
+        'X-Bintray-WebHook-Hmac': hmac_digest
+    }
+
+    response = conduct_request.post(args.dcos_mode, conductr_host(args), url,
+                                    json=payload,
+                                    headers=headers,
+                                    auth=args.conductr_auth,
+                                    verify=args.server_verification_file)
+
+    validation.raise_for_status_inc_3xx(response)
+
+    deployment_id = response.text
+
+    log.info('Deployment request sent.')
+    log.info('Deployment id {}'.format(deployment_id))
+
+    if not args.no_wait:
+        bundle_deploy.wait_for_deployment_complete(deployment_id, resolved_version, args)
+
+    return True
+
+
+def request_deploy_confirmation(resolved_version, args):
+    bundle_id = resolved_version['digest'] if args.long_ids else bundle_utils.short_id(resolved_version['digest'])
+    user_input = input('Deploy {}:{}-{}? [Y/n]: '.format(resolved_version['package_name'],
+                                                         resolved_version['compatibility_version'],
+                                                         bundle_id))
+    confirmation = (user_input if user_input else 'y').lower().strip()
+    return confirmation == 'y' or confirmation == 'yes'

--- a/conductr_cli/custom_settings.py
+++ b/conductr_cli/custom_settings.py
@@ -44,6 +44,11 @@ def load_server_ssl_verification_file(args):
     return None
 
 
+def load_bintray_webhook_secret(args):
+    custom_settings = load_from_file(args)
+    return get_config_value(custom_settings, 'conductr.continuous-delivery.bintray-webhook-secret')
+
+
 def get_auth_config(custom_settings, host, port):
     auth_config_host_port = get_config(custom_settings, 'conductr.auth.\"{}:{}\"'.format(host, port))
     auth_config_host = get_config(custom_settings, 'conductr.auth.\"{}\"'.format(host))

--- a/conductr_cli/exceptions.py
+++ b/conductr_cli/exceptions.py
@@ -80,3 +80,11 @@ class WaitTimeoutError(Exception):
 
     def __str__(self):
         return repr(self.value)
+
+
+class ContinuousDeliveryError(Exception):
+    def __init__(self, value):
+        self.value = value
+
+    def __str__(self):
+        return repr(self.value)

--- a/conductr_cli/resolver.py
+++ b/conductr_cli/resolver.py
@@ -1,4 +1,4 @@
-from conductr_cli.exceptions import BundleResolutionError
+from conductr_cli.exceptions import BundleResolutionError, ContinuousDeliveryError
 from conductr_cli.resolvers import bintray_resolver, uri_resolver
 import importlib
 import logging
@@ -40,6 +40,28 @@ def resolve_bundle_configuration(custom_settings, cache_dir, uri):
             return bundle_configuration_file_name, bundle_configuration_file
 
     raise BundleResolutionError('Unable to resolve bundle using {}'.format(uri))
+
+
+def resolve_bundle_version(custom_settings, uri):
+    all_resolvers = resolver_chain(custom_settings)
+
+    for resolver in all_resolvers:
+        resolved_version = resolver.resolve_bundle_version(uri)
+        if resolved_version:
+            return resolved_version
+
+    raise BundleResolutionError('Unable to resolve bundle using {}'.format(uri))
+
+
+def continuous_delivery_uri(custom_settings, resolved_version):
+    all_resolvers = resolver_chain(custom_settings)
+
+    for resolver in all_resolvers:
+        uri = resolver.continuous_delivery_uri(resolved_version)
+        if uri:
+            return uri
+
+    raise ContinuousDeliveryError('Unable to form Continuous Delivery uri using {}'.format(resolved_version))
 
 
 def resolver_chain(custom_settings):

--- a/conductr_cli/resolvers/test/test_uri_resolver.py
+++ b/conductr_cli/resolvers/test/test_uri_resolver.py
@@ -314,6 +314,11 @@ class TestLoadBundleConfigurationFromCache(TestCase):
         exists_mock.assert_called_with('/cache-dir/bundle-file.zip')
 
 
+class TestContinuousDeliveryUri(TestCase):
+    def test_return_none(self):
+        self.assertIsNone(uri_resolver.continuous_delivery_uri({}))
+
+
 class TestGetUrl(TestCase):
     def test_url(self):
         filename, url = uri_resolver.get_url(
@@ -435,6 +440,11 @@ class TestProgressBar(TestCase):
 
         get_logger_mock.assert_called_with('conductr_cli.resolvers.uri_resolver')
         log_mock.info.assert_called_with('Retrieving http://site.com/bundle-url-resolved')
+
+
+class TestResolveBundleVersion(TestCase):
+    def test_return_none(self):
+        self.assertIsNone(uri_resolver.resolve_bundle_version("bundle"))
 
 
 class TestShowProgress(TestCase):

--- a/conductr_cli/resolvers/uri_resolver.py
+++ b/conductr_cli/resolvers/uri_resolver.py
@@ -58,6 +58,14 @@ def load_bundle_configuration_from_cache(cache_dir, uri):
     return load_bundle_from_cache(cache_dir, uri)
 
 
+def resolve_bundle_version(uri):
+    return None
+
+
+def continuous_delivery_uri(resolved_version):
+    return None
+
+
 def get_url(uri):
     parsed = urlparse(uri, scheme='file')
     op = Path(uri)

--- a/conductr_cli/test/test_bundle_deploy.py
+++ b/conductr_cli/test/test_bundle_deploy.py
@@ -1,0 +1,961 @@
+from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
+from conductr_cli import bundle_deploy, logging_setup
+from conductr_cli.exceptions import ContinuousDeliveryError, WaitTimeoutError
+from conductr_cli.resolvers import bintray_resolver
+from unittest import TestCase
+
+import json
+
+try:
+    from unittest.mock import call, patch, MagicMock  # 3.3 and beyond
+except ImportError:
+    from mock import call, patch, MagicMock
+
+
+class TestGenerateHmac(TestCase):
+    def test_success(self):
+        result = bundle_deploy.generate_hmac_signature('secret', 'reactive-maps-backend-summary')
+        self.assertEqual('GnNDrC0VQ0CN1qbWFgnvLw==', result)
+
+
+class TestGetDeploymentStateIp(CliTestCase):
+
+    conductr_auth = ('username', 'password')
+    server_verification_file = MagicMock(name='server_verification_file')
+
+    def test_success(self):
+        deployment_state = strip_margin(
+            """|{
+               |  "eventType": "deploymentStarted",
+               |  "deploymentId": "abc-def",
+               |  "bundleName": "cassandra",
+               |  "compatibleVersion": "v1"
+               |}
+               |""")
+        http_method = self.respond_with(text=deployment_state)
+
+        args = {
+            'dcos_mode': False,
+            'scheme': 'http',
+            'ip': '127.0.0.1',
+            'port': '9005',
+            'base_path': '/',
+            'api_version': '1',
+            'conductr_auth': self.conductr_auth,
+            'server_verification_file': self.server_verification_file
+        }
+        input_args = MagicMock(**args)
+        with patch('requests.get', http_method):
+            result = bundle_deploy.get_deployment_state('abc-def', input_args)
+            self.assertEqual(json.loads(deployment_state), result)
+
+        http_method.assert_called_with('http://127.0.0.1:9005/deployments/abc-def', auth=self.conductr_auth,
+                                       verify=self.server_verification_file, headers={'Host': '127.0.0.1'})
+
+    def test_return_none_if_404(self):
+        http_method = self.respond_with(status_code=404)
+
+        args = {
+            'dcos_mode': False,
+            'scheme': 'http',
+            'ip': '127.0.0.1',
+            'port': '9005',
+            'base_path': '/',
+            'api_version': '1',
+            'conductr_auth': self.conductr_auth,
+            'server_verification_file': self.server_verification_file
+        }
+        input_args = MagicMock(**args)
+        with patch('requests.get', http_method):
+            result = bundle_deploy.get_deployment_state('abc-def', input_args)
+            self.assertIsNone(result)
+
+        http_method.assert_called_with('http://127.0.0.1:9005/deployments/abc-def', auth=self.conductr_auth,
+                                       verify=self.server_verification_file, headers={'Host': '127.0.0.1'})
+
+
+class TestGetDeploymentStateHost(CliTestCase):
+
+    conductr_auth = ('username', 'password')
+    server_verification_file = MagicMock(name='server_verification_file')
+
+    def test_success(self):
+        deployment_state = strip_margin(
+            """|{
+               |  "eventType": "deploymentStarted",
+               |  "deploymentId": "abc-def",
+               |  "bundleName": "cassandra",
+               |  "compatibleVersion": "v1"
+               |}
+               |""")
+        http_method = self.respond_with(text=deployment_state)
+
+        args = {
+            'dcos_mode': False,
+            'scheme': 'http',
+            'host': '127.0.0.1',
+            'port': '9005',
+            'base_path': '/',
+            'api_version': '1',
+            'conductr_auth': self.conductr_auth,
+            'server_verification_file': self.server_verification_file
+        }
+        input_args = MagicMock(**args)
+        with patch('requests.get', http_method):
+            result = bundle_deploy.get_deployment_state('abc-def', input_args)
+            self.assertEqual(json.loads(deployment_state), result)
+
+        http_method.assert_called_with('http://127.0.0.1:9005/deployments/abc-def', auth=self.conductr_auth,
+                                       verify=self.server_verification_file, headers={'Host': '127.0.0.1'})
+
+    def test_return_none_if_404(self):
+        http_method = self.respond_with(status_code=404)
+
+        args = {
+            'dcos_mode': False,
+            'scheme': 'http',
+            'host': '127.0.0.1',
+            'port': '9005',
+            'base_path': '/',
+            'api_version': '1',
+            'conductr_auth': self.conductr_auth,
+            'server_verification_file': self.server_verification_file
+        }
+        input_args = MagicMock(**args)
+        with patch('requests.get', http_method):
+            result = bundle_deploy.get_deployment_state('abc-def', input_args)
+            self.assertIsNone(result)
+
+        http_method.assert_called_with('http://127.0.0.1:9005/deployments/abc-def', auth=self.conductr_auth,
+                                       verify=self.server_verification_file, headers={'Host': '127.0.0.1'})
+
+
+class TestWaitForDeployment(CliTestCase):
+    conductr_auth = ('username', 'password')
+    server_verification_file = MagicMock(name='server_verification_file')
+
+    def test_wait_for_deployment(self):
+        get_deployment_state_mock = MagicMock(side_effect=[
+            self.create_deployment_state('deploymentStarted'),
+            self.create_deployment_state('bundleDownload'),
+            self.create_deployment_state('configDownload', {
+                'compatibleBundleId': 'abf60451c6af18adcc851d67b369b7f5-a53237c1f4a067e13ef00090627fb3de'
+            }),
+            self.create_deployment_state('load', {'configFileName': 'cassandra-prod-config.zip'}),
+            self.create_deployment_state('deploy', {
+                'bundleOld': {'scale': 1},
+                'bundleNew': {'scale': 0}
+            }),
+            self.create_deployment_state('deploy', {
+                'bundleOld': {'scale': 0},
+                'bundleNew': {'scale': 1}
+            }),
+            self.create_deployment_state('deploymentSuccess'),
+        ])
+        url_mock = MagicMock(return_value='/deployments/events')
+        conductr_host = '10.0.0.1'
+        conductr_host_mock = MagicMock(return_value=conductr_host)
+        get_events_mock = MagicMock(return_value=[
+            self.create_test_event(None),
+            self.create_test_event('deploymentStarted'),
+            self.create_test_event(None),
+            self.create_test_event('bundleDownload'),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event('configDownload'),
+            self.create_test_event('load'),
+            self.create_test_event(None),
+            self.create_test_event('deploy'),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event('deploy'),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event('deploymentSuccess')
+        ])
+
+        stdout = MagicMock()
+
+        deployment_id = 'a101449418187d92c789d1adc240b6d6'
+        resolved_version = {
+            'org': 'typesafe',
+            'repo': 'bundle',
+            'package_name': 'cassandra',
+            'compatibility_version': 'v1',
+            'digest': 'd073991ab918ee22c7426af8a62a48c5-a53237c1f4a067e13ef00090627fb3de',
+            'resolver': bintray_resolver.__name__
+        }
+        dcos_mode = False
+        args = MagicMock(**{
+            'dcos_mode': dcos_mode,
+            'long_ids': False,
+            'wait_timeout': 10,
+            'conductr_auth': self.conductr_auth,
+            'server_verification_file': self.server_verification_file
+
+        })
+        with patch('conductr_cli.conduct_url.url', url_mock), \
+                patch('conductr_cli.conduct_url.conductr_host', conductr_host_mock), \
+                patch('conductr_cli.bundle_deploy.get_deployment_state', get_deployment_state_mock), \
+                patch('conductr_cli.sse_client.get_events', get_events_mock):
+            logging_setup.configure_logging(args, stdout)
+            bundle_deploy.wait_for_deployment_complete(deployment_id, resolved_version, args)
+
+        self.assertEqual(get_deployment_state_mock.call_args_list, [
+            call(deployment_id, args),
+            call(deployment_id, args),
+            call(deployment_id, args),
+            call(deployment_id, args),
+            call(deployment_id, args),
+            call(deployment_id, args),
+            call(deployment_id, args)
+        ])
+
+        url_mock.assert_called_with('deployments/events', args)
+
+        conductr_host_mock.assert_called_with(args)
+
+        get_events_mock.assert_called_with(dcos_mode, conductr_host, '/deployments/events', auth=self.conductr_auth,
+                                           verify=self.server_verification_file)
+
+        self.assertEqual(stdout.method_calls, [
+            call.write('Deploying cassandra:v1-d073991-a53237c'),
+            call.write('\n'),
+            call.flush(),
+            call.write('Downloading bundle\r'),
+            call.write(''),
+            call.flush(),
+            call.write('Downloading bundle\n'),
+            call.write(''),
+            call.flush(),
+            call.write('Downloading config from bundle abf6045-a53237c\r'),
+            call.write(''),
+            call.flush(),
+            call.write('Downloading config from bundle abf6045-a53237c\n'),
+            call.write(''),
+            call.flush(),
+            call.write('Loading bundle with config\r'),
+            call.write(''),
+            call.flush(),
+            call.write('Loading bundle with config\n'),
+            call.write(''),
+            call.flush(),
+            call.write('Deploying - 1 old instance vs 0 new instance\r'),
+            call.write(''),
+            call.flush(),
+            call.write('Deploying - 1 old instance vs 0 new instance\n'),
+            call.write(''),
+            call.flush(),
+            call.write('Deploying - 0 old instance vs 1 new instance\r'),
+            call.write(''),
+            call.flush(),
+            call.write('Deploying - 0 old instance vs 1 new instance\n'),
+            call.write(''),
+            call.flush(),
+            call.write('Success'),
+            call.write('\n'),
+            call.flush()
+        ])
+
+    def test_wait_for_deployment_long_ids(self):
+        get_deployment_state_mock = MagicMock(side_effect=[
+            self.create_deployment_state('deploymentStarted'),
+            self.create_deployment_state('bundleDownload'),
+            self.create_deployment_state('configDownload', {
+                'compatibleBundleId': 'abf60451c6af18adcc851d67b369b7f5-a53237c1f4a067e13ef00090627fb3de'
+            }),
+            self.create_deployment_state('load', {'configFileName': 'cassandra-prod-config.zip'}),
+            self.create_deployment_state('deploy', {
+                'bundleOld': {'scale': 1},
+                'bundleNew': {'scale': 0}
+            }),
+            self.create_deployment_state('deploy', {
+                'bundleOld': {'scale': 0},
+                'bundleNew': {'scale': 1}
+            }),
+            self.create_deployment_state('deploymentSuccess'),
+        ])
+        url_mock = MagicMock(return_value='/deployments/events')
+        conductr_host = '10.0.0.1'
+        conductr_host_mock = MagicMock(return_value=conductr_host)
+        get_events_mock = MagicMock(return_value=[
+            self.create_test_event(None),
+            self.create_test_event('deploymentStarted'),
+            self.create_test_event(None),
+            self.create_test_event('bundleDownload'),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event('configDownload'),
+            self.create_test_event('load'),
+            self.create_test_event(None),
+            self.create_test_event('deploy'),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event('deploy'),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event('deploymentSuccess')
+        ])
+
+        stdout = MagicMock()
+
+        deployment_id = 'a101449418187d92c789d1adc240b6d6'
+        resolved_version = {
+            'org': 'typesafe',
+            'repo': 'bundle',
+            'package_name': 'cassandra',
+            'compatibility_version': 'v1',
+            'digest': 'd073991ab918ee22c7426af8a62a48c5-a53237c1f4a067e13ef00090627fb3de',
+            'resolver': bintray_resolver.__name__
+        }
+        dcos_mode = False
+        args = MagicMock(**{
+            'dcos_mode': dcos_mode,
+            'long_ids': True,
+            'wait_timeout': 10,
+            'conductr_auth': self.conductr_auth,
+            'server_verification_file': self.server_verification_file
+
+        })
+        with patch('conductr_cli.conduct_url.url', url_mock), \
+                patch('conductr_cli.conduct_url.conductr_host', conductr_host_mock), \
+                patch('conductr_cli.bundle_deploy.get_deployment_state', get_deployment_state_mock), \
+                patch('conductr_cli.sse_client.get_events', get_events_mock):
+            logging_setup.configure_logging(args, stdout)
+            bundle_deploy.wait_for_deployment_complete(deployment_id, resolved_version, args)
+
+        self.assertEqual(get_deployment_state_mock.call_args_list, [
+            call(deployment_id, args),
+            call(deployment_id, args),
+            call(deployment_id, args),
+            call(deployment_id, args),
+            call(deployment_id, args),
+            call(deployment_id, args),
+            call(deployment_id, args)
+        ])
+
+        url_mock.assert_called_with('deployments/events', args)
+
+        conductr_host_mock.assert_called_with(args)
+
+        get_events_mock.assert_called_with(dcos_mode, conductr_host, '/deployments/events', auth=self.conductr_auth,
+                                           verify=self.server_verification_file)
+
+        self.assertEqual(stdout.method_calls, [
+            call.write('Deploying cassandra:v1-d073991ab918ee22c7426af8a62a48c5-a53237c1f4a067e13ef00090627fb3de'),
+            call.write('\n'),
+            call.flush(),
+            call.write('Downloading bundle\r'),
+            call.write(''),
+            call.flush(),
+            call.write('Downloading bundle\n'),
+            call.write(''),
+            call.flush(),
+            call.write('Downloading config from bundle abf60451c6af18adcc851d67b369b7f5-a53237c1f4a067e13ef00090627fb3de\r'),
+            call.write(''),
+            call.flush(),
+            call.write('Downloading config from bundle abf60451c6af18adcc851d67b369b7f5-a53237c1f4a067e13ef00090627fb3de\n'),
+            call.write(''),
+            call.flush(),
+            call.write('Loading bundle with config\r'),
+            call.write(''),
+            call.flush(),
+            call.write('Loading bundle with config\n'),
+            call.write(''),
+            call.flush(),
+            call.write('Deploying - 1 old instance vs 0 new instance\r'),
+            call.write(''),
+            call.flush(),
+            call.write('Deploying - 1 old instance vs 0 new instance\n'),
+            call.write(''),
+            call.flush(),
+            call.write('Deploying - 0 old instance vs 1 new instance\r'),
+            call.write(''),
+            call.flush(),
+            call.write('Deploying - 0 old instance vs 1 new instance\n'),
+            call.write(''),
+            call.flush(),
+            call.write('Success'),
+            call.write('\n'),
+            call.flush()
+        ])
+
+    def test_return_immediately_if_deployment_is_successful(self):
+        get_deployment_state_mock = MagicMock(side_effect=[
+            self.create_deployment_state('deploymentSuccess'),
+        ])
+        url_mock = MagicMock(return_value='/deployments/events')
+        conductr_host = '10.0.0.1'
+        conductr_host_mock = MagicMock(return_value=conductr_host)
+        get_events_mock = MagicMock()
+
+        stdout = MagicMock()
+
+        deployment_id = 'a101449418187d92c789d1adc240b6d6'
+        resolved_version = {
+            'org': 'typesafe',
+            'repo': 'bundle',
+            'package_name': 'cassandra',
+            'compatibility_version': 'v1',
+            'digest': 'abcdef',
+            'resolver': bintray_resolver.__name__
+        }
+        dcos_mode = False
+        args = MagicMock(**{
+            'dcos_mode': dcos_mode,
+            'long_ids': False,
+            'wait_timeout': 10,
+            'conductr_auth': self.conductr_auth,
+            'server_verification_file': self.server_verification_file
+
+        })
+        with patch('conductr_cli.conduct_url.url', url_mock), \
+                patch('conductr_cli.conduct_url.conductr_host', conductr_host_mock), \
+                patch('conductr_cli.bundle_deploy.get_deployment_state', get_deployment_state_mock), \
+                patch('conductr_cli.sse_client.get_events', get_events_mock):
+            logging_setup.configure_logging(args, stdout)
+            bundle_deploy.wait_for_deployment_complete(deployment_id, resolved_version, args)
+
+        self.assertEqual(get_deployment_state_mock.call_args_list, [
+            call(deployment_id, args)
+        ])
+
+        url_mock.assert_not_called()
+
+        conductr_host_mock.assert_not_called()
+
+        get_events_mock.assert_not_called()
+
+        self.assertEqual(stdout.method_calls, [
+            call.write('Deploying cassandra:v1-abcdef'),
+            call.write('\n'),
+            call.flush(),
+            call.write('Success'),
+            call.write('\n'),
+            call.flush()
+        ])
+
+    def test_fail_immediately_if_deployment_failed(self):
+        get_deployment_state_mock = MagicMock(side_effect=[
+            self.create_deployment_state('deploymentFailure', {'failure': 'test only'}),
+        ])
+        url_mock = MagicMock(return_value='/deployments/events')
+        conductr_host = '10.0.0.1'
+        conductr_host_mock = MagicMock(return_value=conductr_host)
+        get_events_mock = MagicMock()
+
+        stdout = MagicMock()
+        stderr = MagicMock()
+
+        deployment_id = 'a101449418187d92c789d1adc240b6d6'
+        resolved_version = {
+            'org': 'typesafe',
+            'repo': 'bundle',
+            'package_name': 'cassandra',
+            'compatibility_version': 'v1',
+            'digest': 'abcdef',
+            'resolver': bintray_resolver.__name__
+        }
+        dcos_mode = False
+        args = MagicMock(**{
+            'dcos_mode': dcos_mode,
+            'long_ids': False,
+            'wait_timeout': 10,
+            'conductr_auth': self.conductr_auth,
+            'server_verification_file': self.server_verification_file
+
+        })
+        with patch('conductr_cli.conduct_url.url', url_mock), \
+                patch('conductr_cli.conduct_url.conductr_host', conductr_host_mock), \
+                patch('conductr_cli.bundle_deploy.get_deployment_state', get_deployment_state_mock), \
+                patch('conductr_cli.sse_client.get_events', get_events_mock):
+            logging_setup.configure_logging(args, stdout, stderr)
+            self.assertRaises(ContinuousDeliveryError, bundle_deploy.wait_for_deployment_complete, deployment_id,
+                              resolved_version, args)
+
+        self.assertEqual(get_deployment_state_mock.call_args_list, [
+            call(deployment_id, args)
+        ])
+
+        url_mock.assert_not_called()
+
+        conductr_host_mock.assert_not_called()
+
+        get_events_mock.assert_not_called()
+
+        self.assertEqual(stdout.method_calls, [
+            call.write('Deploying cassandra:v1-abcdef'),
+            call.write('\n'),
+            call.flush()
+        ])
+
+    def test_wait_for_deployment_with_initial_deployment_not_found(self):
+        get_deployment_state_mock = MagicMock(side_effect=[
+            None,
+            self.create_deployment_state('deploymentStarted'),
+            self.create_deployment_state('bundleDownload'),
+            self.create_deployment_state('configDownload', {
+                'compatibleBundleId': 'abf60451c6af18adcc851d67b369b7f5-a53237c1f4a067e13ef00090627fb3de'
+            }),
+            self.create_deployment_state('load', {'configFileName': 'cassandra-prod-config.zip'}),
+            self.create_deployment_state('deploy', {
+                'bundleOld': {'scale': 1},
+                'bundleNew': {'scale': 0}
+            }),
+            self.create_deployment_state('deploy', {
+                'bundleOld': {'scale': 0},
+                'bundleNew': {'scale': 1}
+            }),
+            self.create_deployment_state('deploymentSuccess'),
+        ])
+        url_mock = MagicMock(return_value='/deployments/events')
+        conductr_host = '10.0.0.1'
+        conductr_host_mock = MagicMock(return_value=conductr_host)
+        get_events_mock = MagicMock(return_value=[
+            self.create_test_event(None),
+            self.create_test_event('deploymentStarted'),
+            self.create_test_event(None),
+            self.create_test_event('bundleDownload'),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event('configDownload'),
+            self.create_test_event('load'),
+            self.create_test_event(None),
+            self.create_test_event('deploy'),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event('deploy'),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event('deploymentSuccess')
+        ])
+
+        stdout = MagicMock()
+
+        deployment_id = 'a101449418187d92c789d1adc240b6d6'
+        resolved_version = {
+            'org': 'typesafe',
+            'repo': 'bundle',
+            'package_name': 'cassandra',
+            'compatibility_version': 'v1',
+            'digest': 'abcdef',
+            'resolver': bintray_resolver.__name__
+        }
+        dcos_mode = False
+        args = MagicMock(**{
+            'dcos_mode': dcos_mode,
+            'long_ids': False,
+            'wait_timeout': 10,
+            'conductr_auth': self.conductr_auth,
+            'server_verification_file': self.server_verification_file
+
+        })
+        with patch('conductr_cli.conduct_url.url', url_mock), \
+                patch('conductr_cli.conduct_url.conductr_host', conductr_host_mock), \
+                patch('conductr_cli.bundle_deploy.get_deployment_state', get_deployment_state_mock), \
+                patch('conductr_cli.sse_client.get_events', get_events_mock):
+            logging_setup.configure_logging(args, stdout)
+            bundle_deploy.wait_for_deployment_complete(deployment_id, resolved_version, args)
+
+        self.assertEqual(get_deployment_state_mock.call_args_list, [
+            call(deployment_id, args),
+            call(deployment_id, args),
+            call(deployment_id, args),
+            call(deployment_id, args),
+            call(deployment_id, args),
+            call(deployment_id, args),
+            call(deployment_id, args),
+            call(deployment_id, args)
+        ])
+
+        url_mock.assert_called_with('deployments/events', args)
+
+        conductr_host_mock.assert_called_with(args)
+
+        get_events_mock.assert_called_with(dcos_mode, conductr_host, '/deployments/events', auth=self.conductr_auth,
+                                           verify=self.server_verification_file)
+
+        self.assertEqual(stdout.method_calls, [
+            call.write('Deploying cassandra:v1-abcdef'),
+            call.write('\n'),
+            call.flush(),
+            call.write('Deployment started\r'),
+            call.write(''),
+            call.flush(),
+            call.write('Deployment started\n'),
+            call.write(''),
+            call.flush(),
+            call.write('Downloading bundle\r'),
+            call.write(''),
+            call.flush(),
+            call.write('Downloading bundle\n'),
+            call.write(''),
+            call.flush(),
+            call.write('Downloading config from bundle abf6045-a53237c\r'),
+            call.write(''),
+            call.flush(),
+            call.write('Downloading config from bundle abf6045-a53237c\n'),
+            call.write(''),
+            call.flush(),
+            call.write('Loading bundle with config\r'),
+            call.write(''),
+            call.flush(),
+            call.write('Loading bundle with config\n'),
+            call.write(''),
+            call.flush(),
+            call.write('Deploying - 1 old instance vs 0 new instance\r'),
+            call.write(''),
+            call.flush(),
+            call.write('Deploying - 1 old instance vs 0 new instance\n'),
+            call.write(''),
+            call.flush(),
+            call.write('Deploying - 0 old instance vs 1 new instance\r'),
+            call.write(''),
+            call.flush(),
+            call.write('Deploying - 0 old instance vs 1 new instance\n'),
+            call.write(''),
+            call.flush(),
+            call.write('Success'),
+            call.write('\n'),
+            call.flush()
+        ])
+
+    def test_deployment_completed_with_failure(self):
+        get_deployment_state_mock = MagicMock(side_effect=[
+            self.create_deployment_state('deploymentStarted'),
+            self.create_deployment_state('bundleDownload'),
+            self.create_deployment_state('configDownload', {
+                'compatibleBundleId': 'abf60451c6af18adcc851d67b369b7f5-a53237c1f4a067e13ef00090627fb3de'
+            }),
+            self.create_deployment_state('load', {'configFileName': 'cassandra-prod-config.zip'}),
+            self.create_deployment_state('deploy', {
+                'bundleOld': {'scale': 1},
+                'bundleNew': {'scale': 0}
+            }),
+            self.create_deployment_state('deploy', {
+                'bundleOld': {'scale': 0},
+                'bundleNew': {'scale': 1}
+            }),
+            self.create_deployment_state('deploymentFailure', {'failure': 'test only'}),
+        ])
+        url_mock = MagicMock(return_value='/deployments/events')
+        conductr_host = '10.0.0.1'
+        conductr_host_mock = MagicMock(return_value=conductr_host)
+        get_events_mock = MagicMock(return_value=[
+            self.create_test_event(None),
+            self.create_test_event('deploymentStarted'),
+            self.create_test_event(None),
+            self.create_test_event('bundleDownload'),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event('configDownload'),
+            self.create_test_event('load'),
+            self.create_test_event(None),
+            self.create_test_event('deploy'),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event('deploy'),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event('deploymentFailure')
+        ])
+
+        stdout = MagicMock()
+
+        deployment_id = 'a101449418187d92c789d1adc240b6d6'
+        resolved_version = {
+            'org': 'typesafe',
+            'repo': 'bundle',
+            'package_name': 'cassandra',
+            'compatibility_version': 'v1',
+            'digest': 'abcdef',
+            'resolver': bintray_resolver.__name__
+        }
+        dcos_mode = False
+        args = MagicMock(**{
+            'dcos_mode': dcos_mode,
+            'long_ids': False,
+            'wait_timeout': 10,
+            'conductr_auth': self.conductr_auth,
+            'server_verification_file': self.server_verification_file
+
+        })
+        with patch('conductr_cli.conduct_url.url', url_mock), \
+                patch('conductr_cli.conduct_url.conductr_host', conductr_host_mock), \
+                patch('conductr_cli.bundle_deploy.get_deployment_state', get_deployment_state_mock), \
+                patch('conductr_cli.sse_client.get_events', get_events_mock):
+            logging_setup.configure_logging(args, stdout)
+            self.assertRaises(ContinuousDeliveryError, bundle_deploy.wait_for_deployment_complete, deployment_id,
+                              resolved_version, args)
+
+        self.assertEqual(get_deployment_state_mock.call_args_list, [
+            call(deployment_id, args),
+            call(deployment_id, args),
+            call(deployment_id, args),
+            call(deployment_id, args),
+            call(deployment_id, args),
+            call(deployment_id, args),
+            call(deployment_id, args)
+        ])
+
+        url_mock.assert_called_with('deployments/events', args)
+
+        conductr_host_mock.assert_called_with(args)
+
+        get_events_mock.assert_called_with(dcos_mode, conductr_host, '/deployments/events', auth=self.conductr_auth,
+                                           verify=self.server_verification_file)
+
+        self.assertEqual(stdout.method_calls, [
+            call.write('Deploying cassandra:v1-abcdef'),
+            call.write('\n'),
+            call.flush(),
+            call.write('Downloading bundle\r'),
+            call.write(''),
+            call.flush(),
+            call.write('Downloading bundle\n'),
+            call.write(''),
+            call.flush(),
+            call.write('Downloading config from bundle abf6045-a53237c\r'),
+            call.write(''),
+            call.flush(),
+            call.write('Downloading config from bundle abf6045-a53237c\n'),
+            call.write(''),
+            call.flush(),
+            call.write('Loading bundle with config\r'),
+            call.write(''),
+            call.flush(),
+            call.write('Loading bundle with config\n'),
+            call.write(''),
+            call.flush(),
+            call.write('Deploying - 1 old instance vs 0 new instance\r'),
+            call.write(''),
+            call.flush(),
+            call.write('Deploying - 1 old instance vs 0 new instance\n'),
+            call.write(''),
+            call.flush(),
+            call.write('Deploying - 0 old instance vs 1 new instance\r'),
+            call.write(''),
+            call.flush(),
+            call.write('Deploying - 0 old instance vs 1 new instance\n'),
+            call.write(''),
+            call.flush()
+        ])
+
+    def test_periodic_check_between_events(self):
+        get_deployment_state_mock = MagicMock(return_value=self.create_deployment_state('deploymentStarted'))
+        url_mock = MagicMock(return_value='/deployments/events')
+        conductr_host = '10.0.0.1'
+        conductr_host_mock = MagicMock(return_value=conductr_host)
+        get_events_mock = MagicMock(return_value=[
+            self.create_test_event(None),
+            self.create_test_event('deploymentStarted'),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event('bundleDownload')
+        ])
+
+        stdout = MagicMock()
+
+        deployment_id = 'a101449418187d92c789d1adc240b6d6'
+        resolved_version = {
+            'org': 'typesafe',
+            'repo': 'bundle',
+            'package_name': 'cassandra',
+            'compatibility_version': 'v1',
+            'digest': 'abcdef',
+            'resolver': bintray_resolver.__name__
+        }
+        dcos_mode = False
+        args = MagicMock(**{
+            'dcos_mode': dcos_mode,
+            'long_ids': False,
+            'wait_timeout': 10,
+            'conductr_auth': self.conductr_auth,
+            'server_verification_file': self.server_verification_file
+
+        })
+        with patch('conductr_cli.conduct_url.url', url_mock), \
+                patch('conductr_cli.conduct_url.conductr_host', conductr_host_mock), \
+                patch('conductr_cli.bundle_deploy.get_deployment_state', get_deployment_state_mock), \
+                patch('conductr_cli.sse_client.get_events', get_events_mock):
+            logging_setup.configure_logging(args, stdout)
+            self.assertRaises(WaitTimeoutError, bundle_deploy.wait_for_deployment_complete,
+                              deployment_id, resolved_version, args)
+
+        self.assertEqual(get_deployment_state_mock.call_args_list, [
+            call(deployment_id, args),
+            call(deployment_id, args),
+            call(deployment_id, args),
+            call(deployment_id, args)
+        ])
+
+        url_mock.assert_called_with('deployments/events', args)
+
+        conductr_host_mock.assert_called_with(args)
+
+        get_events_mock.assert_called_with(dcos_mode, conductr_host, '/deployments/events', auth=self.conductr_auth,
+                                           verify=self.server_verification_file)
+
+    def test_wait_timeout(self):
+        get_deployment_state_mock = MagicMock(side_effect=[
+            self.create_deployment_state('deploymentStarted'),
+            self.create_deployment_state('bundleDownload'),
+            self.create_deployment_state('configDownload', {'compatibleBundleId': 'cassandra'}),
+            self.create_deployment_state('load', {'configFileName': 'cassandra-prod-config.zip'}),
+            self.create_deployment_state('deploy', {
+                'bundleOld': {'scale': 1},
+                'bundleNew': {'scale': 0}
+            }),
+            self.create_deployment_state('deploy', {
+                'bundleOld': {'scale': 0},
+                'bundleNew': {'scale': 1}
+            }),
+            self.create_deployment_state('deploymentFailure', {'failure': 'test only'}),
+        ])
+        url_mock = MagicMock(return_value='/deployments/events')
+        conductr_host = '10.0.0.1'
+        conductr_host_mock = MagicMock(return_value=conductr_host)
+        get_events_mock = MagicMock(return_value=[
+            self.create_test_event(None),
+            self.create_test_event('deploymentStarted'),
+            self.create_test_event(None),
+            self.create_test_event('bundleDownload'),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event('configDownload'),
+            self.create_test_event('load'),
+            self.create_test_event(None),
+            self.create_test_event('deploy'),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event('deploy'),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event(None)
+        ])
+
+        stdout = MagicMock()
+
+        deployment_id = 'a101449418187d92c789d1adc240b6d6'
+        resolved_version = {
+            'org': 'typesafe',
+            'repo': 'bundle',
+            'package_name': 'cassandra',
+            'compatibility_version': 'v1',
+            'digest': 'abcdef',
+            'resolver': bintray_resolver.__name__
+        }
+        dcos_mode = False
+        args = MagicMock(**{
+            'dcos_mode': dcos_mode,
+            'long_ids': False,
+            # Purposely set no timeout to invoke the error
+            'wait_timeout': -1,
+            'conductr_auth': self.conductr_auth,
+            'server_verification_file': self.server_verification_file
+
+        })
+        with patch('conductr_cli.conduct_url.url', url_mock), \
+                patch('conductr_cli.conduct_url.conductr_host', conductr_host_mock), \
+                patch('conductr_cli.bundle_deploy.get_deployment_state', get_deployment_state_mock), \
+                patch('conductr_cli.sse_client.get_events', get_events_mock):
+            logging_setup.configure_logging(args, stdout)
+            self.assertRaises(WaitTimeoutError, bundle_deploy.wait_for_deployment_complete, deployment_id,
+                              resolved_version, args)
+
+        self.assertEqual(get_deployment_state_mock.call_args_list, [
+            call(deployment_id, args)
+        ])
+
+        url_mock.assert_called_with('deployments/events', args)
+
+        conductr_host_mock.assert_called_with(args)
+
+        get_events_mock.assert_called_with(dcos_mode, conductr_host, '/deployments/events', auth=self.conductr_auth,
+                                           verify=self.server_verification_file)
+
+    def test_no_events(self):
+        get_deployment_state_mock = MagicMock(side_effect=[
+            self.create_deployment_state('deploymentStarted')
+        ])
+        url_mock = MagicMock(return_value='/deployments/events')
+        conductr_host = '10.0.0.1'
+        conductr_host_mock = MagicMock(return_value=conductr_host)
+        get_events_mock = MagicMock(return_value=[
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event(None),
+            self.create_test_event(None)
+        ])
+
+        stdout = MagicMock()
+
+        deployment_id = 'a101449418187d92c789d1adc240b6d6'
+        resolved_version = {
+            'org': 'typesafe',
+            'repo': 'bundle',
+            'package_name': 'cassandra',
+            'compatibility_version': 'v1',
+            'digest': 'abcdef',
+            'resolver': bintray_resolver.__name__
+        }
+        dcos_mode = False
+        args = MagicMock(**{
+            'dcos_mode': dcos_mode,
+            'long_ids': False,
+            # Purposely set no timeout to invoke the error
+            'wait_timeout': -1,
+            'conductr_auth': self.conductr_auth,
+            'server_verification_file': self.server_verification_file
+
+        })
+        with patch('conductr_cli.conduct_url.url', url_mock), \
+                patch('conductr_cli.conduct_url.conductr_host', conductr_host_mock), \
+                patch('conductr_cli.bundle_deploy.get_deployment_state', get_deployment_state_mock), \
+                patch('conductr_cli.sse_client.get_events', get_events_mock):
+            logging_setup.configure_logging(args, stdout)
+            self.assertRaises(WaitTimeoutError, bundle_deploy.wait_for_deployment_complete, deployment_id,
+                              resolved_version, args)
+
+        self.assertEqual(get_deployment_state_mock.call_args_list, [
+            call(deployment_id, args)
+        ])
+
+        url_mock.assert_called_with('deployments/events', args)
+
+        conductr_host_mock.assert_called_with(args)
+
+        get_events_mock.assert_called_with(dcos_mode, conductr_host, '/deployments/events', auth=self.conductr_auth,
+                                           verify=self.server_verification_file)
+
+    def create_test_event(self, event_name):
+        sse_mock = MagicMock()
+        sse_mock.event = event_name
+        return sse_mock
+
+    def create_deployment_state(self, event_type, data={}):
+        result = {}
+        result.update({'eventType': event_type})
+        result.update(data)
+        return result

--- a/conductr_cli/test/test_conduct_deploy.py
+++ b/conductr_cli/test/test_conduct_deploy.py
@@ -1,0 +1,440 @@
+from conductr_cli.test.cli_test_case import CliTestCase
+from conductr_cli import conduct_deploy
+
+try:
+    from unittest.mock import patch, MagicMock  # 3.3 and beyond
+except ImportError:
+    from mock import patch, MagicMock
+
+
+class TestConductDeploy(CliTestCase):
+
+    host = '10.0.0.1'
+    conductr_auth = ('username', 'password')
+    server_verification_file = '/home/user/test.pem'
+
+    bintray_webhook_secret = 'secret'
+    resolved_version = {
+        'org': 'typesafe',
+        'repo': 'bundle',
+        'package_name': 'cassandra',
+        'compatibility_version': 'v1',
+        'digest': 'abcabc'
+    }
+    deploy_uri = '/deployments/typesafe/bundle/typesafe'
+    bundle_id = 'cass'
+    custom_settings = MagicMock(name='custom_settings')
+    url_mock = MagicMock(name='url_mock')
+    hmac_mock = MagicMock(name='hmac_mock')
+
+    deployment_id = 'deployment_id'
+
+    def test_success(self):
+        load_bintray_webhook_secret_mock = MagicMock(return_value=self.bintray_webhook_secret)
+        resolved_version_mock = MagicMock(return_value=self.resolved_version)
+        continuous_delivery_uri_mock = MagicMock(return_value=self.deploy_uri)
+        request_deploy_confirmation_mock = MagicMock()
+        url_mock = MagicMock(return_value=self.url_mock)
+        generate_hmac_signature_mock = MagicMock(return_value=self.hmac_mock)
+        http_mock = self.respond_with(text=self.deployment_id)
+
+        wait_for_deployment_complete_mock = MagicMock()
+        input_args = MagicMock(**{
+            'dcos_mode': False,
+            'host': self.host,
+            'conductr_auth': self.conductr_auth,
+            'server_verification_file': self.server_verification_file,
+            'auto_deploy': True,
+            'bundle': self.bundle_id,
+            'custom_settings': self.custom_settings,
+            'no_wait': False
+        })
+
+        with patch('conductr_cli.custom_settings.load_bintray_webhook_secret', load_bintray_webhook_secret_mock), \
+                patch('conductr_cli.resolver.resolve_bundle_version', resolved_version_mock), \
+                patch('conductr_cli.resolver.continuous_delivery_uri', continuous_delivery_uri_mock), \
+                patch('conductr_cli.conduct_deploy.request_deploy_confirmation', request_deploy_confirmation_mock), \
+                patch('conductr_cli.conduct_url.url', url_mock), \
+                patch('conductr_cli.bundle_deploy.generate_hmac_signature', generate_hmac_signature_mock), \
+                patch('conductr_cli.conduct_request.post', http_mock), \
+                patch('conductr_cli.bundle_deploy.wait_for_deployment_complete', wait_for_deployment_complete_mock):
+            self.assertTrue(conduct_deploy.deploy(input_args))
+
+        load_bintray_webhook_secret_mock.assert_called_with(input_args)
+        resolved_version_mock.assert_called_with(self.custom_settings, self.bundle_id)
+        continuous_delivery_uri_mock.assert_called_with(self.custom_settings, self.resolved_version)
+        request_deploy_confirmation_mock.assert_not_called()
+        url_mock.assert_called_with(self.deploy_uri, input_args)
+        generate_hmac_signature_mock.assert_called_with(self.bintray_webhook_secret, 'cassandra')
+        http_mock.assert_called_with(False, self.host, self.url_mock,
+                                     json={
+                                         'package': 'cassandra',
+                                         'version': 'v1-abcabc'
+                                     },
+                                     headers={'X-Bintray-WebHook-Hmac': self.hmac_mock},
+                                     auth=self.conductr_auth,
+                                     verify=self.server_verification_file)
+        wait_for_deployment_complete_mock.assert_called_with(self.deployment_id, self.resolved_version, input_args)
+
+    def test_success_no_wait(self):
+        load_bintray_webhook_secret_mock = MagicMock(return_value=self.bintray_webhook_secret)
+        resolved_version_mock = MagicMock(return_value=self.resolved_version)
+        continuous_delivery_uri_mock = MagicMock(return_value=self.deploy_uri)
+        request_deploy_confirmation_mock = MagicMock()
+        url_mock = MagicMock(return_value=self.url_mock)
+        generate_hmac_signature_mock = MagicMock(return_value=self.hmac_mock)
+        http_mock = self.respond_with(text=self.deployment_id)
+        wait_for_deployment_complete_mock = MagicMock()
+
+        input_args = MagicMock(**{
+            'dcos_mode': False,
+            'host': self.host,
+            'conductr_auth': self.conductr_auth,
+            'server_verification_file': self.server_verification_file,
+            'auto_deploy': True,
+            'bundle': self.bundle_id,
+            'custom_settings': self.custom_settings,
+            'no_wait': True
+        })
+
+        with patch('conductr_cli.custom_settings.load_bintray_webhook_secret', load_bintray_webhook_secret_mock), \
+                patch('conductr_cli.resolver.resolve_bundle_version', resolved_version_mock), \
+                patch('conductr_cli.resolver.continuous_delivery_uri', continuous_delivery_uri_mock), \
+                patch('conductr_cli.conduct_deploy.request_deploy_confirmation', request_deploy_confirmation_mock), \
+                patch('conductr_cli.conduct_url.url', url_mock), \
+                patch('conductr_cli.bundle_deploy.generate_hmac_signature', generate_hmac_signature_mock), \
+                patch('conductr_cli.conduct_request.post', http_mock), \
+                patch('conductr_cli.bundle_deploy.wait_for_deployment_complete', wait_for_deployment_complete_mock):
+            self.assertTrue(conduct_deploy.deploy(input_args))
+
+        load_bintray_webhook_secret_mock.assert_called_with(input_args)
+        resolved_version_mock.assert_called_with(self.custom_settings, self.bundle_id)
+        continuous_delivery_uri_mock.assert_called_with(self.custom_settings, self.resolved_version)
+        request_deploy_confirmation_mock.assert_not_called()
+        url_mock.assert_called_with(self.deploy_uri, input_args)
+        generate_hmac_signature_mock.assert_called_with(self.bintray_webhook_secret, 'cassandra')
+        http_mock.assert_called_with(False, self.host, self.url_mock,
+                                     json={
+                                         'package': 'cassandra',
+                                         'version': 'v1-abcabc'
+                                     },
+                                     headers={'X-Bintray-WebHook-Hmac': self.hmac_mock},
+                                     auth=self.conductr_auth,
+                                     verify=self.server_verification_file)
+        wait_for_deployment_complete_mock.assert_not_called()
+
+    def test_success_with_confirmation(self):
+        load_bintray_webhook_secret_mock = MagicMock(return_value=self.bintray_webhook_secret)
+        resolved_version_mock = MagicMock(return_value=self.resolved_version)
+        continuous_delivery_uri_mock = MagicMock(return_value=self.deploy_uri)
+        request_deploy_confirmation_mock = MagicMock(return_value=True)
+        url_mock = MagicMock(return_value=self.url_mock)
+        generate_hmac_signature_mock = MagicMock(return_value=self.hmac_mock)
+        http_mock = self.respond_with(text=self.deployment_id)
+        wait_for_deployment_complete_mock = MagicMock()
+
+        input_args = MagicMock(**{
+            'dcos_mode': False,
+            'host': self.host,
+            'conductr_auth': self.conductr_auth,
+            'server_verification_file': self.server_verification_file,
+            'auto_deploy': False,
+            'bundle': self.bundle_id,
+            'custom_settings': self.custom_settings,
+            'no_wait': False
+        })
+
+        with patch('conductr_cli.custom_settings.load_bintray_webhook_secret', load_bintray_webhook_secret_mock), \
+                patch('conductr_cli.resolver.resolve_bundle_version', resolved_version_mock), \
+                patch('conductr_cli.resolver.continuous_delivery_uri', continuous_delivery_uri_mock), \
+                patch('conductr_cli.conduct_deploy.request_deploy_confirmation', request_deploy_confirmation_mock), \
+                patch('conductr_cli.conduct_url.url', url_mock), \
+                patch('conductr_cli.bundle_deploy.generate_hmac_signature', generate_hmac_signature_mock), \
+                patch('conductr_cli.conduct_request.post', http_mock), \
+                patch('conductr_cli.bundle_deploy.wait_for_deployment_complete', wait_for_deployment_complete_mock):
+            self.assertTrue(conduct_deploy.deploy(input_args))
+
+        load_bintray_webhook_secret_mock.assert_called_with(input_args)
+        resolved_version_mock.assert_called_with(self.custom_settings, self.bundle_id)
+        continuous_delivery_uri_mock.assert_called_with(self.custom_settings, self.resolved_version)
+        request_deploy_confirmation_mock.assert_called_with(self.resolved_version, input_args)
+        url_mock.assert_called_with(self.deploy_uri, input_args)
+        generate_hmac_signature_mock.assert_called_with(self.bintray_webhook_secret, 'cassandra')
+        http_mock.assert_called_with(False, self.host, self.url_mock,
+                                     json={
+                                         'package': 'cassandra',
+                                         'version': 'v1-abcabc'
+                                     },
+                                     headers={'X-Bintray-WebHook-Hmac': self.hmac_mock},
+                                     auth=self.conductr_auth,
+                                     verify=self.server_verification_file)
+        wait_for_deployment_complete_mock.assert_called_with(self.deployment_id, self.resolved_version, input_args)
+
+    def test_declined(self):
+        load_bintray_webhook_secret_mock = MagicMock(return_value=self.bintray_webhook_secret)
+        resolved_version_mock = MagicMock(return_value=self.resolved_version)
+        continuous_delivery_uri_mock = MagicMock(return_value=self.deploy_uri)
+        request_deploy_confirmation_mock = MagicMock(return_value=False)
+        url_mock = MagicMock(return_value=self.url_mock)
+        generate_hmac_signature_mock = MagicMock(return_value=self.hmac_mock)
+        http_mock = self.respond_with(text=self.deployment_id)
+        wait_for_deployment_complete_mock = MagicMock()
+
+        input_args = MagicMock(**{
+            'dcos_mode': False,
+            'host': self.host,
+            'conductr_auth': self.conductr_auth,
+            'server_verification_file': self.server_verification_file,
+            'auto_deploy': False,
+            'bundle': self.bundle_id,
+            'custom_settings': self.custom_settings,
+            'no_wait': False
+        })
+
+        with patch('conductr_cli.custom_settings.load_bintray_webhook_secret', load_bintray_webhook_secret_mock), \
+                patch('conductr_cli.resolver.resolve_bundle_version', resolved_version_mock), \
+                patch('conductr_cli.resolver.continuous_delivery_uri', continuous_delivery_uri_mock), \
+                patch('conductr_cli.conduct_deploy.request_deploy_confirmation', request_deploy_confirmation_mock), \
+                patch('conductr_cli.conduct_url.url', url_mock), \
+                patch('conductr_cli.bundle_deploy.generate_hmac_signature', generate_hmac_signature_mock), \
+                patch('conductr_cli.conduct_request.post', http_mock), \
+                patch('conductr_cli.bundle_deploy.wait_for_deployment_complete', wait_for_deployment_complete_mock):
+            self.assertIsNone(conduct_deploy.deploy(input_args))
+
+        load_bintray_webhook_secret_mock.assert_called_with(input_args)
+        resolved_version_mock.assert_called_with(self.custom_settings, self.bundle_id)
+        continuous_delivery_uri_mock.assert_called_with(self.custom_settings, self.resolved_version)
+        request_deploy_confirmation_mock.assert_called_with(self.resolved_version, input_args)
+        url_mock.assert_not_called()
+        generate_hmac_signature_mock.assert_not_called()
+        http_mock.assert_not_called()
+
+    def test_error_bintray_webhook_secret_not_defined(self):
+        load_bintray_webhook_secret_mock = MagicMock(return_value=None)
+        resolved_version_mock = MagicMock()
+        continuous_delivery_uri_mock = MagicMock()
+        request_deploy_confirmation_mock = MagicMock()
+        url_mock = MagicMock()
+        generate_hmac_signature_mock = MagicMock()
+        http_mock = self.respond_with(text=self.deployment_id)
+        wait_for_deployment_complete_mock = MagicMock()
+
+        input_args = MagicMock(**{
+            'dcos_mode': False,
+            'host': self.host,
+            'conductr_auth': self.conductr_auth,
+            'server_verification_file': self.server_verification_file,
+            'auto_deploy': False,
+            'bundle': self.bundle_id,
+            'custom_settings': self.custom_settings,
+            'no_wait': False
+        })
+
+        with patch('conductr_cli.custom_settings.load_bintray_webhook_secret', load_bintray_webhook_secret_mock), \
+                patch('conductr_cli.resolver.resolve_bundle_version', resolved_version_mock), \
+                patch('conductr_cli.resolver.continuous_delivery_uri', continuous_delivery_uri_mock), \
+                patch('conductr_cli.conduct_deploy.request_deploy_confirmation', request_deploy_confirmation_mock), \
+                patch('conductr_cli.conduct_url.url', url_mock), \
+                patch('conductr_cli.bundle_deploy.generate_hmac_signature', generate_hmac_signature_mock), \
+                patch('conductr_cli.conduct_request.post', http_mock), \
+                patch('conductr_cli.bundle_deploy.wait_for_deployment_complete', wait_for_deployment_complete_mock):
+            self.assertIsNone(conduct_deploy.deploy(input_args))
+
+        load_bintray_webhook_secret_mock.assert_called_with(input_args)
+        resolved_version_mock.assert_not_called()
+        continuous_delivery_uri_mock.assert_not_called()
+        request_deploy_confirmation_mock.assert_not_called()
+        url_mock.assert_not_called()
+        generate_hmac_signature_mock.assert_not_called()
+        http_mock.assert_not_called()
+
+    def test_error_resolved_version_not_found(self):
+        load_bintray_webhook_secret_mock = MagicMock(return_value=self.bintray_webhook_secret)
+        resolved_version_mock = MagicMock(return_value=None)
+        continuous_delivery_uri_mock = MagicMock()
+        request_deploy_confirmation_mock = MagicMock()
+        url_mock = MagicMock()
+        generate_hmac_signature_mock = MagicMock()
+        http_mock = self.respond_with(text=self.deployment_id)
+        wait_for_deployment_complete_mock = MagicMock()
+
+        input_args = MagicMock(**{
+            'dcos_mode': False,
+            'host': self.host,
+            'conductr_auth': self.conductr_auth,
+            'server_verification_file': self.server_verification_file,
+            'auto_deploy': False,
+            'bundle': self.bundle_id,
+            'custom_settings': self.custom_settings,
+            'no_wait': False
+        })
+
+        with patch('conductr_cli.custom_settings.load_bintray_webhook_secret', load_bintray_webhook_secret_mock), \
+                patch('conductr_cli.resolver.resolve_bundle_version', resolved_version_mock), \
+                patch('conductr_cli.resolver.continuous_delivery_uri', continuous_delivery_uri_mock), \
+                patch('conductr_cli.conduct_deploy.request_deploy_confirmation', request_deploy_confirmation_mock), \
+                patch('conductr_cli.conduct_url.url', url_mock), \
+                patch('conductr_cli.bundle_deploy.generate_hmac_signature', generate_hmac_signature_mock), \
+                patch('conductr_cli.conduct_request.post', http_mock), \
+                patch('conductr_cli.bundle_deploy.wait_for_deployment_complete', wait_for_deployment_complete_mock):
+            self.assertIsNone(conduct_deploy.deploy(input_args))
+
+        load_bintray_webhook_secret_mock.assert_called_with(input_args)
+        resolved_version_mock.assert_called_with(self.custom_settings, self.bundle_id)
+        continuous_delivery_uri_mock.assert_not_called()
+        request_deploy_confirmation_mock.assert_not_called()
+        url_mock.assert_not_called()
+        generate_hmac_signature_mock.assert_not_called()
+        http_mock.assert_not_called()
+
+    def test_error_deploy_uri_not_found(self):
+        load_bintray_webhook_secret_mock = MagicMock(return_value=self.bintray_webhook_secret)
+        resolved_version_mock = MagicMock(return_value=self.resolved_version)
+        continuous_delivery_uri_mock = MagicMock(return_value=None)
+        request_deploy_confirmation_mock = MagicMock()
+        url_mock = MagicMock()
+        generate_hmac_signature_mock = MagicMock()
+        http_mock = self.respond_with(text=self.deployment_id)
+        wait_for_deployment_complete_mock = MagicMock()
+
+        input_args = MagicMock(**{
+            'dcos_mode': False,
+            'host': self.host,
+            'conductr_auth': self.conductr_auth,
+            'server_verification_file': self.server_verification_file,
+            'auto_deploy': False,
+            'bundle': self.bundle_id,
+            'custom_settings': self.custom_settings,
+            'no_wait': False
+        })
+
+        with patch('conductr_cli.custom_settings.load_bintray_webhook_secret', load_bintray_webhook_secret_mock), \
+                patch('conductr_cli.resolver.resolve_bundle_version', resolved_version_mock), \
+                patch('conductr_cli.resolver.continuous_delivery_uri', continuous_delivery_uri_mock), \
+                patch('conductr_cli.conduct_deploy.request_deploy_confirmation', request_deploy_confirmation_mock), \
+                patch('conductr_cli.conduct_url.url', url_mock), \
+                patch('conductr_cli.bundle_deploy.generate_hmac_signature', generate_hmac_signature_mock), \
+                patch('conductr_cli.conduct_request.post', http_mock), \
+                patch('conductr_cli.bundle_deploy.wait_for_deployment_complete', wait_for_deployment_complete_mock):
+            self.assertIsNone(conduct_deploy.deploy(input_args))
+
+        load_bintray_webhook_secret_mock.assert_called_with(input_args)
+        resolved_version_mock.assert_called_with(self.custom_settings, self.bundle_id)
+        continuous_delivery_uri_mock.assert_called_with(self.custom_settings, self.resolved_version)
+        request_deploy_confirmation_mock.assert_not_called()
+        url_mock.assert_not_called()
+        generate_hmac_signature_mock.assert_not_called()
+        http_mock.assert_not_called()
+
+    def test_http_post_error(self):
+        load_bintray_webhook_secret_mock = MagicMock(return_value=self.bintray_webhook_secret)
+        resolved_version_mock = MagicMock(return_value=self.resolved_version)
+        continuous_delivery_uri_mock = MagicMock(return_value=self.deploy_uri)
+        request_deploy_confirmation_mock = MagicMock()
+        url_mock = MagicMock(return_value=self.url_mock)
+        generate_hmac_signature_mock = MagicMock(return_value=self.hmac_mock)
+        http_mock = self.respond_with(status_code=404)
+        wait_for_deployment_complete_mock = MagicMock()
+
+        input_args = MagicMock(**{
+            'dcos_mode': False,
+            'host': self.host,
+            'conductr_auth': self.conductr_auth,
+            'server_verification_file': self.server_verification_file,
+            'auto_deploy': True,
+            'bundle': self.bundle_id,
+            'custom_settings': self.custom_settings,
+            'no_wait': False
+        })
+
+        with patch('conductr_cli.custom_settings.load_bintray_webhook_secret', load_bintray_webhook_secret_mock), \
+                patch('conductr_cli.resolver.resolve_bundle_version', resolved_version_mock), \
+                patch('conductr_cli.resolver.continuous_delivery_uri', continuous_delivery_uri_mock), \
+                patch('conductr_cli.conduct_deploy.request_deploy_confirmation', request_deploy_confirmation_mock), \
+                patch('conductr_cli.conduct_url.url', url_mock), \
+                patch('conductr_cli.bundle_deploy.generate_hmac_signature', generate_hmac_signature_mock), \
+                patch('conductr_cli.conduct_request.post', http_mock), \
+                patch('conductr_cli.bundle_deploy.wait_for_deployment_complete', wait_for_deployment_complete_mock):
+            self.assertFalse(conduct_deploy.deploy(input_args))
+
+        load_bintray_webhook_secret_mock.assert_called_with(input_args)
+        resolved_version_mock.assert_called_with(self.custom_settings, self.bundle_id)
+        continuous_delivery_uri_mock.assert_called_with(self.custom_settings, self.resolved_version)
+        request_deploy_confirmation_mock.assert_not_called()
+        url_mock.assert_called_with(self.deploy_uri, input_args)
+        generate_hmac_signature_mock.assert_called_with(self.bintray_webhook_secret, 'cassandra')
+        http_mock.assert_called_with(False, self.host, self.url_mock,
+                                     json={
+                                         'package': 'cassandra',
+                                         'version': 'v1-abcabc'
+                                     },
+                                     headers={'X-Bintray-WebHook-Hmac': self.hmac_mock},
+                                     auth=self.conductr_auth,
+                                     verify=self.server_verification_file)
+        wait_for_deployment_complete_mock.assert_not_called()
+
+
+class TestDeployConfirmation(CliTestCase):
+
+    resolved_version = {
+        'org': 'typesafe',
+        'repo': 'bundle',
+        'package_name': 'cassandra',
+        'compatibility_version': 'v1',
+        'digest': 'd073991ab918ee22c7426af8a62a48c5-a53237c1f4a067e13ef00090627fb3de'
+    }
+
+    def test_return_true_if_empty(self):
+        input_mock = MagicMock(return_value='')
+        input_args = MagicMock(**{
+            'long_ids': False
+        })
+
+        with patch('builtins.input', input_mock):
+            self.assertTrue(conduct_deploy.request_deploy_confirmation(self.resolved_version, input_args))
+
+        input_mock.assert_called_with('Deploy cassandra:v1-d073991-a53237c? [Y/n]: ')
+
+    def test_return_true_if_empty_with_long_ids(self):
+        input_mock = MagicMock(return_value='')
+        input_args = MagicMock(**{
+            'long_ids': True
+        })
+
+        with patch('builtins.input', input_mock):
+            self.assertTrue(conduct_deploy.request_deploy_confirmation(self.resolved_version, input_args))
+
+        input_mock.assert_called_with('Deploy cassandra:v1-d073991ab918ee22c7426af8a62a48c5-a53237c1f4a067e13ef00090627fb3de? [Y/n]: ')
+
+    def test_return_true_if_y(self):
+        input_mock = MagicMock(return_value='y')
+        input_args = MagicMock(**{
+            'long_ids': False
+        })
+
+        with patch('builtins.input', input_mock):
+            self.assertTrue(conduct_deploy.request_deploy_confirmation(self.resolved_version, input_args))
+
+        input_mock.assert_called_with('Deploy cassandra:v1-d073991-a53237c? [Y/n]: ')
+
+    def test_return_true_if_yes(self):
+        input_mock = MagicMock(return_value='yes')
+        input_args = MagicMock(**{
+            'long_ids': False
+        })
+
+        with patch('builtins.input', input_mock):
+            self.assertTrue(conduct_deploy.request_deploy_confirmation(self.resolved_version, input_args))
+
+        input_mock.assert_called_with('Deploy cassandra:v1-d073991-a53237c? [Y/n]: ')
+
+    def test_return_false(self):
+        input_mock = MagicMock(return_value='anything else')
+        input_args = MagicMock(**{
+            'long_ids': False
+        })
+
+        with patch('builtins.input', input_mock):
+            self.assertFalse(conduct_deploy.request_deploy_confirmation(self.resolved_version, input_args))
+
+        input_mock.assert_called_with('Deploy cassandra:v1-d073991-a53237c? [Y/n]: ')

--- a/conductr_cli/test/test_conduct_main.py
+++ b/conductr_cli/test/test_conduct_main.py
@@ -139,6 +139,19 @@ class TestConduct(TestCase):
         self.assertEqual(args.wait_timeout, 60)
         self.assertEqual(args.bundle, 'path-to-bundle')
 
+    def test_parser_deploy(self):
+        args = self.parser.parse_args('deploy cassandra'.split())
+
+        self.assertEqual(args.func.__name__, 'deploy')
+        self.assertEqual(args.ip, None)
+        self.assertEqual(args.port, 9005)
+        self.assertEqual(args.api_version, '2')
+        self.assertEqual(args.cli_settings_dir, '{}/.conductr'.format(os.path.expanduser('~')))
+        self.assertEqual(args.no_wait, False)
+        self.assertEqual(args.wait_timeout, 180)
+        self.assertEqual(args.long_ids, False)
+        self.assertEqual(args.bundle, 'cassandra')
+
     def test_default_with_dcos(self):
         dcos_parser = build_parser(True)
 

--- a/conductr_cli/test/test_custom_settings.py
+++ b/conductr_cli/test/test_custom_settings.py
@@ -287,3 +287,51 @@ class TestCustomSettingsLoadServerSSLVerificationFile(TestCase):
         load_from_file_mock.assert_not_called()
 
         self.assertIsNone(result)
+
+
+class TestLoadBintrayWebhookSecret(TestCase):
+    def test_return_secret(self):
+        test_custom_settings = ConfigFactory.parse_string(
+            strip_margin("""|conductr {
+                            |  continuous-delivery {
+                            |    bintray-webhook-secret = secret
+                            |  }
+                            |}
+                            |""")
+        )
+        load_from_file_mock = MagicMock(return_value=test_custom_settings)
+        input_args = MagicMock(**{})
+
+        with patch('conductr_cli.custom_settings.load_from_file', load_from_file_mock):
+            result = custom_settings.load_bintray_webhook_secret(input_args)
+
+        load_from_file_mock.assert_called_with(input_args)
+
+        self.assertEqual('secret', result)
+
+    def test_return_none_if_custom_settings_not_defined(self):
+        load_from_file_mock = MagicMock(return_value=None)
+        input_args = MagicMock(**{})
+
+        with patch('conductr_cli.custom_settings.load_from_file', load_from_file_mock):
+            result = custom_settings.load_bintray_webhook_secret(input_args)
+
+        load_from_file_mock.assert_called_with(input_args)
+
+        self.assertIsNone(result)
+
+    def test_return_none_if_webhook_not_configured(self):
+        test_custom_settings = ConfigFactory.parse_string(
+            strip_margin("""|abc {
+                            |  def = 123
+                            |}""")
+        )
+        load_from_file_mock = MagicMock(return_value=test_custom_settings)
+        input_args = MagicMock(**{})
+
+        with patch('conductr_cli.custom_settings.load_from_file', load_from_file_mock):
+            result = custom_settings.load_bintray_webhook_secret(input_args)
+
+        load_from_file_mock.assert_called_with(input_args)
+
+        self.assertIsNone(result)


### PR DESCRIPTION
Conduct Deploy command is the CLI interface to the Continuous Delivery service.

It accepts a bundle as the input argument, and requires bintray webhook secret to be configured in the CLI settings file.

When invoked, it will perform the following tasks:

* Use the resolver mechanism to obtain a version to deploy.
* Prompt the user for deploy confirmation. User can specified "always accept" via command line argument.
* If the user agrees to deploy, request deployment to the Continuous Delivery service which are proxied via Control Protocol, using the resolved version as the input.
* Listen to the Deployment events SSE, checking for the deployment state at a regular interval or whenever a new event is received.
* Users are notified of the deployment progress in this manner.
* Deployment may complete with success, failure, or timeout.

Changes required are:

* Modify CLI settings to support bintray webhook secret settings.
* Modify resolvers to return resolved version given a bundle as the input.
* Modify resolvers to return Deployment URIs given a resolved version as the input.
* Implement support for HMAC generation to be sent as part of CD deploy request.