### PR TITLE
Use docker-based HAProxy for JVM-based sandbox

### DIFF
--- a/conductr_cli/constants.py
+++ b/conductr_cli/constants.py
@@ -17,6 +17,11 @@ DEFAULT_CUSTOM_PLUGINS_DIR = os.getenv('CONDUCTR_CUSTOM_PLUGINS_DIR',
 DEFAULT_SANDBOX_IMAGE_DIR = os.path.abspath(os.getenv('CONDUCTR_SANDBOX_IMAGE_DIR',
                                                       '{}/images'.format(DEFAULT_CLI_SETTINGS_DIR)))
 DEFAULT_SANDBOX_ADDR_RANGE = os.getenv('CONDUCTR_SANDBOX_ADDR_RANGE', '192.168.10.0/24')
+DEFAULT_SANDBOX_PROXY_DIR = os.path.abspath(os.getenv('CONDUCTR_SANDBOX_PROXY_DIR',
+                                                      '{}/proxy'.format(DEFAULT_CLI_SETTINGS_DIR)))
+# Prefixed with `sandbox-` to avoid overlap with `cond-` ConductR container names, causing the proxy to be stopped
+# when sandbox stop is called for docker containers.
+DEFAULT_SANDBOX_PROXY_CONTAINER_NAME = os.getenv('CONDUCTR_SANDBOX_PROXY_CONTAINER_NAME', 'sandbox-haproxy')
 DEFAULT_ERROR_LOG_FILE = os.path.abspath(os.getenv('CONDUCTR_CLI_ERROR_LOG',
                                                    '{}/errors.log'.format(DEFAULT_CLI_SETTINGS_DIR)))
 DEFAULT_WAIT_TIMEOUT = 60  # seconds

--- a/conductr_cli/docker.py
+++ b/conductr_cli/docker.py
@@ -2,6 +2,7 @@ import os.path
 import re
 import logging
 from conductr_cli import terminal
+from conductr_cli.exceptions import DockerValidationError
 from subprocess import CalledProcessError
 
 DEFAULT_DOCKER_RAM_SIZE = 3.8
@@ -60,25 +61,28 @@ def validate_docker_vm(vm_type):
                     log.warning('Docker has an insufficient no. of CPUs {} - please increase to a minimum of {} CPUs'
                                 .format(existing_cpu, DEFAULT_DOCKER_CPU_COUNT))
         except (AttributeError, CalledProcessError):
-            log.error('Docker is installed but not running.')
-            log.error('Please start Docker with one of the Docker flavors based on your OS:')
-            log.error('  Linux:   Docker service')
-            log.error('  MacOS:   Docker for Mac')
-            log.error('A successful Docker startup can be verified with: docker info')
-            exit(1)
+            raise DockerValidationError([
+                'Docker is installed but not running.',
+                'Please start Docker with one of the Docker flavors based on your OS:',
+                '  Linux:   Docker service',
+                '  MacOS:   Docker for Mac',
+                'A successful Docker startup can be verified with: docker info'
+            ])
 
     elif vm_type is DockerVmType.DOCKER_MACHINE:
-        log.error('Docker machine envs are set but Docker machine is not supported by the conductr-cli.')
-        log.error('We recommend to use one of following the Docker distributions depending on your OS:')
-        log.error('  Linux:                                         Docker Engine')
-        log.error('  MacOS:                                         Docker for Mac')
-        log.error('For more information checkout: https://www.docker.com/products/overview')
-        exit(1)
+        raise DockerValidationError([
+            'Docker machine envs are set but Docker machine is not supported by the conductr-cli.',
+            'We recommend to use one of following the Docker distributions depending on your OS:',
+            '  Linux:                                         Docker Engine',
+            '  MacOS:                                         Docker for Mac',
+            'For more information checkout: https://www.docker.com/products/overview'
+        ])
 
     elif vm_type is DockerVmType.NONE:
-        log.error('Docker is not installed.')
-        log.error('We recommend to use one of following the Docker distributions depending on your OS:')
-        log.error('  Linux:                                         Docker Engine')
-        log.error('  MacOS:                                         Docker for Mac')
-        log.error('For more information checkout: https://www.docker.com/products/overview')
-        exit(1)
+        raise DockerValidationError([
+            'Docker is not installed.',
+            'We recommend to use one of following the Docker distributions depending on your OS:',
+            '  Linux:                                         Docker Engine',
+            '  MacOS:                                         Docker for Mac',
+            'For more information checkout: https://www.docker.com/products/overview'
+        ])

--- a/conductr_cli/exceptions.py
+++ b/conductr_cli/exceptions.py
@@ -1,3 +1,5 @@
+import os
+
 # FileNotFoundError is only available on > python 3.3
 NOT_FOUND_ERROR = getattr(__builtins__, 'FileNotFoundError', OSError)
 
@@ -139,3 +141,11 @@ class JavaUnsupportedVersionError(Exception):
 
     def __str(self):
         return repr(self.jvm_version)
+
+
+class DockerValidationError(Exception):
+    def __init__(self, messages):
+        self.messages = messages
+
+    def __str(self):
+        return repr(os.linesep.join(self.messages))

--- a/conductr_cli/sandbox_proxy.py
+++ b/conductr_cli/sandbox_proxy.py
@@ -101,7 +101,6 @@ def start_conductr_haproxy():
     log = logging.getLogger(__name__)
     bundle_name = 'conductr-haproxy'
     configuration_name = 'conductr-haproxy-dev-mode'
-    log.info(headline('Starting ConductR HAProxy'))
     log.info('Deploying bundle {} with configuration {}'.format(bundle_name, configuration_name))
     conduct_main.run(['load', bundle_name, configuration_name, '--disable-instructions'], configure_logging=False)
     conduct_main.run(['run', bundle_name, '--disable-instructions'], configure_logging=False)

--- a/conductr_cli/sandbox_proxy.py
+++ b/conductr_cli/sandbox_proxy.py
@@ -1,0 +1,107 @@
+from conductr_cli import conduct_main, terminal
+from conductr_cli.constants import DEFAULT_SANDBOX_PROXY_DIR, DEFAULT_SANDBOX_PROXY_CONTAINER_NAME
+from conductr_cli.screen_utils import headline
+import logging
+import pathlib
+import os
+
+
+HAPROXY_VERSION = '1.5'
+HAPROXY_DOCKER_IMAGE = 'haproxy:{}'.format(HAPROXY_VERSION)
+
+HAPROXY_CFG_DIR = '{}/haproxy'.format(DEFAULT_SANDBOX_PROXY_DIR)
+HAPROXY_CFG_PATH = '{}/haproxy.cfg'.format(HAPROXY_CFG_DIR)
+DEFAULT_PROXY_PORTS = [80, 443, 9000]  # These are the ports which will be opened by default to the proxy.
+
+# This is the default config which will be supplied so HAProxy instance within Docker can be started.
+DEFAULT_HAPROXY_CFG_ENTRIES = 'defaults\n' \
+                              '  log global\n' \
+                              '  mode    http\n' \
+                              '  option  httplog\n' \
+                              '  option  dontlognull\n' \
+                              '  timeout connect 5000\n' \
+                              '  timeout client  50000\n' \
+                              '  timeout server  50000\n' \
+                              '\n' \
+                              'frontend conductr-haproxy-test\n' \
+                              '  bind :65535\n' \
+                              '  mode http\n' \
+                              '  monitor-uri /test\n' \
+                              ''
+
+
+def start_proxy(proxy_bind_addr, proxy_ports):
+    validate_docker_present()
+    setup_haproxy_dirs()
+    stop_proxy()
+    start_docker_instance(proxy_bind_addr, proxy_ports)
+    start_conductr_haproxy()
+
+
+def stop_proxy():
+    # TODO: validate docker present within try block, and catch the error and return False
+    log = logging.getLogger(__name__)
+
+    running_container = get_running_haproxy()
+
+    if running_container:
+        log.info(headline('Stopping HAProxy'))
+        validate_docker_present()
+        terminal.docker_rm([DEFAULT_SANDBOX_PROXY_CONTAINER_NAME])
+        log.info('HAProxy has been successfully stopped')
+
+    return True
+
+
+def validate_docker_present():
+    # TODO: implement docker installation validation
+    pass
+
+
+def setup_haproxy_dirs():
+    os.makedirs(HAPROXY_CFG_DIR, exist_ok=True)
+
+    # Correct haproxy.cfg file must exists in order for Docker image to be working
+    haproxy_cfg = pathlib.Path(HAPROXY_CFG_PATH)
+    if not haproxy_cfg.exists():
+        haproxy_cfg.write_text(DEFAULT_HAPROXY_CFG_ENTRIES)
+
+
+def get_running_haproxy():
+    return terminal.docker_ps(ps_filter='name={}'.format(DEFAULT_SANDBOX_PROXY_CONTAINER_NAME))
+
+
+def start_docker_instance(proxy_bind_addr, proxy_ports):
+    log = logging.getLogger(__name__)
+    log.info(headline('Starting HAProxy'))
+
+    docker_image = terminal.docker_images(HAPROXY_DOCKER_IMAGE)
+    if not docker_image:
+        log.info('Pulling docker image {}'.format(HAPROXY_DOCKER_IMAGE))
+        terminal.docker_pull(HAPROXY_DOCKER_IMAGE)
+
+    all_proxy_ports = []
+    all_proxy_ports.extend(DEFAULT_PROXY_PORTS)
+    all_proxy_ports.extend(proxy_ports)
+    all_proxy_ports = sorted(all_proxy_ports)
+
+    port_args = []
+    for port in all_proxy_ports:
+        port_args.append('-p')
+        port_args.append('{}:{}:{}'.format(proxy_bind_addr.exploded, port, port))
+
+    docker_args = ['-d', '--name', DEFAULT_SANDBOX_PROXY_CONTAINER_NAME] + port_args + \
+                  ['-v', '{}:/usr/local/etc/haproxy:ro'.format(HAPROXY_CFG_DIR)]
+
+    log.info('Exposing the following ports {}'.format(all_proxy_ports))
+    terminal.docker_run(docker_args, HAPROXY_DOCKER_IMAGE, positional_args=[])
+
+
+def start_conductr_haproxy():
+    log = logging.getLogger(__name__)
+    bundle_name = 'conductr-haproxy'
+    configuration_name = 'conductr-haproxy-dev-mode'
+    log.info(headline('Starting ConductR HAProxy'))
+    log.info('Deploying bundle {} with configuration {}'.format(bundle_name, configuration_name))
+    conduct_main.run(['load', bundle_name, configuration_name, '--disable-instructions'], configure_logging=False)
+    conduct_main.run(['run', bundle_name, '--disable-instructions'], configure_logging=False)

--- a/conductr_cli/sandbox_proxy.py
+++ b/conductr_cli/sandbox_proxy.py
@@ -1,4 +1,4 @@
-from conductr_cli import conduct_main, terminal
+from conductr_cli import conduct_main, docker, terminal
 from conductr_cli.constants import DEFAULT_SANDBOX_PROXY_DIR, DEFAULT_SANDBOX_PROXY_CONTAINER_NAME
 from conductr_cli.screen_utils import headline
 from subprocess import CalledProcessError
@@ -58,8 +58,8 @@ def stop_proxy():
 
 
 def validate_docker_present():
-    # TODO: implement docker installation validation
-    pass
+    vm_type = docker.vm_type()
+    docker.validate_docker_vm(vm_type)
 
 
 def setup_haproxy_dirs():

--- a/conductr_cli/sandbox_run.py
+++ b/conductr_cli/sandbox_run.py
@@ -22,6 +22,7 @@ DEFAULT_WAIT_RETRY_INTERVAL = 2.0
 @validation.handle_bintray_credentials_error
 @validation.handle_bintray_unreachable_error
 @validation.handle_jvm_validation_error
+@validation.handle_docker_validation_error
 def run(args):
     """`sandbox run` command"""
     is_conductr_v1 = major_version(args.image_version) == 1

--- a/conductr_cli/sandbox_run.py
+++ b/conductr_cli/sandbox_run.py
@@ -37,7 +37,7 @@ def run(args):
             for feature in features:
                 feature_ports.extend(feature.ports)
 
-            proxy_ports = sorted([] + args.ports + feature_ports)
+            proxy_ports = sorted(args.ports + feature_ports)
             sandbox_proxy.start_proxy(proxy_bind_addr=run_result.core_addrs[0],
                                       proxy_ports=proxy_ports)
 

--- a/conductr_cli/sandbox_run.py
+++ b/conductr_cli/sandbox_run.py
@@ -1,8 +1,7 @@
-from conductr_cli import conduct_main, conduct_request, conduct_url, validation, sandbox_features, \
+from conductr_cli import conduct_request, conduct_url, validation, sandbox_features, sandbox_proxy, \
     sandbox_run_docker, sandbox_run_jvm
 from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
 from conductr_cli.sandbox_common import major_version
-from conductr_cli.screen_utils import headline
 from requests.exceptions import ConnectionError
 
 import logging
@@ -27,23 +26,25 @@ def run(args):
     """`sandbox run` command"""
     is_conductr_v1 = major_version(args.image_version) == 1
     features = sandbox_features.collect_features(args.features, args.image_version)
+    sandbox = sandbox_run_docker if is_conductr_v1 else sandbox_run_jvm
 
-    if is_conductr_v1:
-        run_result = sandbox_run_docker.run(args, features)
-    else:
-        run_result = sandbox_run_jvm.run(args, features)
+    run_result = sandbox.run(args, features)
 
     is_started, wait_timeout = wait_for_start(args, run_result)
     if is_started:
         if not is_conductr_v1:
-            start_proxy(run_result.nr_of_proxy_instances)
+            feature_ports = []
+            for feature in features:
+                feature_ports.extend(feature.ports)
+
+            proxy_ports = sorted([] + args.ports + feature_ports)
+            sandbox_proxy.start_proxy(proxy_bind_addr=run_result.core_addrs[0],
+                                      proxy_ports=proxy_ports)
+
         for feature in features:
             feature.start()
 
-    if is_conductr_v1:
-        sandbox_run_docker.log_run_attempt(args, run_result, is_started, wait_timeout)
-    else:
-        sandbox_run_jvm.log_run_attempt(args, run_result, is_started, wait_timeout)
+    sandbox.log_run_attempt(args, run_result, is_started, wait_timeout)
 
     return True
 
@@ -77,13 +78,3 @@ def wait_for_conductr(args, run_result, current_retry, max_retries, interval):
     # Reprint previous message with flush to go to next line
     log.progress(last_message, flush=True)
     return True if current_retry < max_retries else False
-
-
-def start_proxy(nr_of_instances):
-    log = logging.getLogger(__name__)
-    bundle_name = 'conductr-haproxy'
-    configuration_name = 'conductr-haproxy-dev-mode'
-    log.info(headline('Starting HAProxy'))
-    log.info('Deploying bundle {} with configuration {}'.format(bundle_name, configuration_name))
-    conduct_main.run(['load', bundle_name, configuration_name, '--disable-instructions'], configure_logging=False)
-    conduct_main.run(['run', bundle_name, '--scale', str(nr_of_instances), '--disable-instructions'], configure_logging=False)

--- a/conductr_cli/sandbox_run_docker.py
+++ b/conductr_cli/sandbox_run_docker.py
@@ -9,10 +9,9 @@ import os
 
 
 class SandboxRunResult:
-    def __init__(self, container_names, conductr_host, nr_of_proxy_instances):
+    def __init__(self, container_names, conductr_host):
         self.container_names = container_names
         self.host = conductr_host
-        self.nr_of_proxy_instances = nr_of_proxy_instances
 
     scheme = DEFAULT_SCHEME
     port = DEFAULT_PORT
@@ -27,7 +26,7 @@ def run(args, features):
     nr_of_containers = instance_count(args.image_version, args.nr_of_containers)
     pull_image(args)
     container_names = scale_cluster(args, nr_of_containers, features)
-    return SandboxRunResult(container_names, host.DOCKER_IP, nr_of_proxy_instances=nr_of_containers)
+    return SandboxRunResult(container_names, host.DOCKER_IP)
 
 
 def log_run_attempt(args, run_result, is_started, wait_timeout):

--- a/conductr_cli/sandbox_stop.py
+++ b/conductr_cli/sandbox_stop.py
@@ -1,16 +1,9 @@
 from conductr_cli import sandbox_proxy, sandbox_stop_docker, sandbox_stop_jvm
-from subprocess import CalledProcessError
 
 
 def stop(args):
     """`sandbox stop` command"""
-    try:
-        is_proxy_success = sandbox_proxy.stop_proxy()
-    except (AttributeError, CalledProcessError):
-        # Fail silently as these errors will be raised if Docker is not installed or Docker environment is not
-        # configured properly.
-        is_proxy_success = False
-
+    is_proxy_success = sandbox_proxy.stop_proxy()
     is_docker_success = sandbox_stop_docker.stop(args)
     is_jvm_success = sandbox_stop_jvm.stop(args)
     return is_proxy_success and is_docker_success and is_jvm_success

--- a/conductr_cli/sandbox_stop.py
+++ b/conductr_cli/sandbox_stop.py
@@ -1,8 +1,16 @@
-from conductr_cli import sandbox_stop_docker, sandbox_stop_jvm
+from conductr_cli import sandbox_proxy, sandbox_stop_docker, sandbox_stop_jvm
+from subprocess import CalledProcessError
 
 
 def stop(args):
     """`sandbox stop` command"""
+    try:
+        is_proxy_success = sandbox_proxy.stop_proxy()
+    except (AttributeError, CalledProcessError):
+        # Fail silently as these errors will be raised if Docker is not installed or Docker environment is not
+        # configured properly.
+        is_proxy_success = False
+
     is_docker_success = sandbox_stop_docker.stop(args)
     is_jvm_success = sandbox_stop_jvm.stop(args)
-    return is_docker_success and is_jvm_success
+    return is_proxy_success and is_docker_success and is_jvm_success

--- a/conductr_cli/test/test_sandbox_proxy.py
+++ b/conductr_cli/test/test_sandbox_proxy.py
@@ -1,0 +1,219 @@
+from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
+from conductr_cli import logging_setup, sandbox_proxy
+from unittest.mock import call, patch, MagicMock
+import ipaddress
+
+
+class TestStartProxy(CliTestCase):
+
+    def test_start(self):
+        stdout = MagicMock()
+
+        mock_validate_docker_present = MagicMock()
+        mock_setup_haproxy_dirs = MagicMock()
+        mock_stop_proxy = MagicMock()
+        mock_start_docker_instance = MagicMock()
+        mock_start_conductr_haproxy = MagicMock()
+
+        args = MagicMock(**{})
+
+        with patch('conductr_cli.sandbox_proxy.validate_docker_present', mock_validate_docker_present), \
+                patch('conductr_cli.sandbox_proxy.setup_haproxy_dirs', mock_setup_haproxy_dirs), \
+                patch('conductr_cli.sandbox_proxy.stop_proxy', mock_stop_proxy), \
+                patch('conductr_cli.sandbox_proxy.start_docker_instance', mock_start_docker_instance), \
+                patch('conductr_cli.sandbox_proxy.start_conductr_haproxy', mock_start_conductr_haproxy):
+            logging_setup.configure_logging(args, stdout)
+            sandbox_proxy.start_proxy(ipaddress.ip_address('192.168.1.1'), [3003])
+
+        mock_validate_docker_present.assert_called_once_with()
+        mock_setup_haproxy_dirs.assert_called_once_with()
+        mock_stop_proxy.assert_called_once_with()
+        mock_start_docker_instance.assert_called_once_with(ipaddress.ip_address('192.168.1.1'), [3003])
+        mock_start_conductr_haproxy.assert_called_once_with()
+
+        self.assertEqual('', self.output(stdout))
+
+
+class TestStopProxy(CliTestCase):
+    def test_stop(self):
+        stdout = MagicMock()
+
+        mock_get_running_haproxy = MagicMock(return_value='sandbox-haproxy')
+        mock_validate_docker_present = MagicMock()
+        mock_docker_rm = MagicMock()
+
+        args = MagicMock(**{})
+
+        with patch('conductr_cli.sandbox_proxy.validate_docker_present', mock_validate_docker_present), \
+                patch('conductr_cli.sandbox_proxy.get_running_haproxy', mock_get_running_haproxy), \
+                patch('conductr_cli.terminal.docker_rm', mock_docker_rm):
+            logging_setup.configure_logging(args, stdout)
+            sandbox_proxy.stop_proxy()
+
+        mock_validate_docker_present.assert_called_once_with()
+        mock_docker_rm.assert_called_once_with(['sandbox-haproxy'])
+
+        expected_output = strip_margin("""||------------------------------------------------|
+                                          || Stopping HAProxy                               |
+                                          ||------------------------------------------------|
+                                          |HAProxy has been successfully stopped
+                                          |""")
+        self.assertEqual(expected_output, self.output(stdout))
+
+    def test_already_stopped(self):
+        stdout = MagicMock()
+
+        mock_get_running_haproxy = MagicMock(return_value=None)
+        mock_validate_docker_present = MagicMock()
+        mock_docker_rm = MagicMock()
+
+        args = MagicMock(**{})
+
+        with patch('conductr_cli.sandbox_proxy.validate_docker_present', mock_validate_docker_present), \
+                patch('conductr_cli.sandbox_proxy.get_running_haproxy', mock_get_running_haproxy), \
+                patch('conductr_cli.terminal.docker_rm', mock_docker_rm):
+            logging_setup.configure_logging(args, stdout)
+            sandbox_proxy.stop_proxy()
+
+        mock_validate_docker_present.assert_not_called()
+        mock_docker_rm.assert_not_called()
+
+        self.assertEqual('', self.output(stdout))
+
+
+class TestSetupHAProxyDirs(CliTestCase):
+    def test_create_dir(self):
+        mock_makedirs = MagicMock()
+
+        mock_path = MagicMock()
+        mock_path.exists = MagicMock(return_value=False)
+        mock_path.write_text = MagicMock()
+
+        mock_path_creator = MagicMock(return_value=mock_path)
+
+        with patch('os.makedirs', mock_makedirs), \
+                patch('pathlib.Path', mock_path_creator):
+            sandbox_proxy.setup_haproxy_dirs()
+
+        mock_makedirs.assert_called_once_with(sandbox_proxy.HAPROXY_CFG_DIR, exist_ok=True)
+        mock_path.exists.assert_called_once_with()
+        mock_path.write_text.assert_called_once_with(sandbox_proxy.DEFAULT_HAPROXY_CFG_ENTRIES)
+
+    def test_not_create_dir(self):
+        mock_makedirs = MagicMock()
+
+        mock_path = MagicMock()
+        mock_path.exists = MagicMock(return_value=True)
+        mock_path.write_text = MagicMock()
+
+        mock_path_creator = MagicMock(return_value=mock_path)
+
+        with patch('os.makedirs', mock_makedirs), \
+                patch('pathlib.Path', mock_path_creator):
+            sandbox_proxy.setup_haproxy_dirs()
+
+        mock_makedirs.assert_called_once_with(sandbox_proxy.HAPROXY_CFG_DIR, exist_ok=True)
+        mock_path.exists.assert_called_once_with()
+        mock_path.write_text.assert_not_called()
+
+
+class TestGetRunningHAProxy(CliTestCase):
+    def test_create_dir(self):
+        mock_docker_ps_result = 'test'
+        mock_docker_ps = MagicMock(return_value=mock_docker_ps_result)
+
+        with patch('conductr_cli.terminal.docker_ps', mock_docker_ps):
+            self.assertEqual(mock_docker_ps_result, sandbox_proxy.get_running_haproxy())
+
+        mock_docker_ps.assert_called_once_with(ps_filter='name=sandbox-haproxy')
+
+
+class TestStartDockerInstance(CliTestCase):
+    def test_start(self):
+        stdout = MagicMock()
+
+        mock_docker_images = MagicMock(return_value='sandbox-haproxy-container-id')
+        mock_docker_pull = MagicMock()
+        mock_docker_run = MagicMock()
+
+        args = MagicMock(**{})
+
+        with patch('conductr_cli.terminal.docker_images', mock_docker_images), \
+                patch('conductr_cli.terminal.docker_pull', mock_docker_pull), \
+                patch('conductr_cli.terminal.docker_run', mock_docker_run):
+            logging_setup.configure_logging(args, stdout)
+            sandbox_proxy.start_docker_instance(ipaddress.ip_address('192.168.1.1'), [3003])
+
+        mock_docker_images.assert_called_once_with('haproxy:1.5')
+        mock_docker_pull.assert_not_called()
+        mock_docker_run.assert_called_once_with(
+            ['-d',
+             '--name', 'sandbox-haproxy',
+             '-p', '192.168.1.1:80:80',
+             '-p', '192.168.1.1:443:443',
+             '-p', '192.168.1.1:3003:3003',
+             '-p', '192.168.1.1:9000:9000',
+             '-v', '{}:/usr/local/etc/haproxy:ro'.format(sandbox_proxy.HAPROXY_CFG_DIR)],
+            'haproxy:1.5',
+            positional_args=[]
+        )
+
+        expected_output = strip_margin("""||------------------------------------------------|
+                                          || Starting HAProxy                               |
+                                          ||------------------------------------------------|
+                                          |Exposing the following ports [80, 443, 3003, 9000]
+                                          |""")
+        self.assertEqual(expected_output, self.output(stdout))
+
+    def test_start_with_pull(self):
+        stdout = MagicMock()
+
+        mock_docker_images = MagicMock(return_value=None)
+        mock_docker_pull = MagicMock()
+        mock_docker_run = MagicMock()
+
+        args = MagicMock(**{})
+
+        with patch('conductr_cli.terminal.docker_images', mock_docker_images), \
+                patch('conductr_cli.terminal.docker_pull', mock_docker_pull), \
+                patch('conductr_cli.terminal.docker_run', mock_docker_run):
+            logging_setup.configure_logging(args, stdout)
+            sandbox_proxy.start_docker_instance(ipaddress.ip_address('192.168.1.1'), [3003])
+
+        mock_docker_images.assert_called_once_with('haproxy:1.5')
+        mock_docker_pull.assert_called_once_with('haproxy:1.5')
+        mock_docker_run.assert_called_once_with(
+            ['-d',
+             '--name', 'sandbox-haproxy',
+             '-p', '192.168.1.1:80:80',
+             '-p', '192.168.1.1:443:443',
+             '-p', '192.168.1.1:3003:3003',
+             '-p', '192.168.1.1:9000:9000',
+             '-v', '{}:/usr/local/etc/haproxy:ro'.format(sandbox_proxy.HAPROXY_CFG_DIR)],
+            'haproxy:1.5',
+            positional_args=[]
+        )
+
+        expected_output = strip_margin("""||------------------------------------------------|
+                                          || Starting HAProxy                               |
+                                          ||------------------------------------------------|
+                                          |Pulling docker image haproxy:1.5
+                                          |Exposing the following ports [80, 443, 3003, 9000]
+                                          |""")
+        self.assertEqual(expected_output, self.output(stdout))
+
+
+class TestStartConductrHAProxy(CliTestCase):
+    def test_success(self):
+        stdout = MagicMock()
+        mock_run = MagicMock()
+        args = MagicMock(**{})
+
+        with patch('conductr_cli.conduct_main.run', mock_run):
+            logging_setup.configure_logging(args, stdout)
+            sandbox_proxy.start_conductr_haproxy()
+
+        self.assertEqual([
+            call(['load', 'conductr-haproxy', 'conductr-haproxy-dev-mode', '--disable-instructions'], configure_logging=False),
+            call(['run', 'conductr-haproxy', '--disable-instructions'], configure_logging=False)
+        ], mock_run.call_args_list)

--- a/conductr_cli/test/test_sandbox_proxy.py
+++ b/conductr_cli/test/test_sandbox_proxy.py
@@ -1,5 +1,5 @@
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
-from conductr_cli import logging_setup, sandbox_proxy
+from conductr_cli import docker, logging_setup, sandbox_proxy
 from unittest.mock import call, patch, MagicMock
 from subprocess import CalledProcessError
 import ipaddress
@@ -124,6 +124,19 @@ class TestStopProxy(CliTestCase):
         mock_docker_rm.assert_not_called()
 
         self.assertEqual('', self.output(stdout))
+
+
+class TestValidateDockerVm(CliTestCase):
+    def test_validate(self):
+        mock_vm_type = MagicMock(return_value=docker.DockerVmType.DOCKER_ENGINE)
+        mock_validate_docker_vm = MagicMock()
+
+        with patch('conductr_cli.docker.vm_type', mock_vm_type), \
+                patch('conductr_cli.docker.validate_docker_vm', mock_validate_docker_vm):
+            sandbox_proxy.validate_docker_present()
+
+        mock_vm_type.assert_called_once_with()
+        mock_validate_docker_vm.assert_called_once_with(docker.DockerVmType.DOCKER_ENGINE)
 
 
 class TestSetupHAProxyDirs(CliTestCase):

--- a/conductr_cli/test/test_sandbox_stop.py
+++ b/conductr_cli/test/test_sandbox_stop.py
@@ -1,7 +1,6 @@
 from conductr_cli.test.cli_test_case import CliTestCase
 from conductr_cli import sandbox_stop
 from unittest.mock import patch, MagicMock
-from subprocess import CalledProcessError
 
 
 class TestSandboxStopCommand(CliTestCase):
@@ -27,9 +26,9 @@ class TestSandboxStopCommand(CliTestCase):
         mock_sandbox_stop_docker.assert_called_once_with(input_args)
         mock_sandbox_stop_jvm.assert_called_once_with(input_args)
 
-    def test_stop_proxy_called_process_error(self):
-        mock_sandbox_stop_proxy = MagicMock(side_effect=CalledProcessError(1, 'test'))
-        mock_sandbox_stop_docker = MagicMock(return_value=True)
+    def test_stop_proxy_error(self):
+        mock_sandbox_stop_proxy = MagicMock(return_value=False)
+        mock_sandbox_stop_docker = MagicMock(return_value=False)
         mock_sandbox_stop_jvm = MagicMock(return_value=True)
 
         input_args = MagicMock(**self.default_args)
@@ -42,10 +41,25 @@ class TestSandboxStopCommand(CliTestCase):
         mock_sandbox_stop_docker.assert_called_once_with(input_args)
         mock_sandbox_stop_jvm.assert_called_once_with(input_args)
 
-    def test_stop_proxy_attribute_error(self):
-        mock_sandbox_stop_proxy = MagicMock(side_effect=AttributeError('test'))
-        mock_sandbox_stop_docker = MagicMock(return_value=True)
+    def test_stop_docker_error(self):
+        mock_sandbox_stop_proxy = MagicMock(return_value=True)
+        mock_sandbox_stop_docker = MagicMock(return_value=False)
         mock_sandbox_stop_jvm = MagicMock(return_value=True)
+
+        input_args = MagicMock(**self.default_args)
+        with patch('conductr_cli.sandbox_stop_docker.stop', mock_sandbox_stop_docker), \
+                patch('conductr_cli.sandbox_stop_jvm.stop', mock_sandbox_stop_jvm), \
+                patch('conductr_cli.sandbox_proxy.stop_proxy', mock_sandbox_stop_proxy):
+            self.assertFalse(sandbox_stop.stop(input_args))
+
+        mock_sandbox_stop_proxy.assert_called_once_with()
+        mock_sandbox_stop_docker.assert_called_once_with(input_args)
+        mock_sandbox_stop_jvm.assert_called_once_with(input_args)
+
+    def test_stop_jvm_error(self):
+        mock_sandbox_stop_proxy = MagicMock(return_value=True)
+        mock_sandbox_stop_docker = MagicMock(return_value=True)
+        mock_sandbox_stop_jvm = MagicMock(return_value=False)
 
         input_args = MagicMock(**self.default_args)
         with patch('conductr_cli.sandbox_stop_docker.stop', mock_sandbox_stop_docker), \

--- a/conductr_cli/test/test_sandbox_stop.py
+++ b/conductr_cli/test/test_sandbox_stop.py
@@ -1,6 +1,7 @@
 from conductr_cli.test.cli_test_case import CliTestCase
 from conductr_cli import sandbox_stop
 from unittest.mock import patch, MagicMock
+from subprocess import CalledProcessError
 
 
 class TestSandboxStopCommand(CliTestCase):
@@ -12,10 +13,46 @@ class TestSandboxStopCommand(CliTestCase):
     }
 
     def test_success(self):
-        mock_sandbox_stop_docker = MagicMock()
+        mock_sandbox_stop_proxy = MagicMock(return_value=True)
+        mock_sandbox_stop_docker = MagicMock(return_value=True)
+        mock_sandbox_stop_jvm = MagicMock(return_value=True)
 
         input_args = MagicMock(**self.default_args)
-        with patch('conductr_cli.sandbox_stop_docker.stop', mock_sandbox_stop_docker):
+        with patch('conductr_cli.sandbox_stop_docker.stop', mock_sandbox_stop_docker), \
+                patch('conductr_cli.sandbox_stop_jvm.stop', mock_sandbox_stop_jvm), \
+                patch('conductr_cli.sandbox_proxy.stop_proxy', mock_sandbox_stop_proxy):
             self.assertTrue(sandbox_stop.stop(input_args))
 
+        mock_sandbox_stop_proxy.assert_called_once_with()
         mock_sandbox_stop_docker.assert_called_once_with(input_args)
+        mock_sandbox_stop_jvm.assert_called_once_with(input_args)
+
+    def test_stop_proxy_called_process_error(self):
+        mock_sandbox_stop_proxy = MagicMock(side_effect=CalledProcessError(1, 'test'))
+        mock_sandbox_stop_docker = MagicMock(return_value=True)
+        mock_sandbox_stop_jvm = MagicMock(return_value=True)
+
+        input_args = MagicMock(**self.default_args)
+        with patch('conductr_cli.sandbox_stop_docker.stop', mock_sandbox_stop_docker), \
+                patch('conductr_cli.sandbox_stop_jvm.stop', mock_sandbox_stop_jvm), \
+                patch('conductr_cli.sandbox_proxy.stop_proxy', mock_sandbox_stop_proxy):
+            self.assertFalse(sandbox_stop.stop(input_args))
+
+        mock_sandbox_stop_proxy.assert_called_once_with()
+        mock_sandbox_stop_docker.assert_called_once_with(input_args)
+        mock_sandbox_stop_jvm.assert_called_once_with(input_args)
+
+    def test_stop_proxy_attribute_error(self):
+        mock_sandbox_stop_proxy = MagicMock(side_effect=AttributeError('test'))
+        mock_sandbox_stop_docker = MagicMock(return_value=True)
+        mock_sandbox_stop_jvm = MagicMock(return_value=True)
+
+        input_args = MagicMock(**self.default_args)
+        with patch('conductr_cli.sandbox_stop_docker.stop', mock_sandbox_stop_docker), \
+                patch('conductr_cli.sandbox_stop_jvm.stop', mock_sandbox_stop_jvm), \
+                patch('conductr_cli.sandbox_proxy.stop_proxy', mock_sandbox_stop_proxy):
+            self.assertFalse(sandbox_stop.stop(input_args))
+
+        mock_sandbox_stop_proxy.assert_called_once_with()
+        mock_sandbox_stop_docker.assert_called_once_with(input_args)
+        mock_sandbox_stop_jvm.assert_called_once_with(input_args)

--- a/conductr_cli/validation.py
+++ b/conductr_cli/validation.py
@@ -13,7 +13,7 @@ from conductr_cli.exceptions import BindAddressNotFoundError, \
     InstanceCountError, MalformedBundleError, \
     BintrayCredentialsNotFoundError, MalformedBintrayCredentialsError, BintrayUnreachableError, BundleResolutionError, \
     WaitTimeoutError, InsecureFilePermissions, SandboxImageNotFoundError, JavaCallError, \
-    JavaUnsupportedVendorError, JavaUnsupportedVersionError, JavaVersionParseError
+    JavaUnsupportedVendorError, JavaUnsupportedVersionError, JavaVersionParseError, DockerValidationError
 
 
 def connection_error(log, err, args):
@@ -335,6 +335,24 @@ def handle_jvm_validation_error(func):
             log = get_logger_for_func(func)
             log.error('Unable to obtain java version from the `java -version` command.')
             log.error('Please ensure Oracle JVM 1.8 and above is installed.')
+            return False
+
+        # Do not change the wrapped function name,
+        # so argparse configuration can be tested.
+    handler.__name__ = func.__name__
+
+    return handler
+
+
+def handle_docker_validation_error(func):
+
+    def handler(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except DockerValidationError as e:
+            log = get_logger_for_func(func)
+            for message in e.messages:
+                log.error(message)
             return False
 
         # Do not change the wrapped function name,


### PR DESCRIPTION
JVM-based sandbox will provide proxying through docker-based HAProxy.

As such, starting the JVM-based sandbox will now start docker-based HAProxy before loading `conductr-haproxy` using `conductr-haproxy-dev-mode` configuration.

Similarly, stopping the sandbox will now stop the docker-based HAProxy if it's running.

