### PR TITLE
Obtain and extract ConductR universal binaries

### DIFF
--- a/conductr_cli/conduct_load.py
+++ b/conductr_cli/conduct_load.py
@@ -30,6 +30,7 @@ KEEP_BUNDLE_VERSIONS = 1
 @validation.handle_wait_timeout_error
 @validation.handle_conduct_load_read_timeout_error
 @validation.handle_insecure_file_permissions
+@validation.handle_bintray_credentials_error
 def load(args):
     if args.api_version == '1':
         return load_v1(args)

--- a/conductr_cli/exceptions.py
+++ b/conductr_cli/exceptions.py
@@ -66,6 +66,30 @@ class BintrayResolutionError(Exception):
         return repr(self.value)
 
 
+class BintrayUnreachableError(Exception):
+    def __init__(self, value):
+        self.value = value
+
+    def __str__(self):
+        return repr(self.value)
+
+
+class BintrayCredentialsNotFoundError(Exception):
+    def __init__(self, credential_file_path):
+        self.credential_file_path = credential_file_path
+
+    def __str__(self):
+        return repr(self.value)
+
+
+class MalformedBintrayCredentialsError(Exception):
+    def __init__(self, credential_file_path):
+        self.credential_file_path = credential_file_path
+
+    def __str__(self):
+        return repr(self.value)
+
+
 class InsecureFilePermissions(Exception):
     def __init__(self, value):
         self.value = value
@@ -103,6 +127,15 @@ class InstanceCountError(Exception):
 class BindAddressNotFoundError(Exception):
     def __init__(self, message):
         self.message = message
+
+    def __str(self):
+        return repr(self.message)
+
+
+class SandboxImageNotFoundError(Exception):
+    def __init__(self, component_type, image_version):
+        self.component_type = component_type
+        self.image_version = image_version
 
     def __str(self):
         return repr(self.message)

--- a/conductr_cli/resolvers/uri_resolver.py
+++ b/conductr_cli/resolvers/uri_resolver.py
@@ -10,13 +10,17 @@ import urllib
 
 
 def resolve_bundle(cache_dir, uri, auth=None):
+    return resolve_file(cache_dir, uri, auth)
+
+
+def resolve_file(cache_dir, uri, auth=None):
     log = logging.getLogger(__name__)
 
     if not os.path.exists(cache_dir):
         os.makedirs(cache_dir, mode=0o700)
 
     try:
-        bundle_name, bundle_url = get_url(uri)
+        file_name, file_url = get_url(uri)
 
         cached_file = cache_path(cache_dir, uri)
         tmp_download_path = '{}.tmp'.format(cached_file)
@@ -24,11 +28,11 @@ def resolve_bundle(cache_dir, uri, auth=None):
         if os.path.exists(tmp_download_path):
             os.remove(tmp_download_path)
 
-        download_bundle(log, bundle_url, tmp_download_path, auth)
+        download_bundle(log, file_url, tmp_download_path, auth)
 
         os.chmod(tmp_download_path, 0o600)
         shutil.move(tmp_download_path, cached_file)
-        return True, bundle_name, cached_file
+        return True, file_name, cached_file
     except URLError:
         return False, None, None
 

--- a/conductr_cli/sandbox_common.py
+++ b/conductr_cli/sandbox_common.py
@@ -1,5 +1,11 @@
 from conductr_cli import terminal
 import os
+from enum import Enum
+
+
+class ConductrComponent(Enum):
+    CORE = 1
+    AGENT = 2
 
 
 CONDUCTR_NAME_PREFIX = 'cond-'

--- a/conductr_cli/sandbox_run.py
+++ b/conductr_cli/sandbox_run.py
@@ -32,6 +32,9 @@ class ConductArgs:
 @validation.handle_http_error
 @validation.handle_instance_count_error
 @validation.handle_bind_address_not_found_error
+@validation.handle_sandbox_image_not_found_error
+@validation.handle_bintray_credentials_error
+@validation.handle_bintray_unreachable_error
 def run(args):
     """`sandbox run` command"""
 


### PR DESCRIPTION
The new sandbox approach uses the ConductR universal binaries to start the core and agent processes.

This PR downloads the ConductR core and agent universal binaries from Bintray. First the local cache is interrogated for the presence of the binary. If the binary is not yet available within the local cache, then it will be downloaded from Bintray. If the binary is present within the local cache, they will be used instead.

The core and agent binaries are expanded into the `${image_dir}/core` and `${image_dir}/core`. The directories will be emptied before the binary is expanded.

## Handled error scenarios
The following error scenarios are handled with a descriptive error message (see test output):
- Bintray credential file can not be found
- Malformed Bintray credential file
- Bintray unreachable
- ConductR version on Bintray not found

This PR also improves the Bintray error handling on `conduct load`. When Bintray is unreachable, a descriptive error message is returned. Prior to this PR, an error was displayed saying that ConductR could not been started (which is the wrong error message for this case).

## Test output

### Downloading from Bintray

```
$ sandbox run 2.0.0-rc.2
Bintray credentials loaded from /Users/mj/.lightbend/commercial.credentials
Retrieving https://dl.bintray.com/lightbend/commercial-releases/conductr-2.0.0-rc.2.tgz
[#################################################] 100%
Retrieving https://dl.bintray.com/lightbend/commercial-releases/conductr-agent-2.0.0-rc.2.tgz
[#################################################] 100%
Extracting ConductR core to /Users/mj/.conductr/images/core
Extracting ConductR agent to /Users/mj/.conductr/images/agent
Binding ConductR core to the following address: 192.168.1.1
Binding ConductR agent to the following address: 192.168.1.1
```

### Using local cache

```
sandbox run 2.0.0-rc.2
Extracting ConductR core to /Users/mj/.conductr/images/core
Extracting ConductR agent to /Users/mj/.conductr/images/agent
Binding ConductR core to the following address: 192.168.1.1
Binding ConductR agent to the following address: 192.168.1.1
```

### Bintray credential file not found

```
$ sandbox run 2.0.0-rc.2
Error: Bintray credentials not found in /Users/mj/.lightbend/commercial.credentials
Error: Please follow the instructions to setup the Lightbend Bintray credentials:
Error:   http://developers.lightbend.com/docs/reactive-platform/2.0/setup/setup-sbt.html
```

### Malformed Bintray credential file

```
$ sandbox run 2.0.0-rc.2
Error: Malformed Bintray credentials in /Users/mj/.lightbend/commercial.credentials
Error: Please follow the instructions to setup the Lightbend Bintray credentials:
Error:   http://developers.lightbend.com/docs/reactive-platform/2.0/setup/setup-sbt.html
```

### Bintray unreachable

```
$ sandbox run 2.0.0-rc.2
Bintray credentials loaded from /Users/mj/.lightbend/commercial.credentials
Error: Artifact can not be resolved from Bintray.
Error: It seems that Bintray is unreachable.
Error: Please check your internet connection and try again.
```

### Conduct version not found on Bintray

```
$ sandbox run 2.10.0
Bintray credentials loaded from /Users/mj/.lightbend/commercial.credentials
Error: ConductR core 2.10.0 cannot be found on Bintray.
Error: Please specify a valid ConductR version.
Error: The latest version can be found on: https://www.lightbend.com/product/conductr/developer
```