### PR TITLE
Use cinnamon-grafana-docker bundle for Sandbox version 2 and above

### DIFF
--- a/conductr_cli/sandbox_features.py
+++ b/conductr_cli/sandbox_features.py
@@ -197,10 +197,10 @@ class MonitoringFeature:
     def start(self):
         log = logging.getLogger(__name__)
         log.info(headline('Starting monitoring feature'))
-        bundle_repo = ''
-        if self.version_args and self.version_args[0] == 'snapshot':
-            bundle_repo = 'lightbend/commercial-monitoring/'
-        grafana = select_bintray_uri('cinnamon-grafana', self.version_args, bundle_repo)
+        bundle_repo = 'lightbend/commercial-monitoring/' if self.version_args and self.version_args[0] == 'snapshot' \
+            else ''
+        bundle_name = 'cinnamon-grafana' if major_version(self.image_version) == 1 else 'cinnamon-grafana-docker'
+        grafana = select_bintray_uri(bundle_name, self.version_args, bundle_repo)
         log.info('Deploying bundle %s..' % grafana['bundle'])
         conduct_main.run(['load', grafana['bundle'], '--disable-instructions'], configure_logging=False)
         conduct_main.run(['run', grafana['name'], '--disable-instructions'], configure_logging=False)

--- a/conductr_cli/test/test_sandbox_features.py
+++ b/conductr_cli/test/test_sandbox_features.py
@@ -115,7 +115,7 @@ class TestLiteLoggingFeature(TestCase):
 
 
 class TestMonitoringFeature(TestCase):
-    def test_start(self):
+    def test_start_v1(self):
         run_mock = MagicMock()
 
         with patch('conductr_cli.conduct_main.run', run_mock):
@@ -124,4 +124,15 @@ class TestMonitoringFeature(TestCase):
         self.assertEqual(run_mock.call_args_list, [
             call(['load', 'cinnamon-grafana', '--disable-instructions'], configure_logging=False),
             call(['run', 'cinnamon-grafana', '--disable-instructions'], configure_logging=False)
+        ])
+
+    def test_start_v2(self):
+        run_mock = MagicMock()
+
+        with patch('conductr_cli.conduct_main.run', run_mock):
+            MonitoringFeature([], '2.0.0').start()
+
+        self.assertEqual(run_mock.call_args_list, [
+            call(['load', 'cinnamon-grafana-docker', '--disable-instructions'], configure_logging=False),
+            call(['run', 'cinnamon-grafana-docker', '--disable-instructions'], configure_logging=False)
         ])


### PR DESCRIPTION
When monitoring feature is enabled for Sandbox version 2 and above, the `cinnamon-grafana-docker` bundle is used.

Otherwise, `cinnamon-grafana` will be used instead.