### PR TITLE
Validate for supported JVM version when starting JVM based sandbox

### DIFF
--- a/conductr_cli/exceptions.py
+++ b/conductr_cli/exceptions.py
@@ -139,3 +139,35 @@ class SandboxImageNotFoundError(Exception):
 
     def __str(self):
         return repr(self.message)
+
+
+class JavaCallError(Exception):
+    def __init__(self, message):
+        self.message = message
+
+    def __str(self):
+        return repr(self.message)
+
+
+class JavaVersionParseError(Exception):
+    def __init__(self, java_version_output):
+        self.java_version_output = java_version_output
+
+    def __str(self):
+        return repr(self.java_version_output)
+
+
+class JavaUnsupportedVendorError(Exception):
+    def __init__(self, vendor):
+        self.vendor = vendor
+
+    def __str(self):
+        return repr(self.vendor)
+
+
+class JavaUnsupportedVersionError(Exception):
+    def __init__(self, jvm_version):
+        self.jvm_version = jvm_version
+
+    def __str(self):
+        return repr(self.jvm_version)

--- a/conductr_cli/sandbox_run.py
+++ b/conductr_cli/sandbox_run.py
@@ -22,6 +22,7 @@ DEFAULT_WAIT_RETRY_INTERVAL = 2.0
 @validation.handle_sandbox_image_not_found_error
 @validation.handle_bintray_credentials_error
 @validation.handle_bintray_unreachable_error
+@validation.handle_jvm_validation_error
 def run(args):
     """`sandbox run` command"""
 

--- a/conductr_cli/test/test_sandbox_run.py
+++ b/conductr_cli/test/test_sandbox_run.py
@@ -1,7 +1,8 @@
 from conductr_cli.test.cli_test_case import CliTestCase, as_error, strip_margin
 from conductr_cli import logging_setup, sandbox_run, sandbox_run_docker, sandbox_run_jvm
 from conductr_cli.docker import DockerVmType
-from conductr_cli.exceptions import InstanceCountError
+from conductr_cli.exceptions import InstanceCountError, JavaCallError, JavaUnsupportedVendorError, \
+    JavaUnsupportedVersionError, JavaVersionParseError
 from conductr_cli.sandbox_common import CONDUCTR_DEV_IMAGE
 from conductr_cli.sandbox_run import DEFAULT_WAIT_RETRIES, DEFAULT_WAIT_RETRY_INTERVAL
 from unittest.mock import call, patch, MagicMock
@@ -141,6 +142,123 @@ class TestSandboxRunCommand(CliTestCase):
         self.assertEqual(expected_output, self.output(stderr))
 
         mock_feature.assert_not_called()
+
+    def test_jvm_validation_call_error(self):
+        conductr_version = '2.0.0'
+
+        stdout = MagicMock()
+        stderr = MagicMock()
+
+        mock_feature = MagicMock()
+        features = [mock_feature]
+        mock_collect_features = MagicMock(return_value=features)
+        mock_sandbox_run_jvm = MagicMock(side_effect=JavaCallError('test'))
+
+        args = self.default_args.copy()
+        args.update({
+            'image_version': conductr_version
+        })
+        input_args = MagicMock(**args)
+        with \
+                patch('conductr_cli.sandbox_features.collect_features', mock_collect_features), \
+                patch('conductr_cli.sandbox_run_jvm.run', mock_sandbox_run_jvm):
+            logging_setup.configure_logging(input_args, stdout, stderr)
+            self.assertFalse(sandbox_run.run(input_args))
+
+        mock_sandbox_run_jvm.assert_called_once_with(input_args, features)
+
+        expected_output = strip_margin(as_error("""|Error: Unable to obtain java version.
+                                                   |Error: test
+                                                   |Error: Please ensure Oracle JVM 1.8 and above is installed.
+                                                   |"""))
+        self.assertEqual(expected_output, self.output(stderr))
+
+    def test_jvm_validation_unsupported_vendor(self):
+        conductr_version = '2.0.0'
+
+        stdout = MagicMock()
+        stderr = MagicMock()
+
+        mock_feature = MagicMock()
+        features = [mock_feature]
+        mock_collect_features = MagicMock(return_value=features)
+        mock_sandbox_run_jvm = MagicMock(side_effect=JavaUnsupportedVendorError('test'))
+
+        args = self.default_args.copy()
+        args.update({
+            'image_version': conductr_version
+        })
+        input_args = MagicMock(**args)
+        with \
+                patch('conductr_cli.sandbox_features.collect_features', mock_collect_features), \
+                patch('conductr_cli.sandbox_run_jvm.run', mock_sandbox_run_jvm):
+            logging_setup.configure_logging(input_args, stdout, stderr)
+            self.assertFalse(sandbox_run.run(input_args))
+
+        mock_sandbox_run_jvm.assert_called_once_with(input_args, features)
+
+        expected_output = strip_margin(as_error("""|Error: Unsupported JVM vendor: test
+                                                   |Error: Please ensure Oracle JVM 1.8 and above is installed.
+                                                   |"""))
+        self.assertEqual(expected_output, self.output(stderr))
+
+    def test_jvm_validation_unsupported_version(self):
+        conductr_version = '2.0.0'
+
+        stdout = MagicMock()
+        stderr = MagicMock()
+
+        mock_feature = MagicMock()
+        features = [mock_feature]
+        mock_collect_features = MagicMock(return_value=features)
+        mock_sandbox_run_jvm = MagicMock(side_effect=JavaUnsupportedVersionError('1.4'))
+
+        args = self.default_args.copy()
+        args.update({
+            'image_version': conductr_version
+        })
+        input_args = MagicMock(**args)
+        with \
+                patch('conductr_cli.sandbox_features.collect_features', mock_collect_features), \
+                patch('conductr_cli.sandbox_run_jvm.run', mock_sandbox_run_jvm):
+            logging_setup.configure_logging(input_args, stdout, stderr)
+            self.assertFalse(sandbox_run.run(input_args))
+
+        mock_sandbox_run_jvm.assert_called_once_with(input_args, features)
+
+        expected_output = strip_margin(as_error("""|Error: Unsupported JVM version: 1.4
+                                                   |Error: Please ensure Oracle JVM 1.8 and above is installed.
+                                                   |"""))
+        self.assertEqual(expected_output, self.output(stderr))
+
+    def test_jvm_validation_java_version_parse_error(self):
+        conductr_version = '2.0.0'
+
+        stdout = MagicMock()
+        stderr = MagicMock()
+
+        mock_feature = MagicMock()
+        features = [mock_feature]
+        mock_collect_features = MagicMock(return_value=features)
+        mock_sandbox_run_jvm = MagicMock(side_effect=JavaVersionParseError('this is the output from java -version'))
+
+        args = self.default_args.copy()
+        args.update({
+            'image_version': conductr_version
+        })
+        input_args = MagicMock(**args)
+        with \
+                patch('conductr_cli.sandbox_features.collect_features', mock_collect_features), \
+                patch('conductr_cli.sandbox_run_jvm.run', mock_sandbox_run_jvm):
+            logging_setup.configure_logging(input_args, stdout, stderr)
+            self.assertFalse(sandbox_run.run(input_args))
+
+        mock_sandbox_run_jvm.assert_called_once_with(input_args, features)
+
+        expected_output = strip_margin(as_error("""|Error: Unable to obtain java version from the `java -version` command.
+                                                   |Error: Please ensure Oracle JVM 1.8 and above is installed.
+                                                   |"""))
+        self.assertEqual(expected_output, self.output(stderr))
 
 
 class TestStartProxy(CliTestCase):


### PR DESCRIPTION
Only supports Oracle JDK version 1.8 and above.