### PR TITLE
Fix java version detection on Windows

### DIFF
--- a/conductr_cli/sandbox_run_jvm.py
+++ b/conductr_cli/sandbox_run_jvm.py
@@ -142,7 +142,7 @@ def validate_jvm_support():
     """
     try:
         raw_output = subprocess.getoutput('java -version')
-        lines = raw_output.split(os.linesep)
+        lines = raw_output.splitlines()
         if lines:
             first_line = lines[0]
             parts = first_line.split(' ')


### PR DESCRIPTION
Detecting the java version on Windows currently fails (the following code snippet contains debugging information):

```
C:\Users\mj\workspace\conductr-cli>python -m conductr_cli.sandbox run 2.0.0-rc.2
raw_output: java version "1.8.0_25"
Java(TM) SE Runtime Environment (build 1.8.0_25-b18)
Java HotSpot(TM) 64-Bit Server VM (build 25.25-b02, mixed mode)
lines: ['java version "1.8.0_25"\nJava(TM) SE Runtime Environment (build 1.8.0_25-b18)\nJava HotSpot(TM) 64-Bit Server VM (build 25.25-b02, mixed mode)']
Error: Unable to obtain java version from the `java -version` command.
Error: Please ensure Oracle JVM 1.8 and above is installed.
```

The reason for the error is that `os.linesep` uses on Windows `\n\r`, but the `java version` command uses `\n` to split the lines, also on Windows.

Note that the sandbox is not supported on Windows. Anyhow, I found this issue on the way and I thought it still makes sense to fix it.