### PR TITLE
Ensure address is available during sandbox run

### DIFF
--- a/conductr_cli/constants.py
+++ b/conductr_cli/constants.py
@@ -1,4 +1,3 @@
-from conductr_cli import host
 import os
 
 CONDUCTR_SCHEME = 'CONDUCTR_SCHEME'
@@ -17,7 +16,6 @@ DEFAULT_CUSTOM_PLUGINS_DIR = os.getenv('CONDUCTR_CUSTOM_PLUGINS_DIR',
                                        '{}/plugins'.format(DEFAULT_CLI_SETTINGS_DIR))
 DEFAULT_SANDBOX_IMAGE_DIR = os.path.abspath(os.getenv('CONDUCTR_SANDBOX_IMAGE_DIR',
                                                       '{}/images'.format(DEFAULT_CLI_SETTINGS_DIR)))
-DEFAULT_SANDBOX_INTERFACE = os.getenv('CONDUCTR_SANDBOX_INTERFACE', host.loopback_device_name())
 DEFAULT_SANDBOX_ADDR_RANGE = os.getenv('CONDUCTR_SANDBOX_ADDR_RANGE', '192.168.1.0/24')
 DEFAULT_ERROR_LOG_FILE = os.path.abspath(os.getenv('CONDUCTR_CLI_ERROR_LOG',
                                                    '{}/errors.log'.format(DEFAULT_CLI_SETTINGS_DIR)))

--- a/conductr_cli/exceptions.py
+++ b/conductr_cli/exceptions.py
@@ -98,3 +98,11 @@ class InstanceCountError(Exception):
 
     def __str(self):
         return repr(self.message)
+
+
+class BindAddressNotFoundError(Exception):
+    def __init__(self, message):
+        self.message = message
+
+    def __str(self):
+        return repr(self.message)

--- a/conductr_cli/sandbox_main.py
+++ b/conductr_cli/sandbox_main.py
@@ -3,9 +3,9 @@ import argparse
 import ipaddress
 import logging
 import re
-from conductr_cli.sandbox_common import CONDUCTR_DEV_IMAGE
+from conductr_cli.sandbox_common import CONDUCTR_DEV_IMAGE, major_version
 from conductr_cli.sandbox_features import feature_names
-from conductr_cli.constants import DEFAULT_SANDBOX_ADDR_RANGE, DEFAULT_SANDBOX_IMAGE_DIR, DEFAULT_SANDBOX_INTERFACE
+from conductr_cli.constants import DEFAULT_SANDBOX_ADDR_RANGE, DEFAULT_SANDBOX_IMAGE_DIR
 from conductr_cli.docker import DockerVmType
 from conductr_cli import sandbox_run, sandbox_stop, sandbox_common, logging_setup, docker, \
     docker_machine, terminal, version, validation
@@ -104,9 +104,6 @@ def build_parser():
                             default=False,
                             dest='no_wait',
                             action='store_true')
-    run_parser.add_argument('--interface',
-                            default=DEFAULT_SANDBOX_INTERFACE,
-                            help='The network interface which will be used by ConductR Sandbox to bind to.')
     run_parser.add_argument('--addr-range',
                             type=addr_range,
                             default=DEFAULT_SANDBOX_ADDR_RANGE,
@@ -272,7 +269,10 @@ def run():
                              ', '.join("'%s'" % f for f in feature_names)))
         # Docker VM validation
         args.vm_type = docker.vm_type()
-        validate_docker_vm(args.vm_type)
+        if vars(args).get('func').__name__ == 'run' \
+                and major_version(args.image_version) == '1':
+            validate_docker_vm(args.vm_type)
+
         result = args.func(args)
         if not result:
             exit(1)

--- a/conductr_cli/sandbox_run.py
+++ b/conductr_cli/sandbox_run.py
@@ -31,6 +31,7 @@ class ConductArgs:
 @validation.handle_connection_error
 @validation.handle_http_error
 @validation.handle_instance_count_error
+@validation.handle_bind_address_not_found_error
 def run(args):
     """`sandbox run` command"""
 

--- a/conductr_cli/test/test_sandbox_main.py
+++ b/conductr_cli/test/test_sandbox_main.py
@@ -1,6 +1,6 @@
 from conductr_cli.test.cli_test_case import CliTestCase, as_warn, as_error, strip_margin
 from conductr_cli import sandbox_main, logging_setup
-from conductr_cli.constants import DEFAULT_SANDBOX_ADDR_RANGE, DEFAULT_SANDBOX_IMAGE_DIR, DEFAULT_SANDBOX_INTERFACE
+from conductr_cli.constants import DEFAULT_SANDBOX_ADDR_RANGE, DEFAULT_SANDBOX_IMAGE_DIR
 from conductr_cli.sandbox_common import LATEST_CONDUCTR_VERSION, CONDUCTR_DEV_IMAGE
 from conductr_cli.docker import DockerVmType
 from subprocess import CalledProcessError
@@ -26,7 +26,6 @@ class TestSandbox(CliTestCase):
         self.assertEqual(args.features, [])
         self.assertEqual(args.local_connection, True)
         self.assertEqual(args.resolve_ip, True)
-        self.assertEqual(args.interface, DEFAULT_SANDBOX_INTERFACE)
         self.assertEqual(args.addr_range, ipaddress.ip_network(DEFAULT_SANDBOX_ADDR_RANGE, strict=True))
         self.assertEqual(args.image_dir, DEFAULT_SANDBOX_IMAGE_DIR)
 
@@ -40,7 +39,6 @@ class TestSandbox(CliTestCase):
                                       '--port 1000 -p 1001 '
                                       '--bundle-http-port 7111 '
                                       '--image-dir /foo/bar '
-                                      '--interface ix0 '
                                       '--addr-range 192.168.10.0/24 '
                                       '--feature visualization -f logging -f monitoring 2.1.0'.split())
         self.assertEqual(args.func.__name__, 'run')
@@ -55,7 +53,6 @@ class TestSandbox(CliTestCase):
         self.assertEqual(args.local_connection, True)
         self.assertEqual(args.resolve_ip, True)
         self.assertEqual(args.bundle_http_port, 7111)
-        self.assertEqual(args.interface, 'ix0')
         self.assertEqual(args.addr_range, ipaddress.ip_network('192.168.10.0/24', strict=True))
         self.assertEqual(args.image_dir, '/foo/bar')
 

--- a/conductr_cli/test/test_sandbox_run_jvm.py
+++ b/conductr_cli/test/test_sandbox_run_jvm.py
@@ -1,27 +1,28 @@
 from conductr_cli.test.cli_test_case import CliTestCase
 from conductr_cli import sandbox_run_jvm
-from conductr_cli.exceptions import InstanceCountError
-from unittest.mock import patch, MagicMock
+from conductr_cli.exceptions import BindAddressNotFoundError, InstanceCountError
+from conductr_cli.sandbox_run_jvm import BIND_TEST_PORT
+from unittest.mock import call, patch, MagicMock
 import ipaddress
 
 
 class TestRun(CliTestCase):
-    network_interface = 'lo0'
     addr_range = ipaddress.ip_network('192.168.1.0/24', strict=True)
     default_args = {
         'image_version': '2.0.0',
         'conductr_roles': [],
         'log_level': 'info',
         'nr_of_containers': 1,
-        'interface': network_interface,
         'addr_range': addr_range,
         'no_wait': False
     }
 
     def test_default_args(self):
-        # TODO: remove each of these mocks and update this test with the implementation
         mock_validate_jvm_support = MagicMock()
-        mock_validate_address_aliases = MagicMock()
+
+        bind_addr = MagicMock()
+        bind_addrs = [bind_addr]
+        mock_find_bind_addrs = MagicMock(return_value=bind_addrs)
 
         mock_core_extracted_dir = MagicMock()
         mock_agent_extracted_dir = MagicMock()
@@ -39,7 +40,7 @@ class TestRun(CliTestCase):
         features = []
 
         with patch('conductr_cli.sandbox_run_jvm.validate_jvm_support', mock_validate_jvm_support), \
-                patch('conductr_cli.sandbox_run_jvm.validate_address_aliases', mock_validate_address_aliases), \
+                patch('conductr_cli.sandbox_run_jvm.find_bind_addrs', mock_find_bind_addrs), \
                 patch('conductr_cli.sandbox_run_jvm.obtain_sandbox_image', mock_obtain_sandbox_image), \
                 patch('conductr_cli.sandbox_run_jvm.sandbox_stop', mock_sandbox_stop), \
                 patch('conductr_cli.sandbox_run_jvm.start_core_instances', mock_start_core_instances), \
@@ -47,14 +48,18 @@ class TestRun(CliTestCase):
             result = sandbox_run_jvm.run(input_args, features)
             self.assertEqual((mock_core_pids, mock_agent_pids), result)
 
-        mock_validate_address_aliases.assert_called_with(1, self.network_interface, self.addr_range)
-        mock_start_core_instances.assert_called_with(mock_core_extracted_dir, 1, self.addr_range)
-        mock_start_agent_instances.assert_called_with(mock_agent_extracted_dir, 1, self.addr_range)
+        mock_find_bind_addrs.assert_called_with(1, self.addr_range)
+        mock_start_core_instances.assert_called_with(mock_core_extracted_dir, bind_addrs)
+        mock_start_agent_instances.assert_called_with(mock_agent_extracted_dir, bind_addrs)
 
     def test_nr_of_core_agent_instances(self):
-        # TODO: remove each of these mocks and update this test with the implementation
         mock_validate_jvm_support = MagicMock()
-        mock_validate_address_aliases = MagicMock()
+
+        bind_addr1 = MagicMock()
+        bind_addr2 = MagicMock()
+        bind_addr3 = MagicMock()
+        bind_addrs = [bind_addr1, bind_addr2, bind_addr3]
+        mock_find_bind_addrs = MagicMock(return_value=bind_addrs)
 
         mock_core_extracted_dir = MagicMock()
         mock_agent_extracted_dir = MagicMock()
@@ -76,7 +81,7 @@ class TestRun(CliTestCase):
         features = []
 
         with patch('conductr_cli.sandbox_run_jvm.validate_jvm_support', mock_validate_jvm_support), \
-                patch('conductr_cli.sandbox_run_jvm.validate_address_aliases', mock_validate_address_aliases), \
+                patch('conductr_cli.sandbox_run_jvm.find_bind_addrs', mock_find_bind_addrs), \
                 patch('conductr_cli.sandbox_run_jvm.obtain_sandbox_image', mock_obtain_sandbox_image), \
                 patch('conductr_cli.sandbox_run_jvm.sandbox_stop', mock_sandbox_stop), \
                 patch('conductr_cli.sandbox_run_jvm.start_core_instances', mock_start_core_instances), \
@@ -84,9 +89,9 @@ class TestRun(CliTestCase):
             result = sandbox_run_jvm.run(input_args, features)
             self.assertEqual((mock_core_pids, mock_agent_pids), result)
 
-        mock_validate_address_aliases.assert_called_with(3, self.network_interface, self.addr_range)
-        mock_start_core_instances.assert_called_with(mock_core_extracted_dir, 1, self.addr_range)
-        mock_start_agent_instances.assert_called_with(mock_agent_extracted_dir, 3, self.addr_range)
+        mock_find_bind_addrs.assert_called_with(3, self.addr_range)
+        mock_start_core_instances.assert_called_with(mock_core_extracted_dir, [bind_addr1])
+        mock_start_agent_instances.assert_called_with(mock_agent_extracted_dir, [bind_addr1, bind_addr2, bind_addr3])
 
     def test_invalid_nr_of_containers(self):
         args = self.default_args.copy()
@@ -97,3 +102,67 @@ class TestRun(CliTestCase):
         features = []
 
         self.assertRaises(InstanceCountError, sandbox_run_jvm.run, input_args, features)
+
+
+class TestFindBindAddresses(CliTestCase):
+    nr_of_instances = 3
+    addr_range = ipaddress.ip_network('192.168.1.0/24', strict=True)
+
+    def test_found(self):
+        mock_can_bind = MagicMock(return_value=True)
+        mock_addr_alias_setup_instructions = MagicMock(return_value="test")
+
+        with patch('conductr_cli.host.can_bind', mock_can_bind), \
+                patch('conductr_cli.host.addr_alias_setup_instructions', mock_addr_alias_setup_instructions):
+            result = sandbox_run_jvm.find_bind_addrs(self.nr_of_instances, self.addr_range)
+            self.assertEqual([
+                ipaddress.ip_address('192.168.1.1'),
+                ipaddress.ip_address('192.168.1.2'),
+                ipaddress.ip_address('192.168.1.3')
+            ], result)
+
+        self.assertEqual([
+            call(ipaddress.ip_address('192.168.1.1'), BIND_TEST_PORT),
+            call(ipaddress.ip_address('192.168.1.2'), BIND_TEST_PORT),
+            call(ipaddress.ip_address('192.168.1.3'), BIND_TEST_PORT)
+        ], mock_can_bind.call_args_list)
+
+        mock_addr_alias_setup_instructions.assert_not_called()
+
+    def test_not_found(self):
+        mock_can_bind = MagicMock(return_value=False)
+        mock_addr_alias_setup_instructions = MagicMock(return_value="test")
+
+        with patch('conductr_cli.host.can_bind', mock_can_bind), \
+                patch('conductr_cli.host.addr_alias_setup_instructions', mock_addr_alias_setup_instructions):
+            self.assertRaises(BindAddressNotFoundError, sandbox_run_jvm.find_bind_addrs, 3, self.addr_range)
+
+        self.assertEqual([
+            call(addr, BIND_TEST_PORT) for addr in self.addr_range.hosts()
+        ], mock_can_bind.call_args_list)
+
+        mock_addr_alias_setup_instructions.assert_called_once_with(
+            [ipaddress.ip_address('192.168.1.1'),
+             ipaddress.ip_address('192.168.1.2'),
+             ipaddress.ip_address('192.168.1.3')],
+            self.addr_range.netmask)
+
+    def test_partial_found(self):
+        mock_can_bind = MagicMock(side_effect=[
+            True if idx == 0 else False
+            for idx, addr in enumerate(self.addr_range.hosts())
+        ])
+        mock_addr_alias_setup_instructions = MagicMock(return_value="test")
+
+        with patch('conductr_cli.host.can_bind', mock_can_bind), \
+                patch('conductr_cli.host.addr_alias_setup_instructions', mock_addr_alias_setup_instructions):
+            self.assertRaises(BindAddressNotFoundError, sandbox_run_jvm.find_bind_addrs, 3, self.addr_range)
+
+        self.assertEqual([
+            call(addr, BIND_TEST_PORT) for addr in self.addr_range.hosts()
+        ], mock_can_bind.call_args_list)
+
+        mock_addr_alias_setup_instructions.assert_called_once_with(
+            [ipaddress.ip_address('192.168.1.2'),
+             ipaddress.ip_address('192.168.1.3')],
+            self.addr_range.netmask)

--- a/conductr_cli/validation.py
+++ b/conductr_cli/validation.py
@@ -10,7 +10,7 @@ from requests.exceptions import ConnectionError, HTTPError, ReadTimeout
 from urllib.error import URLError
 from zipfile import BadZipFile
 from conductr_cli import terminal, docker_machine
-from conductr_cli.exceptions import AmbiguousDockerVmError, DockerMachineNotRunningError, \
+from conductr_cli.exceptions import AmbiguousDockerVmError, BindAddressNotFoundError, DockerMachineNotRunningError, \
     DockerMachineCannotConnectToDockerError, InstanceCountError, MalformedBundleError, BundleResolutionError,  \
     WaitTimeoutError, InsecureFilePermissions, NOT_FOUND_ERROR
 from subprocess import CalledProcessError
@@ -308,6 +308,24 @@ def handle_instance_count_error(func):
             log = get_logger_for_func(func)
             log.error('Invalid number of containers {} '
                       'for ConductR version {}'.format(e.nr_of_containers, e.conductr_version))
+            log.error(e.message)
+            return False
+
+    # Do not change the wrapped function name,
+    # so argparse configuration can be tested.
+    handler.__name__ = func.__name__
+
+    return handler
+
+
+def handle_bind_address_not_found_error(func):
+
+    def handler(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except BindAddressNotFoundError as e:
+            log = get_logger_for_func(func)
+            log.error('Unable to allocate bind address')
             log.error(e.message)
             return False
 


### PR DESCRIPTION
When `sandbox run` is invoked for ConductR 2, perform checks to ensure ip addresses is available to each available instance given the address range.

The check is done by performing a socket bind to an address within the specified address range. If the bind is successful, the socket is immediately closed. Otherwise, the address is marked as unavailable.

If addresses can't be allocated to all core and agent instances, the `sandbox run` will fail and produce the commands which can be copy-pasted by the end user to setup the required address aliases.

The `--interface` parser is removed as well since the interface name is used only to print the user instructions in the scenario above and has no further functionality within the application.

The Docker env validation is now going to be performed for `sandbox run` ConductR 1 only.