### PR TITLE
Add missing system properties when starting JVM-based sandbox

### DIFF
--- a/conductr_cli/sandbox_common.py
+++ b/conductr_cli/sandbox_common.py
@@ -70,3 +70,29 @@ def bundle_http_port():
 
 def major_version(version):
     return int(version[0])
+
+
+def resolve_conductr_roles_by_instance(user_conductr_roles, feature_conductr_roles, instance):
+    if not user_conductr_roles:
+        # No ConductR roles have been specified => Return an empty list
+        return []
+    else:
+        if instance + 1 <= len(user_conductr_roles):
+            # Roles have been specified for the current ConductR instance => Get and use these roles.
+            container_conductr_roles = user_conductr_roles[instance]
+        else:
+            # The current ConductR instance is greater than the length of conductr_roles.
+            # In this case the roles of conductr_roles are subsequently applied to the remaining instances.
+            remainder = (instance + 1) % len(user_conductr_roles)
+            remaining_instance = len(user_conductr_roles) if remainder == 0 else remainder
+            container_conductr_roles = user_conductr_roles[remaining_instance - 1]
+
+        # Feature roles are only added to the seed node.
+        if instance == 0:
+            container_conductr_roles = container_conductr_roles + feature_conductr_roles
+
+        return container_conductr_roles
+
+
+def flatten(list):
+    return [item for sublist in list for item in sublist]

--- a/conductr_cli/test/test_sandbox_common.py
+++ b/conductr_cli/test/test_sandbox_common.py
@@ -51,3 +51,47 @@ class TestFindPids(CliTestCase):
         with patch('subprocess.getoutput', mock_getoutput):
             result = sandbox_common.find_pids(self.core_run_dir, self.agent_run_dir)
             self.assertEqual([], result)
+
+
+class TestResolveConductRRolesByInstance(CliTestCase):
+    user_roles = [['role1', 'role2'], ['role3']]
+    feature_roles = ['elasticsearch', 'kibana']
+
+    def test_user_and_feature_roles(self):
+        self.assertEqual(
+            ['role1', 'role2', 'elasticsearch', 'kibana'],
+            sandbox_common.resolve_conductr_roles_by_instance(self.user_roles, self.feature_roles, instance=0))
+
+        self.assertEqual(
+            ['role3'],
+            sandbox_common.resolve_conductr_roles_by_instance(self.user_roles, self.feature_roles, instance=1))
+
+        self.assertEqual(
+            ['role1', 'role2'],
+            sandbox_common.resolve_conductr_roles_by_instance(self.user_roles, self.feature_roles, instance=2))
+
+    def test_empty_user_roles(self):
+        self.assertEqual(
+            [],
+            sandbox_common.resolve_conductr_roles_by_instance([], self.feature_roles, instance=0))
+
+        self.assertEqual(
+            [],
+            sandbox_common.resolve_conductr_roles_by_instance([], self.feature_roles, instance=1))
+
+        self.assertEqual(
+            [],
+            sandbox_common.resolve_conductr_roles_by_instance([], self.feature_roles, instance=2))
+
+    def test_empty_feature_roles(self):
+        self.assertEqual(
+            ['role1', 'role2'],
+            sandbox_common.resolve_conductr_roles_by_instance(self.user_roles, [], instance=0))
+
+        self.assertEqual(
+            ['role3'],
+            sandbox_common.resolve_conductr_roles_by_instance(self.user_roles, [], instance=1))
+
+        self.assertEqual(
+            ['role1', 'role2'],
+            sandbox_common.resolve_conductr_roles_by_instance(self.user_roles, [], instance=2))


### PR DESCRIPTION
This is only applicable in the JVM-based sandbox:

- Add system property for user-defined roles or roles derived from the feature flag when starting ConductR agent process.
- Add system property derived from the feature flag  when starting ConductR agent process.
- Add system property for log level when starting ConductR core and agent process.