### PR TITLE
Initial work for Sandbox run 2.0.0

### DIFF
--- a/conductr_cli/sandbox_run.py
+++ b/conductr_cli/sandbox_run.py
@@ -1,8 +1,8 @@
-from conductr_cli import conduct_main, conduct_request, conduct_url, terminal, validation, sandbox_stop, host
+from conductr_cli import conduct_main, conduct_request, conduct_url, validation, host, \
+    sandbox_features, sandbox_run_docker, sandbox_run_jvm
 from conductr_cli.constants import DEFAULT_SCHEME, DEFAULT_PORT, DEFAULT_BASE_PATH, DEFAULT_API_VERSION
 from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
-from conductr_cli.sandbox_common import CONDUCTR_NAME_PREFIX, CONDUCTR_DEV_IMAGE, CONDUCTR_PORTS, major_version
-from conductr_cli.sandbox_features import collect_features
+from conductr_cli.sandbox_common import major_version
 from conductr_cli.screen_utils import headline
 from requests.exceptions import ConnectionError
 
@@ -33,171 +33,25 @@ class ConductArgs:
 def run(args):
     """`sandbox run` command"""
 
-    pull_image(args)
-    features = collect_features(args.features, args.image_version)
-    container_names = scale_cluster(args, features)
+    is_conductr_v1 = major_version(args.image_version) == 1
+    features = sandbox_features.collect_features(args.features, args.image_version)
+
+    if is_conductr_v1:
+        run_result = sandbox_run_docker.run(args, features)
+    else:
+        run_result = sandbox_run_jvm.run(args, features)
+
     is_started, wait_timeout = wait_for_start(args)
     if is_started:
-        if major_version(args.image_version) != 1:
+        if not is_conductr_v1:
             start_proxy(args.nr_of_containers)
         for feature in features:
             feature.start()
-    print_result(container_names, is_started, args.no_wait, wait_timeout, args.image_version)
 
-
-def pull_image(args):
-    if args.image == CONDUCTR_DEV_IMAGE and not terminal.docker_images(CONDUCTR_DEV_IMAGE):
-        log = logging.getLogger(__name__)
-        log.info('Pulling down the ConductR development image..')
-        terminal.docker_pull('{image_name}:{image_version}'
-                             .format(image_name=CONDUCTR_DEV_IMAGE, image_version=args.image_version))
-
-
-def collect_ports(args, features):
-    """Return a Set of ports based on the ports of each enabled feature and the ports specified by the user"""
-
-    feature_ports = flatten([feature.ports for feature in features])
-    return set(args.ports + feature_ports)
-
-
-def flatten(list):
-    return [item for sublist in list for item in sublist]
-
-
-def scale_cluster(args, features):
-    sandbox_stop.stop(args)
-    return start_nodes(args, features)
-
-
-def start_nodes(args, features):
-    container_names = []
-    log = logging.getLogger(__name__)
-    log.info(headline('Starting ConductR'))
-    ports = collect_ports(args, features)
-    conductr_args = flatten([feature.conductr_args() for feature in features])
-    conductr_features = flatten([feature.conductr_feature_envs() for feature in features])
-    feature_conductr_roles = flatten([feature.conductr_roles() for feature in features])
-    for i in range(args.nr_of_containers):
-        container_name = '{prefix}{nr}'.format(prefix=CONDUCTR_NAME_PREFIX, nr=i)
-        container_names.append(container_name)
-        # Display the ports on the command line. Only if the user specifies a certain feature, then
-        # the corresponding port will be displayed when running 'sandbox run' or 'sandbox debug'
-        if ports:
-            host_ip = host.resolve_ip_by_vm_type(args.vm_type)
-            ports_desc = ' exposing ' + ', '.join(['{}:{}'.format(host_ip, map_port(i, port))
-                                                   for port in sorted(ports)])
-        else:
-            ports_desc = ''
-        log.info('Starting container {container}{port_desc}..'.format(container=container_name,
-                                                                      port_desc=ports_desc))
-        cond0_ip = inspect_cond0_ip() if i > 0 else None
-        conductr_container_roles = resolve_conductr_roles_by_container(args.conductr_roles, feature_conductr_roles, i)
-        run_conductr_cmd(
-            i,
-            args.nr_of_containers,
-            container_name,
-            cond0_ip,
-            args.envs,
-            '{image}:{version}'.format(image=args.image, version=args.image_version),
-            args.log_level,
-            ports,
-            args.bundle_http_port,
-            conductr_features,
-            conductr_container_roles,
-            conductr_args
-        )
-    return container_names
-
-
-def map_port(instance, port):
-    current_port_str_rev = ''.join(reversed(str(port)))
-    current_second_last_nr = int(current_port_str_rev[1])
-    new_second_last_nr = current_second_last_nr if instance == 0 else (current_second_last_nr + instance) % 10
-    new_port_str_rev = current_port_str_rev[0] + str(new_second_last_nr) + current_port_str_rev[2:]
-    return ''.join(reversed(new_port_str_rev))
-
-
-def inspect_cond0_ip():
-    return terminal.docker_inspect('{}0'.format(CONDUCTR_NAME_PREFIX), '{{.NetworkSettings.IPAddress}}')
-
-
-def resolve_conductr_roles_by_container(user_conductr_roles, feature_conductr_roles, instance):
-    if not user_conductr_roles:
-        # No ConductR roles have been specified => Return an empty list
-        return []
+    if is_conductr_v1:
+        sandbox_run_docker.log_run_attempt(args, run_result, is_started, wait_timeout)
     else:
-        if instance + 1 <= len(user_conductr_roles):
-            # Roles have been specified for the current ConductR instance => Get and use these roles.
-            container_conductr_roles = user_conductr_roles[instance]
-        else:
-            # The current ConductR instance is greater than the length of conductr_roles.
-            # In this case the roles of conductr_roles are subsequently applied to the remaining instances.
-            remainder = (instance + 1) % len(user_conductr_roles)
-            remaining_instance = len(user_conductr_roles) if remainder == 0 else remainder
-            container_conductr_roles = user_conductr_roles[remaining_instance - 1]
-
-        # Feature roles are only added to the seed node.
-        if instance == 0:
-            container_conductr_roles = container_conductr_roles + feature_conductr_roles
-
-        return container_conductr_roles
-
-
-def run_conductr_cmd(instance, nr_of_instances, container_name, cond0_ip, envs, image, log_level, ports,
-                     bundle_http_port, conductr_features, conductr_roles, conductr_args):
-    general_args = ['-d', '--name', container_name]
-    env_args = resolve_docker_run_envs(instance, nr_of_instances, envs, log_level, cond0_ip,
-                                       conductr_features, conductr_roles, conductr_args)
-    all_conductr_ports = CONDUCTR_PORTS | {bundle_http_port}
-    port_args = resolve_docker_run_port_args(ports | all_conductr_ports, instance)
-    optional_args = general_args + env_args + port_args
-    additional_optional_args = resolve_conductr_docker_run_opts()
-    positional_args = resolve_docker_run_positional_args(cond0_ip)
-    terminal.docker_run(optional_args + additional_optional_args, image, positional_args)
-
-
-def resolve_docker_run_envs(instance, nr_of_instances, envs, log_level, cond0_ip,
-                            feature_names, conductr_roles, conductr_args):
-    instance_env = ['CONDUCTR_INSTANCE={}'.format(instance), 'CONDUCTR_NR_OF_INSTANCES={}'.format(nr_of_instances)]
-    log_level_env = ['AKKA_LOGLEVEL={}'.format(log_level)]
-    syslog_ip_env = ['SYSLOG_IP={}'.format(cond0_ip)] if cond0_ip else []
-    conductr_features_env = ['CONDUCTR_FEATURES={}'.format(','.join(feature_names))] if feature_names else []
-    conductr_roles_env = ['CONDUCTR_ROLES={}'.format(','.join(conductr_roles))] if conductr_roles else []
-    conductr_args_env = ['CONDUCTR_ARGS={}'.format(' '.join(conductr_args))] if conductr_args else []
-    all_envs = envs + instance_env + log_level_env + syslog_ip_env + conductr_features_env + conductr_roles_env + conductr_args_env
-    env_args = []
-    for env in all_envs:
-        env_args.append('-e')
-        env_args.append(env)
-    return env_args
-
-
-def resolve_docker_run_port_args(ports, instance):
-    port_args = []
-    for port in ports:
-        port_args.append('-p')
-        port_args.append('{external_port}:{internal_port}'.format(external_port=map_port(instance, port),
-                                                                  internal_port=port))
-    return port_args
-
-
-def resolve_docker_run_positional_args(cond0_ip):
-    seed_node_arg = ['--seed', '{}:{}'.format(cond0_ip, 9004)] if cond0_ip else []
-    return ['--discover-host-ip'] + seed_node_arg
-
-
-def resolve_conductr_docker_run_opts():
-    conductr_docker_run_opts = os.getenv('CONDUCTR_DOCKER_RUN_OPTS')
-    if conductr_docker_run_opts:
-        return conductr_docker_run_opts.split(' ')
-    else:
-        return []
-
-
-def stop_nodes(running_containers):
-    log = logging.getLogger(__name__)
-    log.info('Stopping ConductR nodes..')
-    return terminal.docker_rm(running_containers)
+        sandbox_run_jvm.log_run_attempt(args, run_result, is_started, wait_timeout)
 
 
 def wait_for_start(args):
@@ -240,24 +94,3 @@ def start_proxy(nr_of_containers):
     log.info('Deploying bundle {} with configuration {}'.format(bundle_name, configuration_name))
     conduct_main.run(['load', bundle_name, configuration_name, '--disable-instructions'], configure_logging=False)
     conduct_main.run(['run', bundle_name, '--scale', str(nr_of_containers), '--disable-instructions'], configure_logging=False)
-
-
-def print_result(container_names, is_started, no_wait, wait_timeout, image_version):
-    if not no_wait:
-        log = logging.getLogger(__name__)
-        if is_started:
-            log.info(headline('Summary'))
-            log.info('ConductR has been started')
-            plural_string = 's' if len(container_names) > 1 else ''
-            log.info('Check resource consumption of Docker container{} that run the ConductR node{} with:'
-                     .format(plural_string, plural_string))
-            log.info('  docker stats {}'.format(' '.join(container_names)))
-            log.info('Check current bundle status with:')
-            log.info('  conduct info')
-            if major_version(image_version) != 1:
-                log.info('Bundle status:')
-                conduct_main.run(['info'], configure_logging=False)
-        else:
-            log.info(headline('Summary'))
-            log.error('ConductR has not been started within {} seconds.'.format(wait_timeout))
-            log.error('Set the env CONDUCTR_SANDBOX_WAIT_RETRY_INTERVAL to increase the wait timeout.')

--- a/conductr_cli/sandbox_run_docker.py
+++ b/conductr_cli/sandbox_run_docker.py
@@ -1,0 +1,182 @@
+from conductr_cli import conduct_main, host, sandbox_stop, terminal
+from conductr_cli.sandbox_common import CONDUCTR_DEV_IMAGE, CONDUCTR_NAME_PREFIX, CONDUCTR_PORTS, major_version
+from conductr_cli.screen_utils import headline
+
+import logging
+import os
+
+
+def run(args, features):
+    pull_image(args)
+    container_names = scale_cluster(args, features)
+    return container_names
+
+
+def log_run_attempt(args, container_names, is_started, wait_timeout):
+    if not args.no_wait:
+        log = logging.getLogger(__name__)
+        if is_started:
+            log.info(headline('Summary'))
+            log.info('ConductR has been started')
+            plural_string = 's' if len(container_names) > 1 else ''
+            log.info('Check resource consumption of Docker container{} that run the ConductR node{} with:'
+                     .format(plural_string, plural_string))
+            log.info('  docker stats {}'.format(' '.join(container_names)))
+            log.info('Check current bundle status with:')
+            log.info('  conduct info')
+            if major_version(args.image_version) != 1:
+                log.info('Bundle status:')
+                conduct_main.run(['info'], configure_logging=False)
+        else:
+            log.info(headline('Summary'))
+            log.error('ConductR has not been started within {} seconds.'.format(wait_timeout))
+            log.error('Set the env CONDUCTR_SANDBOX_WAIT_RETRY_INTERVAL to increase the wait timeout.')
+
+
+def pull_image(args):
+    if args.image == CONDUCTR_DEV_IMAGE and not terminal.docker_images(CONDUCTR_DEV_IMAGE):
+        log = logging.getLogger(__name__)
+        log.info('Pulling down the ConductR development image..')
+        terminal.docker_pull('{image_name}:{image_version}'
+                             .format(image_name=CONDUCTR_DEV_IMAGE, image_version=args.image_version))
+
+
+def scale_cluster(args, features):
+    sandbox_stop.stop(args)
+    return start_nodes(args, features)
+
+
+def start_nodes(args, features):
+    container_names = []
+    log = logging.getLogger(__name__)
+    log.info(headline('Starting ConductR'))
+    ports = collect_ports(args, features)
+    conductr_args = flatten([feature.conductr_args() for feature in features])
+    conductr_features = flatten([feature.conductr_feature_envs() for feature in features])
+    feature_conductr_roles = flatten([feature.conductr_roles() for feature in features])
+    for i in range(args.nr_of_containers):
+        container_name = '{prefix}{nr}'.format(prefix=CONDUCTR_NAME_PREFIX, nr=i)
+        container_names.append(container_name)
+        # Display the ports on the command line. Only if the user specifies a certain feature, then
+        # the corresponding port will be displayed when running 'sandbox run' or 'sandbox debug'
+        if ports:
+            host_ip = host.resolve_ip_by_vm_type(args.vm_type)
+            ports_desc = ' exposing ' + ', '.join(['{}:{}'.format(host_ip, map_port(i, port))
+                                                   for port in sorted(ports)])
+        else:
+            ports_desc = ''
+        log.info('Starting container {container}{port_desc}..'.format(container=container_name,
+                                                                      port_desc=ports_desc))
+        cond0_ip = inspect_cond0_ip() if i > 0 else None
+        conductr_container_roles = resolve_conductr_roles_by_container(args.conductr_roles, feature_conductr_roles, i)
+        run_conductr_cmd(
+            i,
+            args.nr_of_containers,
+            container_name,
+            cond0_ip,
+            args.envs,
+            '{image}:{version}'.format(image=args.image, version=args.image_version),
+            args.log_level,
+            ports,
+            args.bundle_http_port,
+            conductr_features,
+            conductr_container_roles,
+            conductr_args
+        )
+    return container_names
+
+
+def collect_ports(args, features):
+    """Return a Set of ports based on the ports of each enabled feature and the ports specified by the user"""
+
+    feature_ports = flatten([feature.ports for feature in features])
+    return set(args.ports + feature_ports)
+
+
+def flatten(list):
+    return [item for sublist in list for item in sublist]
+
+
+def map_port(instance, port):
+    current_port_str_rev = ''.join(reversed(str(port)))
+    current_second_last_nr = int(current_port_str_rev[1])
+    new_second_last_nr = current_second_last_nr if instance == 0 else (current_second_last_nr + instance) % 10
+    new_port_str_rev = current_port_str_rev[0] + str(new_second_last_nr) + current_port_str_rev[2:]
+    return ''.join(reversed(new_port_str_rev))
+
+
+def inspect_cond0_ip():
+    return terminal.docker_inspect('{}0'.format(CONDUCTR_NAME_PREFIX), '{{.NetworkSettings.IPAddress}}')
+
+
+def resolve_conductr_roles_by_container(user_conductr_roles, feature_conductr_roles, instance):
+    if not user_conductr_roles:
+        # No ConductR roles have been specified => Return an empty list
+        return []
+    else:
+        if instance + 1 <= len(user_conductr_roles):
+            # Roles have been specified for the current ConductR instance => Get and use these roles.
+            container_conductr_roles = user_conductr_roles[instance]
+        else:
+            # The current ConductR instance is greater than the length of conductr_roles.
+            # In this case the roles of conductr_roles are subsequently applied to the remaining instances.
+            remainder = (instance + 1) % len(user_conductr_roles)
+            remaining_instance = len(user_conductr_roles) if remainder == 0 else remainder
+            container_conductr_roles = user_conductr_roles[remaining_instance - 1]
+
+        # Feature roles are only added to the seed node.
+        if instance == 0:
+            container_conductr_roles = container_conductr_roles + feature_conductr_roles
+
+        return container_conductr_roles
+
+
+def run_conductr_cmd(instance, nr_of_instances, container_name, cond0_ip, envs, image, log_level, ports,
+                     bundle_http_port, conductr_features, conductr_roles, conductr_args):
+    general_args = ['-d', '--name', container_name]
+    env_args = resolve_docker_run_envs(instance, nr_of_instances, envs, log_level, cond0_ip,
+                                       conductr_features, conductr_roles, conductr_args)
+    all_conductr_ports = CONDUCTR_PORTS | {bundle_http_port}
+    port_args = resolve_docker_run_port_args(ports | all_conductr_ports, instance)
+    optional_args = general_args + env_args + port_args
+    additional_optional_args = resolve_conductr_docker_run_opts()
+    positional_args = resolve_docker_run_positional_args(cond0_ip)
+    terminal.docker_run(optional_args + additional_optional_args, image, positional_args)
+
+
+def resolve_docker_run_envs(instance, nr_of_instances, envs, log_level, cond0_ip,
+                            feature_names, conductr_roles, conductr_args):
+    instance_env = ['CONDUCTR_INSTANCE={}'.format(instance), 'CONDUCTR_NR_OF_INSTANCES={}'.format(nr_of_instances)]
+    log_level_env = ['AKKA_LOGLEVEL={}'.format(log_level)]
+    syslog_ip_env = ['SYSLOG_IP={}'.format(cond0_ip)] if cond0_ip else []
+    conductr_features_env = ['CONDUCTR_FEATURES={}'.format(','.join(feature_names))] if feature_names else []
+    conductr_roles_env = ['CONDUCTR_ROLES={}'.format(','.join(conductr_roles))] if conductr_roles else []
+    conductr_args_env = ['CONDUCTR_ARGS={}'.format(' '.join(conductr_args))] if conductr_args else []
+    all_envs = envs + instance_env + log_level_env + syslog_ip_env + conductr_features_env + conductr_roles_env + conductr_args_env
+    env_args = []
+    for env in all_envs:
+        env_args.append('-e')
+        env_args.append(env)
+    return env_args
+
+
+def resolve_docker_run_port_args(ports, instance):
+    port_args = []
+    for port in ports:
+        port_args.append('-p')
+        port_args.append('{external_port}:{internal_port}'.format(external_port=map_port(instance, port),
+                                                                  internal_port=port))
+    return port_args
+
+
+def resolve_docker_run_positional_args(cond0_ip):
+    seed_node_arg = ['--seed', '{}:{}'.format(cond0_ip, 9004)] if cond0_ip else []
+    return ['--discover-host-ip'] + seed_node_arg
+
+
+def resolve_conductr_docker_run_opts():
+    conductr_docker_run_opts = os.getenv('CONDUCTR_DOCKER_RUN_OPTS')
+    if conductr_docker_run_opts:
+        return conductr_docker_run_opts.split(' ')
+    else:
+        return []

--- a/conductr_cli/sandbox_run_jvm.py
+++ b/conductr_cli/sandbox_run_jvm.py
@@ -1,0 +1,255 @@
+from conductr_cli import sandbox_stop
+from conductr_cli.resolvers import bintray_resolver
+from conductr_cli.resolvers.bintray_resolver import BINTRAY_DOWNLOAD_REALM
+
+
+def run(args, features):
+    """
+    Starts the ConductR core and agent.
+
+    :param args: args parsed from the input arguments
+    :param features: list of features which are specified via -f switch.
+                     This is only relevant for Docker based sandbox since the features decides what port to expose
+    :return: a tuple containing list of core pids and list of agent pids
+    """
+    nr_of_core_instances, nr_of_agent_instances = instance_count(args.nr_of_containers)
+
+    validate_jvm_support()
+    validate_address_aliases(max(nr_of_core_instances, nr_of_agent_instances), args.interface, args.addr_range)
+
+    core_extracted_dir, agent_extracted_dir = obtain_sandbox_image(args.resolve_cache_dir, args.image_dir, args.image_version)
+
+    sandbox_stop.stop(args)
+
+    core_pids = start_core_instances(core_extracted_dir, nr_of_core_instances, args.addr_range)
+    agent_pids = start_agent_instances(agent_extracted_dir, nr_of_agent_instances, args.addr_range)
+
+    return (core_pids, agent_pids)
+
+
+def log_run_attempt(args, pids, is_started, wait_timeout):
+    """
+    Logs the run attempt. This method will be called after the completion of run method and when all the features has been started.
+
+    :param args: args parsed from the input arguments
+    :param pids: a tuple containing list of core pids and list of agent pids
+    :param is_started: sets to true if sandbox is started
+    :param wait_timeout: the amount of timeout waiting for sandbox to be started
+    :return:
+    """
+    core_pids, agent_pids = pids
+    pass
+
+
+def instance_count(instance_expression):
+    """
+    Parses the instance expressions into number of core and agent instances, i.e.
+
+    The expression `2` translates to 2 core instances and 2 agent instances.
+    The expression `2:3` translates to 2 core instances and 3 agent instances.
+
+    :param instance_expression:
+    :return: a tuple containing number of core instances and number of agent instances.
+    """
+    pass
+
+
+def validate_jvm_support():
+    """
+    Validates for the presence of supported JVM (i.e. Oracle JVM 8), else raise an exception to fail the sandbox run.
+    """
+    pass
+
+
+def validate_address_aliases(nr_of_alias, interface, addr_range):
+    """
+    Validates for the presence of address alias given a specified interface and address range, i.e.
+    - Let's say 3 address aliases is required.
+    - The interface specified is lo0.
+    - The address range is 192.168.128.0/24
+
+    These addresses requires setup using ifconfig as such:
+
+    sudo ifconfig lo0 alias 192.168.128.1 255.255.255.0
+    sudo ifconfig lo0 alias 192.168.128.2 255.255.255.0
+    sudo ifconfig lo0 alias 192.168.128.3 255.255.255.0
+
+    This command will parse the ifconfig output of the lo0 to ensure the alias for 192.168.128.1, 192.168.128.2, and
+    192.168.128.3 is present.
+
+    If these alias is not present, printout an error message and raise an exception to fail the sandbox run.
+
+    As part of the error message printout, provide the commands so the end user is able to copy-paste and execute these
+    commands.
+
+    :param nr_of_alias: number of address aliases required
+    :param interface: the network interface which will be used to create the address alias to be used by core and agent
+                      as the bind address.
+    :param addr_range: the range of address which is available to core and agent to bind to.
+                       The address is specified in the CIDR format, i.e. 192.168.128.0/24
+    """
+    pass
+
+
+def obtain_sandbox_image(cache_dir, image_dir, image_version):
+    """
+    Obtains the sandbox image.
+
+    The sandbox image is the .tar.gz binary of ConductR core and agent which is available as a download from Bintray.
+
+    First the local cache is interrogated for the presence of the .tar.gz binary.
+
+    If the binary is not yet available within the local cache, then it will be downloaded from Bintray. If the binary
+    is present within the local cache, they will be used instead.
+
+    The core binary will be expanded into the `${image_dir}/core`. The directory `${image_dir}/core` will be emptied
+    before the binary is expanded.
+
+    Similarly, the agent binary will be expanded into the `${image_dir}/agent`. The directory `${image_dir}/agent` will
+    be emptied before the binary is expanded.
+
+    :param cache_dir: the directory where ConductR core and agent binaries will be cached.
+    :param image_dir: the base directory containing the expanded ConductR core and agent binaries.
+    :param image_version: the version of the sandbox to be downloaded.
+    :return: the pair containing path to the expanded core directory and path to the expanded agent directory
+    """
+    def resolve_core_binary_from_cache():
+        """
+        Checks for the presence of `${cache_dir}/core/${image_version}.tar.gz`.
+
+        :return: If present, return the path to the binary file, else return None.
+        """
+        pass
+
+    def resolve_agent_binary_from_cache():
+        """
+        Checks for the presence of `${cache_dir}/agent/${image_version}.tar.gz`.
+
+        :return: If present, return the path to the binary file, else return None.
+        """
+        pass
+
+    def download_core_from_bintray(bintray_auth):
+        """
+        Downloads core from bintray given `${image_version}`.
+
+        The images are expected to be cached in `${cache_dir}/core`.
+
+        If the binary is not yet available within the local cache, then it will be downloaded from Bintray.
+
+        The aftefacts will be available under the following Bintray repo:
+
+        https://bintray.com/lightbend/commercial-releases/ConductR-Universal
+
+        As part of the download:
+        - A progress bar will be displayed.
+        - The download will be saved into `${cache_dir}/core/${image_version}.tar.gz.tmp`. Once download is complete,
+          this file will be moved to `${cache_dir}/core/${image_version}.tar.gz`.
+
+        :param bintray_auth: a tuple containing Bintray auth information which can be passed into the request library.
+                             This information is loaded from bintray credentials file, which can be None if the
+                             credentials is not specified
+        :return: path to the downloaded file
+        """
+        pass
+
+    def download_agent_from_bintray(bintray_auth):
+        """
+        Downloads agent from bintray given `${image_version}`.
+
+        The images are expected to be cached in `${cache_dir}/agent`.
+
+        If the binary is not yet available within the local cache, then it will be downloaded from Bintray.
+
+        The aftefacts will be available under the following Bintray repo:
+
+        https://bintray.com/lightbend/commercial-releases/ConductR-Agent-Universal
+
+        As part of the download:
+        - A progress bar will be displayed.
+        - The download will be saved into `${cache_dir}/agent/${image_version}.tar.gz.tmp`. Once download is complete,
+          this file will be moved to `${cache_dir}/agent/${image_version}.tar.gz`.
+
+        :param bintray_auth: a tuple containing Bintray auth information which can be passed into the request library.
+                             This information is loaded from bintray credentials file, which can be None if the
+                             credentials is not specified
+        :return: path to the downloaded file
+        """
+        pass
+
+    def extract_core(core_binary):
+        """
+        The core binary will be expanded into the `${image_dir}/core`. The directory `${image_dir}/core` will be emptied
+        before the binary is expanded.
+
+        :param core_binary: the path to the core binary to be expanded.
+        :return: path to the directory containing expanded core binary.
+        """
+        pass
+
+    def extract_agent(agent_binary):
+        """
+        The agent binary will be expanded into the `${image_dir}/agent`. The directory `${image_dir}/agent` will be emptied
+        before the binary is expanded.
+
+        :param agent_binary: the path to the agent binary to be expanded.
+        :return: path to the directory containing expanded agent binary.
+        """
+        pass
+
+    core_binary = resolve_core_binary_from_cache()
+    agent_binary = resolve_agent_binary_from_cache()
+
+    if (not core_binary) and (not agent_binary):
+        bintray_username, bintray_password = bintray_resolver.load_bintray_credentials()
+        bintray_auth = (BINTRAY_DOWNLOAD_REALM, bintray_username, bintray_password) if bintray_username else None
+        if not core_binary:
+            core_binary = download_core_from_bintray(bintray_auth)
+
+        if not agent_binary:
+            agent_binary = download_agent_from_bintray(bintray_auth)
+
+    core_extracted_dir = extract_core(core_binary)
+    agent_extracted_dir = extract_agent(agent_binary)
+
+    return (core_extracted_dir, agent_extracted_dir)
+
+
+def start_core_instances(core_extracted_dir, nr_of_instances, addr_range):
+    """
+    Starts the ConductR core process.
+
+    Each instance is allocated an address to be bound based on the address range. For example:
+    - Given 3 required core instances
+    - Given the address range input of 192.168.128.0/24
+    - The instances will be allocated these addresses: 192.168.128.1, 192.168.128.2, 192.168.128.3
+
+    TODO: investigate if each ConductR core process requires its own log files, or all the logs can be sent into the
+    same file.
+
+    :param core_extracted_dir: the directory containing the files expanded from core's binary .tar.gz
+    :param nr_of_instances: number of core instances required
+    :param addr_range: the range of address required, i.e. 192.168.128.0/24
+    :return: the pids of the core instances.
+    """
+    pass
+
+
+def start_agent_instances(agent_extracted_dir, nr_of_instances, addr_range):
+    """
+    Starts the ConductR agent process.
+
+    Each instance is allocated an address to be bound based on the address range. For example:
+    - Given 3 required agent instances
+    - Given the address range input of 192.168.128.0/24
+    - The instances will be allocated these addresses: 192.168.128.1, 192.168.128.2, 192.168.128.3
+
+    TODO: investigate if each ConductR agent process requires its own log files, or all the logs can be sent into the
+    same file.
+
+    :param agent_extracted_dir: the directory containing the files expanded from agent's binary .tar.gz
+    :param nr_of_instances: number of agent instances required
+    :param addr_range: the range of address required, i.e. 192.168.128.0/24
+    :return: the pids of the agent instances.
+    """
+    pass

--- a/conductr_cli/sandbox_stop.py
+++ b/conductr_cli/sandbox_stop.py
@@ -1,13 +1,7 @@
-from conductr_cli import sandbox_common, terminal
-from conductr_cli.screen_utils import headline
-import logging
+from conductr_cli import sandbox_stop_docker
 
 
 def stop(args):
     """`sandbox stop` command"""
 
-    log = logging.getLogger(__name__)
-    running_containers = sandbox_common.resolve_running_docker_containers()
-    if running_containers:
-        log.info(headline('Stopping ConductR'))
-        terminal.docker_rm(running_containers)
+    sandbox_stop_docker.stop(args)

--- a/conductr_cli/sandbox_stop_docker.py
+++ b/conductr_cli/sandbox_stop_docker.py
@@ -1,0 +1,12 @@
+from conductr_cli import sandbox_common, terminal
+from conductr_cli.screen_utils import headline
+
+import logging
+
+
+def stop(args):
+    log = logging.getLogger(__name__)
+    running_containers = sandbox_common.resolve_running_docker_containers()
+    if running_containers:
+        log.info(headline('Stopping ConductR'))
+        terminal.docker_rm(running_containers)

--- a/conductr_cli/sandbox_stop_jvm.py
+++ b/conductr_cli/sandbox_stop_jvm.py
@@ -1,0 +1,91 @@
+def stop(args):
+    """
+    Stops the existing ConductR core and agent processes.
+    This is done by interrogating the output of the ps, looking for java process which is running of the sandbox image.
+    directory.
+
+    :param args: args parsed from the input arguments
+    """
+
+    core_pids = find_conductr_core_pids(args.image_dir)
+    core_killed_pids, core_hung_pids = kill_processes(core_pids)
+
+    agent_pids = find_conductr_agent_pids(args.image_dir)
+    agent_killed_pids, agent_hung_pids = kill_processes(agent_pids)
+
+    if core_hung_pids or agent_hung_pids:
+        if core_hung_pids:
+            log_hung_core_processes(core_hung_pids)
+
+        if agent_hung_pids:
+            log_hung_agent_processes(agent_hung_pids)
+
+        raise_hung_processes_error(core_hung_pids, agent_hung_pids)
+    else:
+        log_terminated_successfully(core_killed_pids, agent_killed_pids)
+
+
+def find_conductr_core_pids(run_dir):
+    """
+    Finds the PIDs of the ConductR core from the output of the ps process, looking for java process which is running
+    of the sandbox image.
+    :param run_dir: directory of where ConductR core is running from.
+    :return: the list of the ConductR core pids.
+    """
+    pass
+
+
+def find_conductr_agent_pids(run_dir):
+    """
+    Finds the PIDs of the ConductR agent from the output of the ps process, looking for java process which is running
+    of the sandbox image.
+    :param run_dir: directory of where ConductR agent is running from.
+    :return: the list of the ConductR agent pids.
+    """
+    pass
+
+
+def kill_processes(pids):
+    """
+    Kills the processes given the pids by sending SIGTERM.
+    :param pids: List of pids to be killed.
+    :return: a tuple containing list of pids which can be killed successfully and a list of pids which has hung and
+             can't be killed using SIGTERM.
+    """
+    pass
+
+
+def log_hung_core_processes(core_hung_pids):
+    """
+    Displays an error message to indicate the core process pids which can't be terminated by SIGTERM.
+    :param core_hung_pids: list of pids of the hung core process
+    """
+    pass
+
+
+def log_hung_agent_processes(agent_hung_pids):
+    """
+    Displays an error message to indicate the agent process pids which can't be terminated by SIGTERM.
+    :param core_hung_pids: list of pids of the hung agent process
+    """
+    pass
+
+
+def log_terminated_successfully(core_killed_pids, agent_killed_pids):
+    """
+    Displays a log message to indicate that all sandbox processes has been terminated successfully.
+    :param core_killed_pids: list of core pids which was terminated successfully.
+    :param agent_killed_pids: list of agent pids which was terminated successfully.
+    :return:
+    """
+    pass
+
+
+def raise_hung_processes_error(core_hung_pids, agent_hung_pids):
+    """
+    Raises an error given pids of the hung core and agent processes.
+    :param core_hung_pids: list of pids of the hung core process.
+    :param agent_hung_pids: list of pids of the hung agent process.
+    :return:
+    """
+    pass

--- a/conductr_cli/test/test_sandbox_run_docker.py
+++ b/conductr_cli/test/test_sandbox_run_docker.py
@@ -1,0 +1,394 @@
+from conductr_cli.test.cli_test_case import CliTestCase, strip_margin, as_error
+from conductr_cli import sandbox_run_docker, logging_setup
+from conductr_cli.docker import DockerVmType
+from conductr_cli.sandbox_common import CONDUCTR_DEV_IMAGE, LATEST_CONDUCTR_VERSION
+from conductr_cli.sandbox_features import VisualizationFeature, LoggingFeature
+from unittest.mock import patch, MagicMock
+import os
+
+
+class TestRun(CliTestCase):
+
+    default_args = {
+        'vm_type': DockerVmType.DOCKER_ENGINE,
+        'image_version': LATEST_CONDUCTR_VERSION,
+        'conductr_roles': [],
+        'envs': [],
+        'image': CONDUCTR_DEV_IMAGE,
+        'log_level': 'info',
+        'nr_of_containers': 1,
+        'ports': [],
+        'bundle_http_port': 9000,
+        'features': [],
+        'no_wait': False,
+        'local_connection': True
+    }
+
+    def default_general_args(self, container_name):
+        return ['-d', '--name', container_name]
+
+    default_env_args = ['-e', 'CONDUCTR_INSTANCE=0', '-e', 'CONDUCTR_NR_OF_INSTANCES=1', '-e', 'AKKA_LOGLEVEL=info']
+    default_port_args = ['-p', '9000:9000',
+                         '-p', '9004:9004',
+                         '-p', '9005:9005',
+                         '-p', '9006:9006']
+    default_positional_args = ['--discover-host-ip']
+
+    def test_default_args(self):
+        stdout = MagicMock()
+
+        input_args = MagicMock(**self.default_args)
+        features = []
+        with \
+                patch('conductr_cli.terminal.docker_images', return_value=''), \
+                patch('conductr_cli.terminal.docker_pull', return_value=''), \
+                patch('conductr_cli.terminal.docker_ps', return_value=''), \
+                patch('conductr_cli.terminal.docker_inspect', return_value='10.10.10.10'), \
+                patch('conductr_cli.terminal.docker_run', return_value='') as mock_docker_run, \
+                patch('conductr_cli.sandbox_common.resolve_running_docker_containers', return_value=[]):
+            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
+            sandbox_run_docker.run(input_args, features)
+
+        expected_stdout = strip_margin("""|Pulling down the ConductR development image..
+                                          ||------------------------------------------------|
+                                          || Starting ConductR                              |
+                                          ||------------------------------------------------|
+                                          |Starting container cond-0..
+                                          |""")
+        expected_optional_args = self.default_general_args('cond-0') + self.default_env_args + self.default_port_args
+        expected_image = '{}:{}'.format(CONDUCTR_DEV_IMAGE, LATEST_CONDUCTR_VERSION)
+        expected_positional_args = self.default_positional_args
+
+        self.assertEqual(expected_stdout, self.output(stdout))
+        mock_docker_run.assert_called_once_with(expected_optional_args, expected_image, expected_positional_args)
+
+    def test_multiple_container(self):
+        stdout = MagicMock()
+        nr_of_containers = 3
+
+        with \
+                patch('conductr_cli.terminal.docker_images', return_value='some-image'), \
+                patch('conductr_cli.terminal.docker_ps', return_value=''), \
+                patch('conductr_cli.terminal.docker_inspect', return_value='10.10.10.10'), \
+                patch('conductr_cli.terminal.docker_run', return_value='') as mock_docker_run, \
+                patch('conductr_cli.sandbox_common.resolve_running_docker_containers', return_value=[]):
+            args = self.default_args.copy()
+            args.update({'nr_of_containers': nr_of_containers})
+            input_args = MagicMock(**args)
+            logging_setup.configure_logging(input_args, stdout)
+            features = []
+            sandbox_run_docker.run(input_args, features)
+
+        expected_stdout = strip_margin("""||------------------------------------------------|
+                                          || Starting ConductR                              |
+                                          ||------------------------------------------------|
+                                          |Starting container cond-0..
+                                          |Starting container cond-1..
+                                          |Starting container cond-2..
+                                          |""")
+        expected_image = '{}:{}'.format(CONDUCTR_DEV_IMAGE, LATEST_CONDUCTR_VERSION)
+
+        self.assertEqual(expected_stdout, self.output(stdout))
+        # Assert cond-0
+        mock_docker_run.assert_any_call(
+            ['-d', '--name', 'cond-0',
+             '-e', 'CONDUCTR_INSTANCE=0', '-e', 'CONDUCTR_NR_OF_INSTANCES=3',
+             '-e', 'AKKA_LOGLEVEL=info',
+             '-p', '9000:9000', '-p', '9004:9004', '-p', '9005:9005', '-p', '9006:9006'],
+            expected_image,
+            self.default_positional_args
+        )
+        # Assert cond-1
+        mock_docker_run.assert_any_call(
+            ['-d', '--name', 'cond-1',
+             '-e', 'CONDUCTR_INSTANCE=1', '-e', 'CONDUCTR_NR_OF_INSTANCES=3',
+             '-e', 'AKKA_LOGLEVEL=info', '-e', 'SYSLOG_IP=10.10.10.10',
+             '-p', '9010:9000', '-p', '9014:9004', '-p', '9015:9005', '-p', '9016:9006'],
+            expected_image,
+            self.default_positional_args + ['--seed', '10.10.10.10:9004']
+        )
+        # Assert cond-2
+        mock_docker_run.assert_any_call(
+            ['-d', '--name', 'cond-2',
+             '-e', 'CONDUCTR_INSTANCE=2', '-e', 'CONDUCTR_NR_OF_INSTANCES=3',
+             '-e', 'AKKA_LOGLEVEL=info', '-e', 'SYSLOG_IP=10.10.10.10',
+             '-p', '9020:9000', '-p', '9024:9004', '-p', '9025:9005', '-p', '9026:9006'],
+            expected_image,
+            self.default_positional_args + ['--seed', '10.10.10.10:9004']
+        )
+
+    def test_with_custom_args(self):
+        stdout = MagicMock()
+        image_version = '1.1.0'
+        conductr_roles = [['role1', 'role2']]
+        envs = ['key1=value1', 'key2=value2']
+        image = 'my-image'
+        log_level = 'debug'
+        nr_of_containers = 1
+        ports = [3000, 3001]
+        features = [
+            VisualizationFeature(version_args=[], image_version=image_version),
+            LoggingFeature(version_args=[], image_version=image_version)
+        ]
+
+        with \
+                patch('conductr_cli.terminal.docker_images', return_value='some-image'), \
+                patch('conductr_cli.terminal.docker_ps', return_value=''), \
+                patch('conductr_cli.terminal.docker_inspect', return_value='10.10.10.10'), \
+                patch('conductr_cli.terminal.docker_run', return_value='') as mock_docker_run, \
+                patch('conductr_cli.sandbox_common.resolve_running_docker_containers', return_value=[]):
+            args = self.default_args.copy()
+            args.update({
+                'image_version': image_version,
+                'conductr_roles': conductr_roles,
+                'envs': envs,
+                'image': image,
+                'log_level': log_level,
+                'nr_of_containers': nr_of_containers,
+                'ports': ports,
+                'bundle_http_port': 7222,
+                'features': features
+            })
+            input_args = MagicMock(**args)
+            logging_setup.configure_logging(input_args, stdout)
+            sandbox_run_docker.run(input_args, features)
+
+        expected_stdout = strip_margin("""||------------------------------------------------|
+                                          || Starting ConductR                              |
+                                          ||------------------------------------------------|
+                                          |Starting container cond-0 exposing 127.0.0.1:3000, 127.0.0.1:3001, 127.0.0.1:5601, 127.0.0.1:9200, 127.0.0.1:9999..
+                                          |""")
+
+        self.assertEqual(expected_stdout, self.output(stdout))
+        mock_docker_run.assert_called_once_with(
+            ['-d', '--name', 'cond-0', '-e', 'key1=value1', '-e', 'key2=value2',
+             '-e', 'CONDUCTR_INSTANCE=0', '-e', 'CONDUCTR_NR_OF_INSTANCES=1', '-e', 'AKKA_LOGLEVEL=debug',
+             '-e', 'CONDUCTR_FEATURES=visualization,logging', '-e', 'CONDUCTR_ROLES=role1,role2',
+             '-p', '5601:5601', '-p', '9004:9004', '-p', '9005:9005', '-p', '9006:9006',
+             '-p', '9999:9999', '-p', '9200:9200', '-p', '7222:7222', '-p', '3000:3000',
+             '-p', '3001:3001'],
+            '{}:{}'.format(image, image_version),
+            self.default_positional_args
+        )
+
+    def test_roles(self):
+        stdout = MagicMock()
+        nr_of_containers = 3
+        conductr_roles = [['role1', 'role2'], ['role3']]
+        features = []
+
+        with \
+                patch('conductr_cli.terminal.docker_images', return_value='some-image'), \
+                patch('conductr_cli.terminal.docker_ps', return_value=''), \
+                patch('conductr_cli.terminal.docker_inspect', return_value='10.10.10.10'), \
+                patch('conductr_cli.terminal.docker_run', return_value='') as mock_docker_run, \
+                patch('conductr_cli.sandbox_common.resolve_running_docker_containers', return_value=[]):
+            args = self.default_args.copy()
+            args.update({
+                'nr_of_containers': nr_of_containers,
+                'conductr_roles': conductr_roles
+            })
+            input_args = MagicMock(**args)
+            logging_setup.configure_logging(input_args, stdout)
+            sandbox_run_docker.run(input_args, features)
+
+        expected_stdout = strip_margin("""||------------------------------------------------|
+                                          || Starting ConductR                              |
+                                          ||------------------------------------------------|
+                                          |Starting container cond-0..
+                                          |Starting container cond-1..
+                                          |Starting container cond-2..
+                                          |""")
+        expected_image = '{}:{}'.format(CONDUCTR_DEV_IMAGE, LATEST_CONDUCTR_VERSION)
+
+        self.assertEqual(expected_stdout, self.output(stdout))
+        # Assert cond-0
+        mock_docker_run.assert_any_call(
+            ['-d', '--name', 'cond-0',
+             '-e', 'CONDUCTR_INSTANCE=0', '-e', 'CONDUCTR_NR_OF_INSTANCES=3',
+             '-e', 'AKKA_LOGLEVEL=info', '-e', 'CONDUCTR_ROLES=role1,role2',
+             '-p', '9000:9000', '-p', '9004:9004', '-p', '9005:9005', '-p', '9006:9006'],
+            expected_image,
+            self.default_positional_args
+        )
+        # Assert cond-1
+        mock_docker_run.assert_any_call(
+            ['-d', '--name', 'cond-1',
+             '-e', 'CONDUCTR_INSTANCE=1', '-e', 'CONDUCTR_NR_OF_INSTANCES=3',
+             '-e', 'AKKA_LOGLEVEL=info', '-e', 'SYSLOG_IP=10.10.10.10',
+             '-e', 'CONDUCTR_ROLES=role3',
+             '-p', '9010:9000', '-p', '9014:9004', '-p', '9015:9005', '-p', '9016:9006'],
+            expected_image,
+            self.default_positional_args + ['--seed', '10.10.10.10:9004']
+        )
+        # Assert cond-2
+        mock_docker_run.assert_any_call(
+            ['-d', '--name', 'cond-2',
+             '-e', 'CONDUCTR_INSTANCE=2', '-e', 'CONDUCTR_NR_OF_INSTANCES=3',
+             '-e', 'AKKA_LOGLEVEL=info', '-e', 'SYSLOG_IP=10.10.10.10',
+             '-e', 'CONDUCTR_ROLES=role1,role2',
+             '-p', '9020:9000', '-p', '9024:9004', '-p', '9025:9005', '-p', '9026:9006'],
+            expected_image,
+            self.default_positional_args + ['--seed', '10.10.10.10:9004']
+        )
+
+    def test_containers_already_running(self):
+        stdout = MagicMock()
+
+        features = []
+        running_containers = ['cond-0']
+
+        input_args = MagicMock(**self.default_args)
+        with \
+                patch('conductr_cli.terminal.docker_images', return_value='some-image'), \
+                patch('conductr_cli.terminal.docker_pull', return_value=''), \
+                patch('conductr_cli.terminal.docker_ps', return_value=''), \
+                patch('conductr_cli.terminal.docker_inspect', return_value='10.10.10.10'), \
+                patch('conductr_cli.terminal.docker_run', return_value=''), \
+                patch('conductr_cli.sandbox_common.resolve_running_docker_containers', return_value=running_containers), \
+                patch('conductr_cli.terminal.docker_rm') as mock_docker_rm:
+            logging_setup.configure_logging(input_args, stdout)
+            sandbox_run_docker.run(input_args, features)
+
+        expected_stdout = strip_margin("""||------------------------------------------------|
+                                          || Stopping ConductR                              |
+                                          ||------------------------------------------------|
+                                          ||------------------------------------------------|
+                                          || Starting ConductR                              |
+                                          ||------------------------------------------------|
+                                          |Starting container cond-0..
+                                          |""")
+
+        self.assertEqual(expected_stdout, self.output(stdout))
+        mock_docker_rm.assert_called_once_with(running_containers)
+
+    def test_run_options(self):
+        stdout = MagicMock()
+        run_options = {'CONDUCTR_DOCKER_RUN_OPTS': "-v /etc/haproxy:/usr/local/etc/haproxy"}
+
+        def run_env(key, default=None):
+            return run_options[key] if key in run_options else os.environ.get(key, default)
+
+        input_args = MagicMock(**self.default_args)
+        features = []
+        with \
+                patch('conductr_cli.terminal.docker_images', return_value=''), \
+                patch('conductr_cli.terminal.docker_pull', return_value=''), \
+                patch('conductr_cli.terminal.docker_ps', return_value=''), \
+                patch('conductr_cli.terminal.docker_inspect', return_value='10.10.10.10'), \
+                patch('conductr_cli.terminal.docker_run', return_value='') as mock_docker_run, \
+                patch('conductr_cli.sandbox_common.resolve_running_docker_containers', return_value=[]), \
+                patch('os.getenv', side_effect=run_env) as mock_get_env:
+            logging_setup.configure_logging(input_args, stdout)
+            sandbox_run_docker.run(input_args, features)
+
+        expected_stdout = strip_margin("""|Pulling down the ConductR development image..
+                                          ||------------------------------------------------|
+                                          || Starting ConductR                              |
+                                          ||------------------------------------------------|
+                                          |Starting container cond-0..
+                                          |""")
+        expected_optional_args = self.default_general_args('cond-0') + self.default_env_args + self.default_port_args
+        expected_image = '{}:{}'.format(CONDUCTR_DEV_IMAGE, LATEST_CONDUCTR_VERSION)
+        expected_positional_args = self.default_positional_args
+
+        self.assertEqual(expected_stdout, self.output(stdout))
+        mock_get_env.assert_any_call('CONDUCTR_DOCKER_RUN_OPTS')
+        mock_docker_run.assert_called_once_with(expected_optional_args + ['-v', '/etc/haproxy:/usr/local/etc/haproxy'],
+                                                expected_image, expected_positional_args)
+
+
+class TestLogRunAttempt(CliTestCase):
+    wait_timeout = 60
+
+    def test_log_output(self):
+        stdout = MagicMock()
+        input_args = MagicMock(**{
+            'no_wait': False
+        })
+
+        logging_setup.configure_logging(input_args, stdout)
+        sandbox_run_docker.log_run_attempt(
+            input_args,
+            container_names=['cond-0', 'cond-1', 'cond-2'],
+            is_started=True,
+            wait_timeout=self.wait_timeout
+        )
+
+        expected_stdout = strip_margin("""||------------------------------------------------|
+                                          || Summary                                        |
+                                          ||------------------------------------------------|
+                                          |ConductR has been started
+                                          |Check resource consumption of Docker containers that run the ConductR nodes with:
+                                          |  docker stats cond-0 cond-1 cond-2
+                                          |Check current bundle status with:
+                                          |  conduct info
+                                          |""")
+        self.assertEqual(expected_stdout, self.output(stdout))
+
+    def test_log_output_single_container(self):
+        stdout = MagicMock()
+        input_args = MagicMock(**{
+            'no_wait': False
+        })
+
+        logging_setup.configure_logging(input_args, stdout)
+        sandbox_run_docker.log_run_attempt(
+            input_args,
+            container_names=['cond-0'],
+            is_started=True,
+            wait_timeout=self.wait_timeout
+        )
+
+        expected_stdout = strip_margin("""||------------------------------------------------|
+                                          || Summary                                        |
+                                          ||------------------------------------------------|
+                                          |ConductR has been started
+                                          |Check resource consumption of Docker container that run the ConductR node with:
+                                          |  docker stats cond-0
+                                          |Check current bundle status with:
+                                          |  conduct info
+                                          |""")
+        self.assertEqual(expected_stdout, self.output(stdout))
+
+    def test_log_output_not_started(self):
+        stdout = MagicMock()
+        stderr = MagicMock()
+        input_args = MagicMock(**{
+            'no_wait': False
+        })
+
+        logging_setup.configure_logging(input_args, stdout, stderr)
+        sandbox_run_docker.log_run_attempt(
+            input_args,
+            container_names=['cond-0'],
+            is_started=False,
+            wait_timeout=self.wait_timeout
+        )
+
+        expected_stdout = strip_margin("""||------------------------------------------------|
+                                          || Summary                                        |
+                                          ||------------------------------------------------|
+                                          |""")
+        self.assertEqual(expected_stdout, self.output(stdout))
+
+        expected_stderr = strip_margin(as_error("""|Error: ConductR has not been started within 60 seconds.
+                                                   |Error: Set the env CONDUCTR_SANDBOX_WAIT_RETRY_INTERVAL to increase the wait timeout.
+                                                   |"""))
+        self.assertEqual(expected_stderr, self.output(stderr))
+
+    def test_log_output_no_wait(self):
+        stdout = MagicMock()
+        input_args = MagicMock(**{
+            'no_wait': True
+        })
+
+        logging_setup.configure_logging(input_args, stdout)
+        sandbox_run_docker.log_run_attempt(
+            input_args,
+            container_names=['cond-0'],
+            is_started=True,
+            wait_timeout=self.wait_timeout
+        )
+
+        self.assertEqual('', self.output(stdout))


### PR DESCRIPTION
- [x] Externalize docker-specific sandbox run functionality into separate file.
- [x] Externalize docker-specific sandbox stop functionality into separate file.
- [x] Enable docker-based sandbox based on required ConductR version.
- [x] Provide skeleton implementation of the new sandbox run and stop behaviour.
