### PR TITLE
Fix Docker error handling

### DIFF
--- a/conductr_cli/sandbox_common.py
+++ b/conductr_cli/sandbox_common.py
@@ -1,6 +1,7 @@
 from conductr_cli import terminal
 import os
 from enum import Enum
+from subprocess import CalledProcessError
 
 
 class ConductrComponent(Enum):
@@ -19,9 +20,12 @@ LATEST_CONDUCTR_VERSION = '1.1.11'
 def resolve_running_docker_containers():
     """Resolve running docker containers.
        Return the running container names (e.g. cond-0) in ascending order"""
-    container_ids = terminal.docker_ps(ps_filter='name={}'.format(CONDUCTR_NAME_PREFIX))
-    container_names = [terminal.docker_inspect(container_id, '{{.Name}}')[1:] for container_id in container_ids]
-    return sorted(container_names)
+    try:
+        container_ids = terminal.docker_ps(ps_filter='name={}'.format(CONDUCTR_NAME_PREFIX))
+        container_names = [terminal.docker_inspect(container_id, '{{.Name}}')[1:] for container_id in container_ids]
+        return sorted(container_names)
+    except (AttributeError, CalledProcessError):
+        return []
 
 
 def bundle_http_port():

--- a/conductr_cli/sandbox_main.py
+++ b/conductr_cli/sandbox_main.py
@@ -269,8 +269,7 @@ def run():
                              ', '.join("'%s'" % f for f in feature_names)))
         # Docker VM validation
         args.vm_type = docker.vm_type()
-        if vars(args).get('func').__name__ == 'run' \
-                and major_version(args.image_version) == '1':
+        if vars(args).get('func').__name__ == 'run' and major_version(args.image_version) == 1:
             validate_docker_vm(args.vm_type)
 
         result = args.func(args)


### PR DESCRIPTION
The PR fixes the following issues:
- For `sandbox run 1.x.x` the Docker VM validation was not called. As a result exceptions were thrown to the terminal when Docker was not running
- For `sandbox stop` an exception was thrown if Docker was not running. Now sandbox stop will ignore this. If Docker is not running it means that no ConductR Docker container need to be stopped