### PR TITLE
Remove unused test codes to support Python 2.7

### DIFF
--- a/conductr_cli/resolvers/test/test_bintray_resolver.py
+++ b/conductr_cli/resolvers/test/test_bintray_resolver.py
@@ -5,11 +5,7 @@ from conductr_cli.exceptions import MalformedBundleUriError, BintrayResolutionEr
 from requests.exceptions import HTTPError
 import io
 import os
-
-try:
-    from unittest.mock import call, patch, MagicMock, Mock  # 3.3 and beyond
-except ImportError:
-    from mock import call, patch, MagicMock, Mock
+from unittest.mock import call, patch, MagicMock, Mock
 
 
 class TestResolveBundle(TestCase):

--- a/conductr_cli/resolvers/test/test_uri_resolver.py
+++ b/conductr_cli/resolvers/test/test_uri_resolver.py
@@ -4,10 +4,7 @@ from conductr_cli.resolvers import uri_resolver
 from conductr_cli.test.cli_test_case import create_mock_logger
 import os
 
-try:
-    from unittest.mock import call, patch, MagicMock  # 3.3 and beyond
-except ImportError:
-    from mock import call, patch, MagicMock
+from unittest.mock import call, patch, MagicMock
 
 
 class TestResolveBundle(TestCase):

--- a/conductr_cli/test/cli_test_case.py
+++ b/conductr_cli/test/cli_test_case.py
@@ -4,11 +4,7 @@ import tempfile
 from unittest import TestCase
 from requests.exceptions import ConnectionError, HTTPError, ReadTimeout
 from conductr_cli.ansi_colors import RED, YELLOW, UNDERLINE, ENDC
-
-try:
-    from unittest.mock import MagicMock  # 3.3 and beyond
-except ImportError:
-    from mock import MagicMock
+from unittest.mock import MagicMock
 
 
 class CliTestCase(TestCase):

--- a/conductr_cli/test/conduct_load_test_base.py
+++ b/conductr_cli/test/conduct_load_test_base.py
@@ -3,13 +3,8 @@ from conductr_cli import conduct_load, logging_setup
 from conductr_cli.exceptions import BundleResolutionError, WaitTimeoutError
 from zipfile import BadZipFile
 from urllib.error import HTTPError, URLError
+from unittest.mock import patch, MagicMock
 import logging
-
-
-try:
-    from unittest.mock import patch, MagicMock  # 3.3 and beyond
-except ImportError:
-    from mock import patch, MagicMock
 
 
 class ConductLoadTestBase(CliTestCase):

--- a/conductr_cli/test/conduct_run_test_base.py
+++ b/conductr_cli/test/conduct_run_test_base.py
@@ -1,11 +1,7 @@
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin, as_error
 from conductr_cli import conduct_run, logging_setup
 from conductr_cli.exceptions import WaitTimeoutError
-
-try:
-    from unittest.mock import patch, MagicMock  # 3.3 and beyond
-except ImportError:
-    from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 
 class ConductRunTestBase(CliTestCase):

--- a/conductr_cli/test/test_bundle_deploy.py
+++ b/conductr_cli/test/test_bundle_deploy.py
@@ -3,13 +3,9 @@ from conductr_cli import bundle_deploy, logging_setup
 from conductr_cli.exceptions import ContinuousDeliveryError, WaitTimeoutError
 from conductr_cli.resolvers import bintray_resolver
 from unittest import TestCase
+from unittest.mock import call, patch, MagicMock
 
 import json
-
-try:
-    from unittest.mock import call, patch, MagicMock  # 3.3 and beyond
-except ImportError:
-    from mock import call, patch, MagicMock
 
 
 class TestGenerateHmac(TestCase):

--- a/conductr_cli/test/test_bundle_installation.py
+++ b/conductr_cli/test/test_bundle_installation.py
@@ -1,11 +1,7 @@
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
 from conductr_cli import bundle_installation, logging_setup
 from conductr_cli.exceptions import WaitTimeoutError
-
-try:
-    from unittest.mock import call, patch, MagicMock  # 3.3 and beyond
-except ImportError:
-    from mock import call, patch, MagicMock
+from unittest.mock import call, patch, MagicMock
 
 
 def create_test_event(event_name):

--- a/conductr_cli/test/test_bundle_scale.py
+++ b/conductr_cli/test/test_bundle_scale.py
@@ -1,11 +1,7 @@
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
 from conductr_cli import bundle_scale, logging_setup
 from conductr_cli.exceptions import WaitTimeoutError
-
-try:
-    from unittest.mock import call, patch, MagicMock  # 3.3 and beyond
-except ImportError:
-    from mock import call, patch, MagicMock
+from unittest.mock import call, patch, MagicMock
 
 
 class TestGetScaleIp(CliTestCase):

--- a/conductr_cli/test/test_conduct_acls.py
+++ b/conductr_cli/test/test_conduct_acls.py
@@ -1,11 +1,7 @@
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
 from conductr_cli import conduct_acls, logging_setup
 from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
-
-try:
-    from unittest.mock import patch, MagicMock  # 3.3 and beyond
-except ImportError:
-    from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 
 class TestConductAclsCommandForHttp(CliTestCase):

--- a/conductr_cli/test/test_conduct_dcos.py
+++ b/conductr_cli/test/test_conduct_dcos.py
@@ -1,12 +1,8 @@
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
 from conductr_cli import conduct_dcos, logging_setup
+from unittest.mock import patch, MagicMock
 
 import os
-
-try:
-    from unittest.mock import patch, MagicMock  # 3.3 and beyond
-except ImportError:
-    from mock import patch, MagicMock
 
 
 class TestConductDcosCommand(CliTestCase):

--- a/conductr_cli/test/test_conduct_deploy.py
+++ b/conductr_cli/test/test_conduct_deploy.py
@@ -1,10 +1,6 @@
 from conductr_cli.test.cli_test_case import CliTestCase
 from conductr_cli import conduct_deploy
-
-try:
-    from unittest.mock import patch, MagicMock  # 3.3 and beyond
-except ImportError:
-    from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 
 class TestConductDeploy(CliTestCase):

--- a/conductr_cli/test/test_conduct_events.py
+++ b/conductr_cli/test/test_conduct_events.py
@@ -1,12 +1,7 @@
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
 from conductr_cli import conduct_events, logging_setup
 from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
-
-
-try:
-    from unittest.mock import patch, MagicMock  # 3.3 and beyond
-except ImportError:
-    from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 
 class TestConductEventsCommand(CliTestCase):

--- a/conductr_cli/test/test_conduct_info.py
+++ b/conductr_cli/test/test_conduct_info.py
@@ -1,12 +1,7 @@
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
 from conductr_cli import conduct_info, logging_setup
 from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
-
-
-try:
-    from unittest.mock import patch, MagicMock  # 3.3 and beyond
-except ImportError:
-    from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 
 class TestConductInfoCommand(CliTestCase):

--- a/conductr_cli/test/test_conduct_load_functions.py
+++ b/conductr_cli/test/test_conduct_load_functions.py
@@ -1,14 +1,10 @@
 from unittest import TestCase
+from unittest.mock import call, patch, MagicMock
 from conductr_cli import conduct_load
 from requests_toolbelt.multipart.encoder import MultipartEncoder, MultipartEncoderMonitor
 
 import datetime
 import io
-
-try:
-    from unittest.mock import call, patch, MagicMock  # 3.3 and beyond
-except ImportError:
-    from mock import call, patch, MagicMock
 
 
 class TestCommonFunctions(TestCase):

--- a/conductr_cli/test/test_conduct_load_v1.py
+++ b/conductr_cli/test/test_conduct_load_v1.py
@@ -2,12 +2,8 @@ from conductr_cli.test.conduct_load_test_base import ConductLoadTestBase
 from conductr_cli.test.cli_test_case import create_temp_bundle, strip_margin, as_error, \
     create_temp_bundle_with_contents
 from conductr_cli import conduct_load, logging_setup
+from unittest.mock import call, patch, MagicMock, Mock
 import shutil
-
-try:
-    from unittest.mock import call, patch, MagicMock, Mock  # 3.3 and beyond
-except ImportError:
-    from mock import call, patch, MagicMock, Mock
 
 
 class TestConductLoadCommand(ConductLoadTestBase):

--- a/conductr_cli/test/test_conduct_load_v2.py
+++ b/conductr_cli/test/test_conduct_load_v2.py
@@ -2,11 +2,7 @@ from conductr_cli.test.cli_test_case import create_temp_bundle, strip_margin, as
     create_temp_bundle_with_contents
 from conductr_cli.test.conduct_load_test_base import ConductLoadTestBase
 from conductr_cli import conduct_load, logging_setup
-
-try:
-    from unittest.mock import call, patch, MagicMock, Mock  # 3.3 and beyond
-except ImportError:
-    from mock import call, patch, MagicMock, Mock
+from unittest.mock import call, patch, MagicMock, Mock
 
 
 class TestConductLoadCommand(ConductLoadTestBase):

--- a/conductr_cli/test/test_conduct_logging.py
+++ b/conductr_cli/test/test_conduct_logging.py
@@ -1,11 +1,7 @@
 from unittest import TestCase
 from conductr_cli import validation
+from unittest.mock import MagicMock
 import arrow
-
-try:
-    from unittest.mock import MagicMock  # 3.3 and beyond
-except ImportError:
-    from mock import MagicMock
 
 
 class TestConductLogsCommand(TestCase):

--- a/conductr_cli/test/test_conduct_logs.py
+++ b/conductr_cli/test/test_conduct_logs.py
@@ -1,12 +1,7 @@
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
 from conductr_cli import conduct_logs, logging_setup
 from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
-
-
-try:
-    from unittest.mock import patch, MagicMock  # 3.3 and beyond
-except ImportError:
-    from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 
 class TestConductLogsCommand(CliTestCase):

--- a/conductr_cli/test/test_conduct_request.py
+++ b/conductr_cli/test/test_conduct_request.py
@@ -1,11 +1,6 @@
 from unittest import TestCase
-
+from unittest.mock import patch, MagicMock
 from conductr_cli import conduct_request
-
-try:
-    from unittest.mock import patch, MagicMock  # 3.3 and beyond
-except ImportError:
-    from mock import patch, MagicMock
 
 
 class TestRequest(TestCase):

--- a/conductr_cli/test/test_conduct_run_v1.py
+++ b/conductr_cli/test/test_conduct_run_v1.py
@@ -1,12 +1,7 @@
 from conductr_cli.test.cli_test_case import strip_margin, as_error
 from conductr_cli.test.conduct_run_test_base import ConductRunTestBase
 from conductr_cli import conduct_run, logging_setup
-
-
-try:
-    from unittest.mock import MagicMock  # 3.3 and beyond
-except ImportError:
-    from mock import MagicMock
+from unittest.mock import MagicMock
 
 
 class TestConductRunCommand(ConductRunTestBase):

--- a/conductr_cli/test/test_conduct_run_v2.py
+++ b/conductr_cli/test/test_conduct_run_v2.py
@@ -1,10 +1,6 @@
 from conductr_cli.test.conduct_run_test_base import ConductRunTestBase
 from conductr_cli import conduct_run, logging_setup
-
-try:
-    from unittest.mock import patch, MagicMock  # 3.3 and beyond
-except ImportError:
-    from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 
 class TestConductRunCommand(ConductRunTestBase):

--- a/conductr_cli/test/test_conduct_service_names.py
+++ b/conductr_cli/test/test_conduct_service_names.py
@@ -1,12 +1,7 @@
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin, as_warn
 from conductr_cli import conduct_service_names, logging_setup
 from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
-
-
-try:
-    from unittest.mock import patch, MagicMock  # 3.3 and beyond
-except ImportError:
-    from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 
 class TestConductServiceNamesCommand(CliTestCase):

--- a/conductr_cli/test/test_conduct_stop.py
+++ b/conductr_cli/test/test_conduct_stop.py
@@ -2,12 +2,7 @@ from conductr_cli.test.cli_test_case import CliTestCase, strip_margin, as_error
 from conductr_cli import conduct_stop, logging_setup
 from conductr_cli.exceptions import WaitTimeoutError
 from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
-
-
-try:
-    from unittest.mock import patch, MagicMock  # 3.3 and beyond
-except ImportError:
-    from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 
 class TestConductStopCommand(CliTestCase):

--- a/conductr_cli/test/test_conduct_unload.py
+++ b/conductr_cli/test/test_conduct_unload.py
@@ -1,11 +1,7 @@
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin, as_error
 from conductr_cli import conduct_unload, logging_setup
 from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
-
-try:
-    from unittest.mock import patch, MagicMock  # 3.3 and beyond
-except ImportError:
-    from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 
 class TestConductUnloadCommand(CliTestCase):

--- a/conductr_cli/test/test_conduct_url.py
+++ b/conductr_cli/test/test_conduct_url.py
@@ -1,10 +1,6 @@
 from unittest import TestCase
 from conductr_cli import conduct_url
-
-try:
-    from unittest.mock import MagicMock  # 3.3 and beyond
-except ImportError:
-    from mock import MagicMock
+from unittest.mock import MagicMock
 
 
 class TestConductUrlIp(TestCase):

--- a/conductr_cli/test/test_custom_settings.py
+++ b/conductr_cli/test/test_custom_settings.py
@@ -1,12 +1,8 @@
 from unittest import TestCase
+from unittest.mock import patch, MagicMock
 from conductr_cli.test.cli_test_case import strip_margin
 from conductr_cli import custom_settings
 from pyhocon import ConfigFactory
-
-try:
-    from unittest.mock import patch, MagicMock  # 3.3 and beyond
-except ImportError:
-    from mock import patch, MagicMock
 
 
 class TestCustomSettingsLoadCredentials(TestCase):

--- a/conductr_cli/test/test_host.py
+++ b/conductr_cli/test/test_host.py
@@ -1,12 +1,8 @@
 from unittest import TestCase
+from unittest.mock import patch, MagicMock
 from conductr_cli import host
 from conductr_cli.docker import DockerVmType
 from conductr_cli.exceptions import DockerMachineNotRunningError
-
-try:
-    from unittest.mock import patch, MagicMock  # 3.3 and beyond
-except ImportError:
-    from mock import patch, MagicMock
 
 
 class TestResolveDefaultHost(TestCase):

--- a/conductr_cli/test/test_logging_setup.py
+++ b/conductr_cli/test/test_logging_setup.py
@@ -1,11 +1,7 @@
 from conductr_cli.test.cli_test_case import CliTestCase, as_error, as_warn, strip_margin
 from conductr_cli import logging_setup
+from unittest.mock import MagicMock
 import logging
-
-try:
-    from unittest.mock import MagicMock  # 3.3 and beyond
-except ImportError:
-    from mock import MagicMock
 
 
 class TestRootLogger(CliTestCase):

--- a/conductr_cli/test/test_main_handler.py
+++ b/conductr_cli/test/test_main_handler.py
@@ -1,13 +1,8 @@
 from conductr_cli.test.cli_test_case import CliTestCase
 from conductr_cli import main_handler
 from conductr_cli.constants import DEFAULT_CLI_SETTINGS_DIR, DEFAULT_ERROR_LOG_FILE
+from unittest.mock import MagicMock, patch, call
 import sys
-
-
-try:
-    from unittest.mock import MagicMock, patch, call  # 3.3 and beyond
-except ImportError:
-    from mock import MagicMock, patch, call
 
 
 class TestMainHandler(CliTestCase):

--- a/conductr_cli/test/test_resolver.py
+++ b/conductr_cli/test/test_resolver.py
@@ -1,14 +1,10 @@
 from unittest import TestCase
+from unittest.mock import patch, MagicMock, Mock
 from conductr_cli.test.cli_test_case import strip_margin, create_mock_logger
 from conductr_cli.exceptions import BundleResolutionError
 from conductr_cli import resolver
 from conductr_cli.resolvers import bintray_resolver, uri_resolver
 from pyhocon import ConfigFactory
-
-try:
-    from unittest.mock import patch, MagicMock, Mock  # 3.3 and beyond
-except ImportError:
-    from mock import patch, MagicMock, Mock
 
 
 class TestResolver(TestCase):

--- a/conductr_cli/test/test_sandbox_common.py
+++ b/conductr_cli/test/test_sandbox_common.py
@@ -1,10 +1,6 @@
 from conductr_cli.test.cli_test_case import CliTestCase
 from conductr_cli import sandbox_common
-
-try:
-    from unittest.mock import patch, MagicMock  # 3.3 and beyond
-except ImportError:
-    from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 
 class TestSandboxCommon(CliTestCase):

--- a/conductr_cli/test/test_sandbox_features.py
+++ b/conductr_cli/test/test_sandbox_features.py
@@ -1,13 +1,9 @@
 from unittest import TestCase
+from unittest.mock import call, patch, MagicMock
 from conductr_cli.sandbox_features import VisualizationFeature, LiteLoggingFeature,\
     LoggingFeature, MonitoringFeature, \
     collect_features, select_bintray_uri
 from conductr_cli.sandbox_common import LATEST_CONDUCTR_VERSION
-
-try:
-    from unittest.mock import call, patch, MagicMock  # 3.3 and beyond
-except ImportError:
-    from mock import call, patch, MagicMock
 
 
 class TestFeatures(TestCase):

--- a/conductr_cli/test/test_sandbox_main.py
+++ b/conductr_cli/test/test_sandbox_main.py
@@ -3,11 +3,7 @@ from conductr_cli import sandbox_main, logging_setup
 from conductr_cli.sandbox_common import LATEST_CONDUCTR_VERSION, CONDUCTR_DEV_IMAGE
 from conductr_cli.docker import DockerVmType
 from subprocess import CalledProcessError
-
-try:
-    from unittest.mock import patch, MagicMock  # 3.3 and beyond
-except ImportError:
-    from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 
 class TestSandbox(CliTestCase):

--- a/conductr_cli/test/test_sandbox_run.py
+++ b/conductr_cli/test/test_sandbox_run.py
@@ -3,13 +3,8 @@ from conductr_cli import sandbox_run, logging_setup
 from conductr_cli.docker import DockerVmType
 from conductr_cli.sandbox_common import CONDUCTR_DEV_IMAGE, LATEST_CONDUCTR_VERSION
 from conductr_cli.sandbox_run import DEFAULT_WAIT_RETRIES, DEFAULT_WAIT_RETRY_INTERVAL
+from unittest.mock import patch, MagicMock
 import os
-
-
-try:
-    from unittest.mock import patch, MagicMock  # 3.3 and beyond
-except ImportError:
-    from mock import patch, MagicMock
 
 
 class TestSandboxRunCommand(CliTestCase):

--- a/conductr_cli/test/test_sandbox_stop.py
+++ b/conductr_cli/test/test_sandbox_stop.py
@@ -1,12 +1,7 @@
 from conductr_cli.test.cli_test_case import CliTestCase
 from conductr_cli import sandbox_stop, logging_setup
 from conductr_cli.screen_utils import headline
-
-
-try:
-    from unittest.mock import patch, MagicMock  # 3.3 and beyond
-except ImportError:
-    from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 
 class TestSandboxStopCommand(CliTestCase):

--- a/conductr_cli/test/test_shazar_main.py
+++ b/conductr_cli/test/test_shazar_main.py
@@ -6,11 +6,7 @@ from os import remove
 from conductr_cli import logging_setup
 from conductr_cli.shazar_main import create_digest, build_parser, run
 from conductr_cli.test.cli_test_case import CliTestCase
-
-try:
-    from unittest.mock import patch, MagicMock  # 3.3 and beyond
-except ImportError:
-    from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 
 class TestShazar(TestCase):

--- a/conductr_cli/test/test_sse_client.py
+++ b/conductr_cli/test/test_sse_client.py
@@ -1,11 +1,7 @@
 from unittest import TestCase
 from conductr_cli.test.cli_test_case import strip_margin
 from conductr_cli import sse_client
-
-try:
-    from unittest.mock import patch, MagicMock  # 3.3 and beyond
-except ImportError:
-    from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 
 class TestSSEClient(TestCase):

--- a/conductr_cli/test/test_terminal.py
+++ b/conductr_cli/test/test_terminal.py
@@ -1,12 +1,7 @@
 import subprocess
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
 from conductr_cli import terminal
-
-
-try:
-    from unittest.mock import patch, MagicMock  # 3.3 and beyond
-except ImportError:
-    from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 
 class TestTerminal(CliTestCase):

--- a/conductr_cli/test/test_version.py
+++ b/conductr_cli/test/test_version.py
@@ -1,10 +1,6 @@
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
 from conductr_cli import version, logging_setup
-
-try:
-    from unittest.mock import MagicMock  # 3.3 and beyond
-except ImportError:
-    from mock import MagicMock
+from unittest.mock import MagicMock
 
 
 class TestConductVersionCommand(CliTestCase):


### PR DESCRIPTION
This is because we now support python 3.4 and above.