### PR TITLE
Use type int for --wait-timeout

### DIFF
--- a/conductr_cli/conduct_main.py
+++ b/conductr_cli/conduct_main.py
@@ -137,6 +137,7 @@ def add_wait_timeout(sub_parser):
     sub_parser.add_argument('--wait-timeout',
                             help='Timeout in seconds waiting for bundle scale to be achieved in conduct run, '
                                  'or bundle to be stopped in conduct stop, defaults to {}'.format(DEFAULT_WAIT_TIMEOUT),
+                            type=int,
                             default=DEFAULT_WAIT_TIMEOUT,
                             dest='wait_timeout')
 


### PR DESCRIPTION
The `--wait-timeout` was interpreted as string and not as int. Therefore, an exception was thrown when speciying a wait timeout:

```
2016-12-08 11:05:47,296: Failure running the following command: ['/usr/local/bin/conduct', 'load', '--wait-timeout', '99.0', '/Users/mj/workspace/conductr/conductr/target/universal/stage/samples/visualizer-v2-66ce7af1a4845b941ec00dd9a8f4c992a99115a2c9800bd622396fa2f99eb203.zip']
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/site-packages/conductr_cli/main_handler.py", line 14, in run
    result = callback()
  File "/usr/local/lib/python3.5/site-packages/conductr_cli/conduct.py", line 6, in main_method
    conduct_main.run()
  File "/usr/local/lib/python3.5/site-packages/conductr_cli/conduct_main.py", line 445, in run
    is_completed_without_error = args.func(args)
  File "/usr/local/lib/python3.5/site-packages/conductr_cli/validation.py", line 36, in handler
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.5/site-packages/conductr_cli/validation.py", line 52, in handler
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.5/site-packages/conductr_cli/validation.py", line 70, in handler
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.5/site-packages/conductr_cli/validation.py", line 87, in handler
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.5/site-packages/conductr_cli/validation.py", line 107, in handler
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.5/site-packages/conductr_cli/validation.py", line 123, in handler
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.5/site-packages/conductr_cli/validation.py", line 139, in handler
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.5/site-packages/conductr_cli/validation.py", line 155, in handler
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.5/site-packages/conductr_cli/validation.py", line 171, in handler
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.5/site-packages/conductr_cli/validation.py", line 189, in handler
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.5/site-packages/conductr_cli/conduct_load.py", line 37, in load
    return load_v2(args)
  File "/usr/local/lib/python3.5/site-packages/conductr_cli/conduct_load.py", line 199, in load_v2
    bundle_installation.wait_for_installation(response_json['bundleId'], args)
  File "/usr/local/lib/python3.5/site-packages/conductr_cli/bundle_installation.py", line 29, in wait_for_installation
    return wait_for_condition(bundle_id, is_installed, 'installed', args)
  File "/usr/local/lib/python3.5/site-packages/conductr_cli/bundle_installation.py", line 52, in wait_for_condition
    if elapsed > args.wait_timeout:
TypeError: unorderable types: float() > str()
```

This exception has been fixed by using the type `int` for the `--wait-timeout`.