### PR TITLE
Start ConductR core and agent for JVM based sandbox

### DIFF
--- a/conductr_cli/constants.py
+++ b/conductr_cli/constants.py
@@ -16,7 +16,7 @@ DEFAULT_CUSTOM_PLUGINS_DIR = os.getenv('CONDUCTR_CUSTOM_PLUGINS_DIR',
                                        '{}/plugins'.format(DEFAULT_CLI_SETTINGS_DIR))
 DEFAULT_SANDBOX_IMAGE_DIR = os.path.abspath(os.getenv('CONDUCTR_SANDBOX_IMAGE_DIR',
                                                       '{}/images'.format(DEFAULT_CLI_SETTINGS_DIR)))
-DEFAULT_SANDBOX_ADDR_RANGE = os.getenv('CONDUCTR_SANDBOX_ADDR_RANGE', '192.168.1.0/24')
+DEFAULT_SANDBOX_ADDR_RANGE = os.getenv('CONDUCTR_SANDBOX_ADDR_RANGE', '192.168.10.0/24')
 DEFAULT_ERROR_LOG_FILE = os.path.abspath(os.getenv('CONDUCTR_CLI_ERROR_LOG',
                                                    '{}/errors.log'.format(DEFAULT_CLI_SETTINGS_DIR)))
 DEFAULT_WAIT_TIMEOUT = 60  # seconds

--- a/conductr_cli/test/test_sandbox_run_docker.py
+++ b/conductr_cli/test/test_sandbox_run_docker.py
@@ -311,6 +311,9 @@ class TestRun(CliTestCase):
 
 class TestLogRunAttempt(CliTestCase):
     wait_timeout = 60
+    container_names = ['cond-0', 'cond-1', 'cond-2']
+    hostname = '10.0.0.1'
+    run_result = sandbox_run_docker.SandboxRunResult(container_names, hostname, nr_of_proxy_instances=1)
 
     def test_log_output(self):
         stdout = MagicMock()
@@ -321,7 +324,7 @@ class TestLogRunAttempt(CliTestCase):
         logging_setup.configure_logging(input_args, stdout)
         sandbox_run_docker.log_run_attempt(
             input_args,
-            container_names=['cond-0', 'cond-1', 'cond-2'],
+            run_result=self.run_result,
             is_started=True,
             wait_timeout=self.wait_timeout
         )
@@ -346,7 +349,7 @@ class TestLogRunAttempt(CliTestCase):
         logging_setup.configure_logging(input_args, stdout)
         sandbox_run_docker.log_run_attempt(
             input_args,
-            container_names=['cond-0'],
+            run_result=sandbox_run_docker.SandboxRunResult(['cond-0'], self.hostname, nr_of_proxy_instances=1),
             is_started=True,
             wait_timeout=self.wait_timeout
         )
@@ -372,7 +375,7 @@ class TestLogRunAttempt(CliTestCase):
         logging_setup.configure_logging(input_args, stdout, stderr)
         sandbox_run_docker.log_run_attempt(
             input_args,
-            container_names=['cond-0'],
+            run_result=self.run_result,
             is_started=False,
             wait_timeout=self.wait_timeout
         )
@@ -397,7 +400,7 @@ class TestLogRunAttempt(CliTestCase):
         logging_setup.configure_logging(input_args, stdout)
         sandbox_run_docker.log_run_attempt(
             input_args,
-            container_names=['cond-0'],
+            run_result=self.run_result,
             is_started=True,
             wait_timeout=self.wait_timeout
         )


### PR DESCRIPTION
- Start ConductR core and agent for JVM based sandbox based on the detected available addresses from supplied address range, running from the expanded core and agent directory.
- Modify `sandbox_run_docker` and `sandbox_run_jvm` to return `SandboxRunResult` specific to either Docker or JVM based sandbox.
- Installation of proxy and features is now based on the ConductR host address supplied by the `SandboxRunResult`.
- Move the default address range to `192.168.10.0/24`. This is done to avoid conflict with common address range used by routers.
- Detection for ConductR host for `conduct` commands now includes the check if ConductR is listening on the first address within the default address range.