### PR TITLE
Consistent sandbox run output

### DIFF
--- a/conductr_cli/sandbox_run_jvm.py
+++ b/conductr_cli/sandbox_run_jvm.py
@@ -55,11 +55,15 @@ def run(args, features):
     nr_of_core_instances, nr_of_agent_instances = instance_count(args.image_version, args.nr_of_containers)
 
     validate_jvm_support()
+
+    sandbox_stop.stop(args)
+
+    log = logging.getLogger(__name__)
+    log.info(headline('Starting ConductR'))
+
     bind_addrs = find_bind_addrs(max(nr_of_core_instances, nr_of_agent_instances), args.addr_range)
 
     core_extracted_dir, agent_extracted_dir = obtain_sandbox_image(args.image_dir, args.image_version)
-
-    sandbox_stop.stop(args)
 
     core_addrs = bind_addrs[0:nr_of_core_instances]
     core_pids = start_core_instances(core_extracted_dir, core_addrs)


### PR DESCRIPTION
Chaning output of the `sandbox run` JVM mode so that the output between the Docker and JVM mode is consistent.

**Docker mode**

```
$ sandbox run 1.1.12
|------------------------------------------------|
| Stopping ConductR                              |
|------------------------------------------------|
cond-0
ConductR has been successfully stopped
|------------------------------------------------|
| Starting ConductR                              |
|------------------------------------------------|
Starting container cond-0..
746d12b213b68e0f890ccd46b9f8273cfe96ce538b39fe58ed00787253eb8a41
Waiting for ConductR to start.
```

**JVM mode**

```
$ sandbox run 2.0.0-rc.2
|------------------------------------------------|
| Stopping ConductR                              |
|------------------------------------------------|
cond-0
ConductR has been successfully stopped
|------------------------------------------------|
| Starting ConductR                              |
|------------------------------------------------|
Extracting ConductR core to /Users/mj/.conductr/images/core
Extracting ConductR agent to /Users/mj/.conductr/images/agent
Starting ConductR core instance 0 on 192.168.10.1..
Starting ConductR agent instance 0 on 192.168.10.1..
Waiting for ConductR to start.
```