### PR TITLE
Stop sandbox JVM mode

### DIFF
--- a/conductr_cli/sandbox_common.py
+++ b/conductr_cli/sandbox_common.py
@@ -1,12 +1,8 @@
 from conductr_cli import terminal
+from conductr_cli.resolvers.bintray_resolver import BINTRAY_CONDUCTR_CORE_PACKAGE_NAME, \
+    BINTRAY_CONDUCTR_AGENT_PACKAGE_NAME
 import os
-from enum import Enum
 from subprocess import CalledProcessError
-
-
-class ConductrComponent(Enum):
-    CORE = 1
-    AGENT = 2
 
 
 CONDUCTR_NAME_PREFIX = 'cond-'
@@ -14,7 +10,20 @@ CONDUCTR_PORTS = {9004,  # ConductR internal akka remoting
                   9005,  # ConductR controlServer
                   9006}  # ConductR bundleStreamServer
 CONDUCTR_DEV_IMAGE = 'typesafe-docker-registry-for-subscribers-only.bintray.io/conductr/conductr'
-LATEST_CONDUCTR_VERSION = '1.1.11'
+
+
+def resolve_conductr_info(image_dir):
+    core_info = {
+        'type': 'core',
+        'extraction_dir': '{}/core'.format(image_dir),
+        'bintray_package_name': BINTRAY_CONDUCTR_CORE_PACKAGE_NAME
+    }
+    agent_info = {
+        'type': 'agent',
+        'extraction_dir': '{}/agent'.format(image_dir),
+        'bintray_package_name': BINTRAY_CONDUCTR_AGENT_PACKAGE_NAME
+    }
+    return core_info, agent_info
 
 
 def resolve_running_docker_containers():

--- a/conductr_cli/sandbox_main.py
+++ b/conductr_cli/sandbox_main.py
@@ -30,6 +30,7 @@ def build_parser():
                                        usage='%(prog)s IMAGE_VERSION [ARGS]',
                                        formatter_class=argparse.RawTextHelpFormatter)
     add_default_arguments(run_parser)
+    add_image_dir(run_parser)
     run_parser.add_argument('image_version',
                             nargs='?',
                             help='Version of the ConductR docker image to use.\n'
@@ -109,14 +110,12 @@ def build_parser():
                             default=DEFAULT_SANDBOX_ADDR_RANGE,
                             help='Range of address which will be used by ConductR Sandbox to bind to.\n'
                                  'The address range is specified using CIDR notation, i.e. 192.168.1.0/24')
-    run_parser.add_argument('--image-dir',
-                            default=DEFAULT_SANDBOX_IMAGE_DIR,
-                            help='Default directory where sandbox images is stored.')
     run_parser.set_defaults(func=sandbox_run.run)
 
     # Sub-parser for `stop` sub-command
     stop_parser = subparsers.add_parser('stop',
                                         help='Stop ConductR sandbox cluster')
+    add_image_dir(stop_parser)
     add_default_arguments(stop_parser)
     stop_parser.set_defaults(func=sandbox_stop.stop)
     return parser
@@ -135,6 +134,12 @@ def add_resolve_ip(sub_parser, default_value):
                             dest='resolve_ip',
                             action='store_true',
                             help=argparse.SUPPRESS)
+
+
+def add_image_dir(sub_parser):
+    sub_parser.add_argument('--image-dir',
+                            default=DEFAULT_SANDBOX_IMAGE_DIR,
+                            help='Default directory where sandbox images is stored.')
 
 
 @validation.handle_vbox_manage_not_found_error

--- a/conductr_cli/sandbox_run.py
+++ b/conductr_cli/sandbox_run.py
@@ -25,7 +25,6 @@ DEFAULT_WAIT_RETRY_INTERVAL = 2.0
 @validation.handle_jvm_validation_error
 def run(args):
     """`sandbox run` command"""
-
     is_conductr_v1 = major_version(args.image_version) == 1
     features = sandbox_features.collect_features(args.features, args.image_version)
 

--- a/conductr_cli/sandbox_stop.py
+++ b/conductr_cli/sandbox_stop.py
@@ -1,8 +1,8 @@
-from conductr_cli import sandbox_stop_docker
+from conductr_cli import sandbox_stop_docker, sandbox_stop_jvm
 
 
 def stop(args):
     """`sandbox stop` command"""
-
-    sandbox_stop_docker.stop(args)
-    return True
+    is_docker_success = sandbox_stop_docker.stop(args)
+    is_jvm_success = sandbox_stop_jvm.stop(args)
+    return is_docker_success and is_jvm_success

--- a/conductr_cli/sandbox_stop_docker.py
+++ b/conductr_cli/sandbox_stop_docker.py
@@ -1,6 +1,6 @@
 from conductr_cli import sandbox_common, terminal
 from conductr_cli.screen_utils import headline
-
+from subprocess import CalledProcessError
 import logging
 
 
@@ -9,4 +9,13 @@ def stop(args):
     running_containers = sandbox_common.resolve_running_docker_containers()
     if running_containers:
         log.info(headline('Stopping ConductR'))
-        terminal.docker_rm(running_containers)
+        try:
+            terminal.docker_rm(running_containers)
+            log.info('ConductR has been successfully stopped')
+            return True
+        except (AttributeError, CalledProcessError):
+            log.error('ConductR containers could not be stopped pid 58002 could not be stopped')
+            log.error('Please stop the Docker containers manually')
+            return False
+    else:
+        return True

--- a/conductr_cli/test/data/test_constants.py
+++ b/conductr_cli/test/data/test_constants.py
@@ -1,0 +1,2 @@
+# Constants that are only used during testing
+LATEST_CONDUCTR_VERSION = '1.1.12'

--- a/conductr_cli/test/test_sandbox_features.py
+++ b/conductr_cli/test/test_sandbox_features.py
@@ -3,7 +3,7 @@ from unittest.mock import call, patch, MagicMock
 from conductr_cli.sandbox_features import VisualizationFeature, LiteLoggingFeature,\
     LoggingFeature, MonitoringFeature, \
     collect_features, select_bintray_uri
-from conductr_cli.sandbox_common import LATEST_CONDUCTR_VERSION
+from conductr_cli.test.data.test_constants import LATEST_CONDUCTR_VERSION
 
 
 class TestFeatures(TestCase):

--- a/conductr_cli/test/test_sandbox_main.py
+++ b/conductr_cli/test/test_sandbox_main.py
@@ -1,7 +1,8 @@
 from conductr_cli.test.cli_test_case import CliTestCase, as_warn, as_error, strip_margin
 from conductr_cli import sandbox_main, logging_setup
 from conductr_cli.constants import DEFAULT_SANDBOX_ADDR_RANGE, DEFAULT_SANDBOX_IMAGE_DIR
-from conductr_cli.sandbox_common import LATEST_CONDUCTR_VERSION, CONDUCTR_DEV_IMAGE
+from conductr_cli.sandbox_common import CONDUCTR_DEV_IMAGE
+from conductr_cli.test.data.test_constants import LATEST_CONDUCTR_VERSION
 from conductr_cli.docker import DockerVmType
 from subprocess import CalledProcessError
 from unittest.mock import patch, MagicMock

--- a/conductr_cli/test/test_sandbox_run_docker.py
+++ b/conductr_cli/test/test_sandbox_run_docker.py
@@ -2,8 +2,9 @@ from conductr_cli.test.cli_test_case import CliTestCase, strip_margin, as_error
 from conductr_cli import sandbox_run_docker, logging_setup
 from conductr_cli.docker import DockerVmType
 from conductr_cli.exceptions import InstanceCountError
-from conductr_cli.sandbox_common import CONDUCTR_DEV_IMAGE, LATEST_CONDUCTR_VERSION
+from conductr_cli.sandbox_common import CONDUCTR_DEV_IMAGE
 from conductr_cli.sandbox_features import VisualizationFeature, LoggingFeature
+from conductr_cli.test.data.test_constants import LATEST_CONDUCTR_VERSION
 from unittest.mock import patch, MagicMock
 import os
 
@@ -254,6 +255,7 @@ class TestRun(CliTestCase):
         expected_stdout = strip_margin("""||------------------------------------------------|
                                           || Stopping ConductR                              |
                                           ||------------------------------------------------|
+                                          |ConductR has been successfully stopped
                                           ||------------------------------------------------|
                                           || Starting ConductR                              |
                                           ||------------------------------------------------|

--- a/conductr_cli/test/test_sandbox_stop_docker.py
+++ b/conductr_cli/test/test_sandbox_stop_docker.py
@@ -1,18 +1,19 @@
-from conductr_cli.test.cli_test_case import CliTestCase
+from conductr_cli.test.cli_test_case import CliTestCase, strip_margin, as_error
 from conductr_cli import sandbox_stop_docker, logging_setup
-from conductr_cli.screen_utils import headline
 from unittest.mock import patch, MagicMock
+from subprocess import CalledProcessError
 
 
-class TestSandboxStopCommand(CliTestCase):
+class TestStop(CliTestCase):
 
     default_args = {
         'local_connection': True,
         'verbose': False,
-        'quiet': False
+        'quiet': False,
+        'image_dir': '/Users/mj/.conductr/images'
     }
 
-    def test_success(self):
+    def test_stop_containers(self):
         stdout = MagicMock()
         containers = ['cond-0', 'cond-1']
 
@@ -21,5 +22,42 @@ class TestSandboxStopCommand(CliTestCase):
             logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
             sandbox_stop_docker.stop(MagicMock(**self.default_args))
 
-        self.assertEqual(headline('Stopping ConductR') + '\n', self.output(stdout))
+        self.assertEqual(strip_margin("""||------------------------------------------------|
+                                         || Stopping ConductR                              |
+                                         ||------------------------------------------------|
+                                         |ConductR has been successfully stopped
+                                         |"""), self.output(stdout))
         mock_docker_rm.assert_called_once_with(containers)
+
+    def test_cannot_stop_containers(self):
+        stdout = MagicMock()
+        stderr = MagicMock()
+        mock_docker_rm = MagicMock(side_effect=CalledProcessError(-1, 'test only'))
+        containers = ['cond-0', 'cond-1']
+
+        with patch('conductr_cli.sandbox_common.resolve_running_docker_containers', return_value=containers), \
+                patch('conductr_cli.terminal.docker_rm', mock_docker_rm):
+            logging_setup.configure_logging(MagicMock(**self.default_args), stdout, stderr)
+            sandbox_stop_docker.stop(MagicMock(**self.default_args))
+
+        self.assertEqual(strip_margin("""||------------------------------------------------|
+                                         || Stopping ConductR                              |
+                                         ||------------------------------------------------|
+                                         |"""), self.output(stdout))
+        self.assertEqual(
+            as_error(strip_margin("""|Error: ConductR containers could not be stopped pid 58002 could not be stopped
+                                     |Error: Please stop the Docker containers manually
+                                     |""")), self.output(stderr))
+        mock_docker_rm.assert_called_once_with(containers)
+
+    def test_stop_no_containers(self):
+        stdout = MagicMock()
+        containers = []
+
+        with patch('conductr_cli.sandbox_common.resolve_running_docker_containers', return_value=containers), \
+                patch('conductr_cli.terminal.docker_rm') as mock_docker_rm:
+            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
+            sandbox_stop_docker.stop(MagicMock(**self.default_args))
+
+        self.assertEqual('', self.output(stdout))
+        mock_docker_rm.assert_not_called()

--- a/conductr_cli/test/test_sandbox_stop_jvm.py
+++ b/conductr_cli/test/test_sandbox_stop_jvm.py
@@ -1,0 +1,147 @@
+from conductr_cli.test.cli_test_case import CliTestCase, as_error, strip_margin
+from conductr_cli import sandbox_stop_jvm, logging_setup
+from conductr_cli.screen_utils import headline
+from unittest.mock import patch, MagicMock, call
+import signal
+
+
+class TestStop(CliTestCase):
+
+    default_args = {
+        'local_connection': True,
+        'verbose': False,
+        'quiet': False,
+        'image_dir': '/Users/mj/.conductr/images'
+    }
+
+    def test_stop_processes_with_first_attempt(self):
+        ps_output_first = '58001   ??  Ss     0:36.97 /sbin/launchd\n' \
+                          '58002   ??  Ss     0:30.48 /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java -Dconductr.ip=192.168.10.1 -cp /Users/mj/.conductr/images/core/lib/com.typesafe.conductr.conductr-2.0.0-rc.2.jar:/dependent-libs com.typesafe.conductr.ConductR\n' \
+                          '58003   ??  Ss     1:17.36 /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java -Dconductr.agent.ip=192.168.10.1 -cp /Users/mj/.conductr/images/agent/lib/com.typesafe.conductr.conductr-agent-2.0.0-rc.2.jar:/dependent-libs com.typesafe.conductr.agent.ConductRAgent --core-node 192.168.10.1:9004\n' \
+                          '58004   ??  Ss     0:30.48 /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java -Dconductr.ip=192.168.10.2 -cp /Users/mj/.conductr/images/core/lib/com.typesafe.conductr.conductr-2.0.0-rc.2.jar:/dependent-libs com.typesafe.conductr.ConductR\n' \
+                          '58005   ??  Ss     1:17.36 /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java -Dconductr.agent.ip=192.168.10.2 -cp /Users/mj/.conductr/images/agent/lib/com.typesafe.conductr.conductr-agent-2.0.0-rc.2.jar:/dependent-libs com.typesafe.conductr.agent.ConductRAgent --core-node 192.168.10.2:9004\n' \
+                          '58006   ??  Ss     0:30.48 /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java -Dconductr.ip=192.168.10.3 -cp /Users/mj/.conductr/images/core/lib/com.typesafe.conductr.conductr-2.0.0-rc.2.jar:/dependent-libs com.typesafe.conductr.ConductR\n' \
+                          '58007   ??  Ss     1:17.36 /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java -Dconductr.agent.ip=192.168.10.3 -cp /Users/mj/.conductr/images/agent/lib/com.typesafe.conductr.conductr-agent-2.0.0-rc.2.jar:/dependent-libs com.typesafe.conductr.agent.ConductRAgent --core-node 192.168.10.3:9004\n' \
+                          '58008   ??  Ss     0:36.97 /usr/libexec/logd'
+        ps_output_second = '58001   ??  Ss     0:36.97 /sbin/launchd\n' \
+                           '58008   ??  Ss     0:36.97 /usr/libexec/logd'
+
+        stdout = MagicMock()
+        mock_os_kill = MagicMock()
+        mock_time_sleep = MagicMock()
+        mock_subprocess_getoutput = MagicMock(side_effect=[ps_output_first, ps_output_second])
+
+        with patch('os.kill', mock_os_kill), \
+                patch('time.sleep', mock_time_sleep), \
+                patch('subprocess.getoutput', mock_subprocess_getoutput), \
+                patch('conductr_cli.sandbox_stop_jvm', mock_subprocess_getoutput):
+            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
+            sandbox_stop_jvm.stop(MagicMock(**self.default_args))
+
+        self.assertEqual(strip_margin("""||------------------------------------------------|
+                                         || Stopping ConductR                              |
+                                         ||------------------------------------------------|
+                                         |ConductR core pid 58002 stopped
+                                         |ConductR agent pid 58003 stopped
+                                         |ConductR core pid 58004 stopped
+                                         |ConductR agent pid 58005 stopped
+                                         |ConductR core pid 58006 stopped
+                                         |ConductR agent pid 58007 stopped
+                                         |ConductR has been successfully stopped
+                                         |"""), self.output(stdout))
+        mock_os_kill.assert_has_calls([call(58002, signal.SIGTERM),
+                                       call(58003, signal.SIGTERM),
+                                       call(58004, signal.SIGTERM),
+                                       call(58005, signal.SIGTERM),
+                                       call(58006, signal.SIGTERM),
+                                       call(58007, signal.SIGTERM)])
+
+    def test_stop_processes_with_second_attempt(self):
+        ps_output_first = '58001   ??  Ss     0:36.97 /sbin/launchd\n' \
+                          '58002   ??  Ss     0:30.48 /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java -Dconductr.ip=192.168.10.1 -cp /Users/mj/.conductr/images/core/lib/com.typesafe.conductr.conductr-2.0.0-rc.2.jar:/dependent-libs com.typesafe.conductr.ConductR\n' \
+                          '58003   ??  Ss     1:17.36 /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java -Dconductr.agent.ip=192.168.10.1 -cp /Users/mj/.conductr/images/agent/lib/com.typesafe.conductr.conductr-agent-2.0.0-rc.2.jar:/dependent-libs com.typesafe.conductr.agent.ConductRAgent --core-node 192.168.10.1:9004\n' \
+                          '58004   ??  Ss     0:30.48 /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java -Dconductr.ip=192.168.10.2 -cp /Users/mj/.conductr/images/core/lib/com.typesafe.conductr.conductr-2.0.0-rc.2.jar:/dependent-libs com.typesafe.conductr.ConductR\n' \
+                          '58005   ??  Ss     1:17.36 /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java -Dconductr.agent.ip=192.168.10.2 -cp /Users/mj/.conductr/images/agent/lib/com.typesafe.conductr.conductr-agent-2.0.0-rc.2.jar:/dependent-libs com.typesafe.conductr.agent.ConductRAgent --core-node 192.168.10.2:9004\n' \
+                          '58006   ??  Ss     0:30.48 /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java -Dconductr.ip=192.168.10.3 -cp /Users/mj/.conductr/images/core/lib/com.typesafe.conductr.conductr-2.0.0-rc.2.jar:/dependent-libs com.typesafe.conductr.ConductR\n' \
+                          '58007   ??  Ss     1:17.36 /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java -Dconductr.agent.ip=192.168.10.3 -cp /Users/mj/.conductr/images/agent/lib/com.typesafe.conductr.conductr-agent-2.0.0-rc.2.jar:/dependent-libs com.typesafe.conductr.agent.ConductRAgent --core-node 192.168.10.3:9004\n' \
+                          '58008   ??  Ss     0:36.97 /usr/libexec/logd'
+        ps_output_second = '58001   ??  Ss     0:36.97 /sbin/launchd\n' \
+                           '58002   ??  Ss     0:30.48 /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java -Dconductr.ip=192.168.10.1 -cp /Users/mj/.conductr/images/core/lib/com.typesafe.conductr.conductr-2.0.0-rc.2.jar:/dependent-libs com.typesafe.conductr.ConductR\n' \
+                           '58003   ??  Ss     1:17.36 /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java -Dconductr.agent.ip=192.168.10.1 -cp /Users/mj/.conductr/images/agent/lib/com.typesafe.conductr.conductr-agent-2.0.0-rc.2.jar:/dependent-libs com.typesafe.conductr.agent.ConductRAgent --core-node 192.168.10.1:9004\n' \
+                           '58008   ??  Ss     0:36.97 /usr/libexec/logd'
+        ps_output_third = '58001   ??  Ss     0:36.97 /sbin/launchd\n' \
+                          '58008   ??  Ss     0:36.97 /usr/libexec/logd'
+
+        stdout = MagicMock()
+        mock_os_kill = MagicMock()
+        mock_time_sleep = MagicMock()
+        mock_subprocess_getoutput = MagicMock(side_effect=[ps_output_first, ps_output_second, ps_output_third])
+
+        with patch('os.kill', mock_os_kill), \
+                patch('time.sleep', mock_time_sleep), \
+                patch('subprocess.getoutput', mock_subprocess_getoutput), \
+                patch('conductr_cli.sandbox_stop_jvm', mock_subprocess_getoutput):
+            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
+            sandbox_stop_jvm.stop(MagicMock(**self.default_args))
+
+        self.assertEqual(strip_margin("""||------------------------------------------------|
+                                         || Stopping ConductR                              |
+                                         ||------------------------------------------------|
+                                         |ConductR core pid 58004 stopped
+                                         |ConductR agent pid 58005 stopped
+                                         |ConductR core pid 58006 stopped
+                                         |ConductR agent pid 58007 stopped
+                                         |ConductR core pid 58002 stopped
+                                         |ConductR agent pid 58003 stopped
+                                         |ConductR has been successfully stopped
+                                         |"""), self.output(stdout))
+        mock_os_kill.assert_has_calls([call(58002, signal.SIGTERM),
+                                       call(58003, signal.SIGTERM),
+                                       call(58004, signal.SIGTERM),
+                                       call(58005, signal.SIGTERM),
+                                       call(58006, signal.SIGTERM),
+                                       call(58007, signal.SIGTERM)])
+
+    def test_hung_processes(self):
+        ps_output = '58001   ??  Ss     0:36.97 /sbin/launchd\n' \
+                    '58002   ??  Ss     0:30.48 /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java -Dconductr.ip=192.168.10.1 -cp /Users/mj/.conductr/images/core/lib/com.typesafe.conductr.conductr-2.0.0-rc.2.jar:/dependent-libs com.typesafe.conductr.ConductR\n' \
+                    '58003   ??  Ss     1:17.36 /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java -Dconductr.agent.ip=192.168.10.1 -cp /Users/mj/.conductr/images/agent/lib/com.typesafe.conductr.conductr-agent-2.0.0-rc.2.jar:/dependent-libs com.typesafe.conductr.agent.ConductRAgent --core-node 192.168.10.1:9004\n' \
+                    '58008   ??  Ss     0:36.97 /usr/libexec/logd'
+
+        stdout = MagicMock()
+        stderr = MagicMock()
+        mock_os_kill = MagicMock()
+        mock_time_sleep = MagicMock()
+        mock_subprocess_getoutput = MagicMock(return_value=ps_output)
+
+        with patch('os.kill', mock_os_kill), \
+                patch('time.sleep', mock_time_sleep), \
+                patch('subprocess.getoutput', mock_subprocess_getoutput), \
+                patch('conductr_cli.sandbox_stop_jvm', mock_subprocess_getoutput):
+            logging_setup.configure_logging(MagicMock(**self.default_args), stdout, stderr)
+            sandbox_stop_jvm.stop(MagicMock(**self.default_args))
+
+        self.assertEqual(headline('Stopping ConductR') + '\n', self.output(stdout))
+        self.assertEqual(strip_margin(as_error("""|Error: ConductR core pid 58002 could not be stopped
+                                                  |Error: ConductR agent pid 58003 could not be stopped
+                                                  |Error: Please stop the processes manually
+                                                  |""")), self.output(stderr))
+        mock_os_kill.assert_has_calls([call(58002, signal.SIGTERM),
+                                       call(58003, signal.SIGTERM)])
+
+    def test_no_process(self):
+        ps_output = '58001   ??  Ss     0:36.97 /sbin/launchd\n' \
+                    '58008   ??  Ss     0:36.97 /usr/libexec/logd'
+
+        stdout = MagicMock()
+        mock_os_kill = MagicMock()
+        mock_subprocess_getoutput = MagicMock(return_value=ps_output)
+
+        with patch('os.kill', mock_os_kill), \
+                patch('subprocess.getoutput', mock_subprocess_getoutput), \
+                patch('conductr_cli.sandbox_stop_jvm', mock_subprocess_getoutput):
+            logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
+            sandbox_stop_jvm.stop(MagicMock(**self.default_args))
+
+        self.assertEqual('', self.output(stdout))
+        mock_os_kill.assert_not_called()


### PR DESCRIPTION
Implementation of the `sandbox stop` command for the ConductR JVM binaries.

The `sandbox stop` command is stopping both the docker containers and the JVM processes. If no containers or processes are running then no output is produced. If either the JVM or Docker stop function cannot stop the processes or containers respectively then an error is reported and the stop function returns False.

This PR also introduces additional unit tests for the `sandbox_stop_docker` module to validate the scenarios:
- No containers running
- Cannot stop containers

The PR has been tested both with ConductR 1.1.x and ConductR 2.0.0-rc.2