### PR TITLE
Set local_connection flag correctly

### DIFF
--- a/conductr_cli/conduct_main.py
+++ b/conductr_cli/conduct_main.py
@@ -10,7 +10,6 @@ from conductr_cli.constants import \
     DEFAULT_API_VERSION, DEFAULT_DCOS_SERVICE, DEFAULT_CLI_SETTINGS_DIR,\
     DEFAULT_CUSTOM_SETTINGS_FILE, DEFAULT_CUSTOM_PLUGINS_DIR,\
     DEFAULT_BUNDLE_RESOLVE_CACHE_DIR, DEFAULT_WAIT_TIMEOUT
-from conductr_cli.host import CONDUCTR_HOST
 from dcos import config, constants
 
 from pathlib import Path
@@ -420,20 +419,16 @@ def run(_args=[], configure_logging=True):
             else:
                 args.command = 'conduct'
 
-            # Ensure ConductR host is not empty
+            # Set ConductR host is --host or --ip argument not set
+            # Also set the local_connection argument accordingly
             host_from_args = conduct_url.conductr_host(args)
             if not host_from_args:
-                host_from_env = host.resolve_default_host()
+                host_from_env = host.resolve_host_from_env()
                 if host_from_env:
                     args.host = host_from_env
+                    args.local_connection = False
                 else:
-                    # Configure logging so error message can be logged properly before exiting with failure
-                    logging_setup.configure_logging(args)
-                    log = logging.getLogger(__name__)
-                    log.error('ConductR host address is not specified')
-                    log.error('Please ensure either `{}` environment is specified,'
-                              ' or specify the ConductR host using `--host` argument'.format(CONDUCTR_HOST))
-                    exit(1)
+                    args.host = host.resolve_default_host()
             else:
                 args.local_connection = False
 

--- a/conductr_cli/host.py
+++ b/conductr_cli/host.py
@@ -12,7 +12,7 @@ DOCKER_IP = '127.0.0.1'
 
 
 def resolve_default_host():
-    return os.getenv(CONDUCTR_HOST, resolve_default_ip())
+    return resolve_default_ip()
 
 
 def resolve_default_ip():
@@ -21,11 +21,12 @@ def resolve_default_ip():
         addr = list(addr_range.hosts())[0]
         return addr.exploded if is_listening(addr, int(DEFAULT_PORT)) else None
 
-    def resolve():
-        from_addr_range = result_from_default_addr_range()
-        return from_addr_range if from_addr_range else DOCKER_IP
+    from_addr_range = result_from_default_addr_range()
+    return from_addr_range if from_addr_range else DOCKER_IP
 
-    return os.getenv(CONDUCTR_IP, resolve())
+
+def resolve_host_from_env():
+    return os.getenv(CONDUCTR_HOST, os.getenv(CONDUCTR_IP, None))
 
 
 def loopback_device_name():


### PR DESCRIPTION
Prior to this PR the `local_connection` flag of the conduct command was only `false` if the `—ip` or `—host` args have been set, not if the `CONDUCTR_HOST` or `CONDUCTR_IP` envs have been set.

As a result, a failed conduct load command recommended to start the sandbox when the `CONDUCTR_HOST` or `CONDUCTR_IP` env was set to an external ConductR cluster. This PR fixes this issue.

**Prior output**

```
$ export CONDUCTR_HOST=10.10.10.10
$ conduct load visualizer
Retrieving bundle..
Loading bundle from cache typesafe/bundle/visualizer
Bintray credentials loaded from /Users/mj/.lightbend/commercial.credentials
Retrieving from cache /Users/mj/.conductr/cache/visualizer-v2-4bbf7b78508b53645eb4dc7b769e2643c5429767c187f284452905fa25e77b46.zip
Loading bundle to ConductR..
Error: Unable to contact ConductR.
Error: Reason: HTTPConnectionPool(host='10.10.10.10', port=9005): Max retries exceeded with url: /v2/bundles (Caused by NewConnectionError('<requests.packages.urllib3.connection.HTTPConnection object at 0x10fa4d7f0>: Failed to establish a new connection: [Errno 60] Operation timed out',))
Error: Start the ConductR sandbox with: sandbox run IMAGE_VERSION
```

**New output**

```
$ export CONDUCTR_HOST=10.10.10.10
$ conduct load visualizer
Retrieving bundle..
Loading bundle from cache typesafe/bundle/visualizer
Bintray credentials loaded from /Users/mj/.lightbend/commercial.credentials
Retrieving from cache /Users/mj/.conductr/cache/visualizer-v2-4bbf7b78508b53645eb4dc7b769e2643c5429767c187f284452905fa25e77b46.zip
Loading bundle to ConductR..
Error: Unable to contact ConductR.
Error: Reason: HTTPConnectionPool(host='10.10.10.10', port=9005): Max retries exceeded with url: /v2/bundles (Caused by NewConnectionError('<requests.packages.urllib3.connection.HTTPConnection object at 0x1081cd780>: Failed to establish a new connection: [Errno 60] Operation timed out',))
Error: Make sure it can be accessed at http://10.10.10.10:9005/v2/bundles
```