### PR TITLE
Sandbox parser modification to support ConductR 2

### DIFF
--- a/conductr_cli/constants.py
+++ b/conductr_cli/constants.py
@@ -1,3 +1,4 @@
+from conductr_cli import host
 import os
 
 CONDUCTR_SCHEME = 'CONDUCTR_SCHEME'
@@ -14,6 +15,10 @@ DEFAULT_CUSTOM_SETTINGS_FILE = os.getenv('CONDUCTR_CUSTOM_SETTINGS_FILE',
                                          '{}/settings.conf'.format(DEFAULT_CLI_SETTINGS_DIR))
 DEFAULT_CUSTOM_PLUGINS_DIR = os.getenv('CONDUCTR_CUSTOM_PLUGINS_DIR',
                                        '{}/plugins'.format(DEFAULT_CLI_SETTINGS_DIR))
+DEFAULT_SANDBOX_IMAGE_DIR = os.path.abspath(os.getenv('CONDUCTR_SANDBOX_IMAGE_DIR',
+                                                      '{}/images'.format(DEFAULT_CLI_SETTINGS_DIR)))
+DEFAULT_SANDBOX_INTERFACE = os.getenv('CONDUCTR_SANDBOX_INTERFACE', host.loopback_device_name())
+DEFAULT_SANDBOX_ADDR_RANGE = os.getenv('CONDUCTR_SANDBOX_ADDR_RANGE', '192.168.1.0/24')
 DEFAULT_ERROR_LOG_FILE = os.path.abspath(os.getenv('CONDUCTR_CLI_ERROR_LOG',
                                                    '{}/errors.log'.format(DEFAULT_CLI_SETTINGS_DIR)))
 DEFAULT_WAIT_TIMEOUT = 60  # seconds

--- a/conductr_cli/exceptions.py
+++ b/conductr_cli/exceptions.py
@@ -88,3 +88,13 @@ class ContinuousDeliveryError(Exception):
 
     def __str__(self):
         return repr(self.value)
+
+
+class InstanceCountError(Exception):
+    def __init__(self, conductr_version, nr_of_containers, message):
+        self.conductr_version = conductr_version
+        self.nr_of_containers = nr_of_containers
+        self.message = message
+
+    def __str(self):
+        return repr(self.message)

--- a/conductr_cli/host.py
+++ b/conductr_cli/host.py
@@ -3,6 +3,7 @@ from conductr_cli import terminal, validation, docker_machine, docker
 from conductr_cli.exceptions import DockerMachineNotRunningError
 from subprocess import CalledProcessError
 from conductr_cli.docker import DockerVmType
+import platform
 
 
 CONDUCTR_HOST = 'CONDUCTR_HOST'
@@ -39,3 +40,7 @@ def with_docker_machine():
             raise DockerMachineNotRunningError('docker-machine host is not running.')
     except CalledProcessError:
         raise DockerMachineNotRunningError('docker-machine host is not running.')
+
+
+def loopback_device_name():
+    return 'lo' if platform.system().lower() == 'linux' else 'lo0'

--- a/conductr_cli/sandbox_run.py
+++ b/conductr_cli/sandbox_run.py
@@ -30,6 +30,7 @@ class ConductArgs:
 
 @validation.handle_connection_error
 @validation.handle_http_error
+@validation.handle_instance_count_error
 def run(args):
     """`sandbox run` command"""
 
@@ -52,6 +53,8 @@ def run(args):
         sandbox_run_docker.log_run_attempt(args, run_result, is_started, wait_timeout)
     else:
         sandbox_run_jvm.log_run_attempt(args, run_result, is_started, wait_timeout)
+
+    return True
 
 
 def wait_for_start(args):

--- a/conductr_cli/sandbox_stop.py
+++ b/conductr_cli/sandbox_stop.py
@@ -5,3 +5,4 @@ def stop(args):
     """`sandbox stop` command"""
 
     sandbox_stop_docker.stop(args)
+    return True

--- a/conductr_cli/test/test_host.py
+++ b/conductr_cli/test/test_host.py
@@ -90,3 +90,15 @@ class TestWithDockerMachine(TestCase):
 
         vm_name_mock.assert_called_with()
         docker_machine_ip_mock.assert_called_with('vm_name')
+
+
+class TestLoopbackDeviceName(TestCase):
+    def test_linux(self):
+        mock_system = MagicMock(return_value='Linux')
+        with patch('platform.system', mock_system):
+            self.assertEqual('lo', host.loopback_device_name())
+
+    def test_osx(self):
+        mock_system = MagicMock(return_value='Darwin')
+        with patch('platform.system', mock_system):
+            self.assertEqual('lo0', host.loopback_device_name())

--- a/conductr_cli/test/test_sandbox_run_docker.py
+++ b/conductr_cli/test/test_sandbox_run_docker.py
@@ -1,6 +1,7 @@
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin, as_error
 from conductr_cli import sandbox_run_docker, logging_setup
 from conductr_cli.docker import DockerVmType
+from conductr_cli.exceptions import InstanceCountError
 from conductr_cli.sandbox_common import CONDUCTR_DEV_IMAGE, LATEST_CONDUCTR_VERSION
 from conductr_cli.sandbox_features import VisualizationFeature, LoggingFeature
 from unittest.mock import patch, MagicMock
@@ -296,6 +297,16 @@ class TestRun(CliTestCase):
         mock_get_env.assert_any_call('CONDUCTR_DOCKER_RUN_OPTS')
         mock_docker_run.assert_called_once_with(expected_optional_args + ['-v', '/etc/haproxy:/usr/local/etc/haproxy'],
                                                 expected_image, expected_positional_args)
+
+    def test_invalid_nr_of_containers(self):
+        args = self.default_args.copy()
+        args.update({
+            'nr_of_containers': 'FOO'
+        })
+        input_args = MagicMock(**args)
+        features = []
+
+        self.assertRaises(InstanceCountError, sandbox_run_docker.run, input_args, features)
 
 
 class TestLogRunAttempt(CliTestCase):

--- a/conductr_cli/test/test_sandbox_run_jvm.py
+++ b/conductr_cli/test/test_sandbox_run_jvm.py
@@ -1,0 +1,99 @@
+from conductr_cli.test.cli_test_case import CliTestCase
+from conductr_cli import sandbox_run_jvm
+from conductr_cli.exceptions import InstanceCountError
+from unittest.mock import patch, MagicMock
+import ipaddress
+
+
+class TestRun(CliTestCase):
+    network_interface = 'lo0'
+    addr_range = ipaddress.ip_network('192.168.1.0/24', strict=True)
+    default_args = {
+        'image_version': '2.0.0',
+        'conductr_roles': [],
+        'log_level': 'info',
+        'nr_of_containers': 1,
+        'interface': network_interface,
+        'addr_range': addr_range,
+        'no_wait': False
+    }
+
+    def test_default_args(self):
+        # TODO: remove each of these mocks and update this test with the implementation
+        mock_validate_jvm_support = MagicMock()
+        mock_validate_address_aliases = MagicMock()
+
+        mock_core_extracted_dir = MagicMock()
+        mock_agent_extracted_dir = MagicMock()
+        mock_obtain_sandbox_image = MagicMock(return_value=(mock_core_extracted_dir, mock_agent_extracted_dir))
+
+        mock_sandbox_stop = MagicMock()
+
+        mock_core_pids = MagicMock()
+        mock_start_core_instances = MagicMock(return_value=mock_core_pids)
+
+        mock_agent_pids = MagicMock()
+        mock_start_agent_instances = MagicMock(return_value=mock_agent_pids)
+
+        input_args = MagicMock(**self.default_args)
+        features = []
+
+        with patch('conductr_cli.sandbox_run_jvm.validate_jvm_support', mock_validate_jvm_support), \
+                patch('conductr_cli.sandbox_run_jvm.validate_address_aliases', mock_validate_address_aliases), \
+                patch('conductr_cli.sandbox_run_jvm.obtain_sandbox_image', mock_obtain_sandbox_image), \
+                patch('conductr_cli.sandbox_run_jvm.sandbox_stop', mock_sandbox_stop), \
+                patch('conductr_cli.sandbox_run_jvm.start_core_instances', mock_start_core_instances), \
+                patch('conductr_cli.sandbox_run_jvm.start_agent_instances', mock_start_agent_instances):
+            result = sandbox_run_jvm.run(input_args, features)
+            self.assertEqual((mock_core_pids, mock_agent_pids), result)
+
+        mock_validate_address_aliases.assert_called_with(1, self.network_interface, self.addr_range)
+        mock_start_core_instances.assert_called_with(mock_core_extracted_dir, 1, self.addr_range)
+        mock_start_agent_instances.assert_called_with(mock_agent_extracted_dir, 1, self.addr_range)
+
+    def test_nr_of_core_agent_instances(self):
+        # TODO: remove each of these mocks and update this test with the implementation
+        mock_validate_jvm_support = MagicMock()
+        mock_validate_address_aliases = MagicMock()
+
+        mock_core_extracted_dir = MagicMock()
+        mock_agent_extracted_dir = MagicMock()
+        mock_obtain_sandbox_image = MagicMock(return_value=(mock_core_extracted_dir, mock_agent_extracted_dir))
+
+        mock_sandbox_stop = MagicMock()
+
+        mock_core_pids = MagicMock()
+        mock_start_core_instances = MagicMock(return_value=mock_core_pids)
+
+        mock_agent_pids = MagicMock()
+        mock_start_agent_instances = MagicMock(return_value=mock_agent_pids)
+
+        args = self.default_args.copy()
+        args.update({
+            'nr_of_containers': '1:3'
+        })
+        input_args = MagicMock(**args)
+        features = []
+
+        with patch('conductr_cli.sandbox_run_jvm.validate_jvm_support', mock_validate_jvm_support), \
+                patch('conductr_cli.sandbox_run_jvm.validate_address_aliases', mock_validate_address_aliases), \
+                patch('conductr_cli.sandbox_run_jvm.obtain_sandbox_image', mock_obtain_sandbox_image), \
+                patch('conductr_cli.sandbox_run_jvm.sandbox_stop', mock_sandbox_stop), \
+                patch('conductr_cli.sandbox_run_jvm.start_core_instances', mock_start_core_instances), \
+                patch('conductr_cli.sandbox_run_jvm.start_agent_instances', mock_start_agent_instances):
+            result = sandbox_run_jvm.run(input_args, features)
+            self.assertEqual((mock_core_pids, mock_agent_pids), result)
+
+        mock_validate_address_aliases.assert_called_with(3, self.network_interface, self.addr_range)
+        mock_start_core_instances.assert_called_with(mock_core_extracted_dir, 1, self.addr_range)
+        mock_start_agent_instances.assert_called_with(mock_agent_extracted_dir, 3, self.addr_range)
+
+    def test_invalid_nr_of_containers(self):
+        args = self.default_args.copy()
+        args.update({
+            'nr_of_containers': 'FOO'
+        })
+        input_args = MagicMock(**args)
+        features = []
+
+        self.assertRaises(InstanceCountError, sandbox_run_jvm.run, input_args, features)

--- a/conductr_cli/test/test_sandbox_stop.py
+++ b/conductr_cli/test/test_sandbox_stop.py
@@ -1,6 +1,5 @@
 from conductr_cli.test.cli_test_case import CliTestCase
-from conductr_cli import sandbox_stop, logging_setup
-from conductr_cli.screen_utils import headline
+from conductr_cli import sandbox_stop
 from unittest.mock import patch, MagicMock
 
 
@@ -13,13 +12,10 @@ class TestSandboxStopCommand(CliTestCase):
     }
 
     def test_success(self):
-        stdout = MagicMock()
-        containers = ['cond-0', 'cond-1']
+        mock_sandbox_stop_docker = MagicMock()
 
-        with patch('conductr_cli.sandbox_common.resolve_running_docker_containers', return_value=containers), \
-                patch('conductr_cli.terminal.docker_rm') as mock_docker_rm:
-            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
-            sandbox_stop.stop(MagicMock(**self.default_args))
+        input_args = MagicMock(**self.default_args)
+        with patch('conductr_cli.sandbox_stop_docker.stop', mock_sandbox_stop_docker):
+            self.assertTrue(sandbox_stop.stop(input_args))
 
-        self.assertEqual(headline('Stopping ConductR') + '\n', self.output(stdout))
-        mock_docker_rm.assert_called_once_with(containers)
+        mock_sandbox_stop_docker.assert_called_once_with(input_args)

--- a/conductr_cli/test/test_sandbox_stop_docker.py
+++ b/conductr_cli/test/test_sandbox_stop_docker.py
@@ -1,0 +1,25 @@
+from conductr_cli.test.cli_test_case import CliTestCase
+from conductr_cli import sandbox_stop_docker, logging_setup
+from conductr_cli.screen_utils import headline
+from unittest.mock import patch, MagicMock
+
+
+class TestSandboxStopCommand(CliTestCase):
+
+    default_args = {
+        'local_connection': True,
+        'verbose': False,
+        'quiet': False
+    }
+
+    def test_success(self):
+        stdout = MagicMock()
+        containers = ['cond-0', 'cond-1']
+
+        with patch('conductr_cli.sandbox_common.resolve_running_docker_containers', return_value=containers), \
+                patch('conductr_cli.terminal.docker_rm') as mock_docker_rm:
+            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
+            sandbox_stop_docker.stop(MagicMock(**self.default_args))
+
+        self.assertEqual(headline('Stopping ConductR') + '\n', self.output(stdout))
+        mock_docker_rm.assert_called_once_with(containers)

--- a/conductr_cli/validation.py
+++ b/conductr_cli/validation.py
@@ -11,7 +11,7 @@ from urllib.error import URLError
 from zipfile import BadZipFile
 from conductr_cli import terminal, docker_machine
 from conductr_cli.exceptions import AmbiguousDockerVmError, DockerMachineNotRunningError, \
-    DockerMachineCannotConnectToDockerError, MalformedBundleError, BundleResolutionError,  \
+    DockerMachineCannotConnectToDockerError, InstanceCountError, MalformedBundleError, BundleResolutionError,  \
     WaitTimeoutError, InsecureFilePermissions, NOT_FOUND_ERROR
 from subprocess import CalledProcessError
 
@@ -291,6 +291,25 @@ def handle_vbox_manage_not_found_error(func):
             log.error('VBoxManage command not found')
             log.error('Make sure VirtualBox is installed and VBoxManage is in the path')
             exit(1)
+
+    # Do not change the wrapped function name,
+    # so argparse configuration can be tested.
+    handler.__name__ = func.__name__
+
+    return handler
+
+
+def handle_instance_count_error(func):
+
+    def handler(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except InstanceCountError as e:
+            log = get_logger_for_func(func)
+            log.error('Invalid number of containers {} '
+                      'for ConductR version {}'.format(e.nr_of_containers, e.conductr_version))
+            log.error(e.message)
+            return False
 
     # Do not change the wrapped function name,
     # so argparse configuration can be tested.


### PR DESCRIPTION
- Modify parser for `-n` or `--nr-of-containers` to support instance expression for ConductR 2, i.e. `2:3`.
- Add parser for `--interface` with `lo0` as the default for the time being.
- Add parser for `--addr-range` with `192.168.1.0/24` as default.
- Add parser for `--image-dir` with `~/.conductr/images` as default.
- Ensure correct return code (`0` or `1`) is returned if sandbox commands completes successfully or with failure.