### PR TITLE
Implement `sandbox ps` command

### DIFF
--- a/conductr_cli/sandbox_common.py
+++ b/conductr_cli/sandbox_common.py
@@ -2,6 +2,7 @@ from conductr_cli import terminal
 from conductr_cli.resolvers.bintray_resolver import BINTRAY_CONDUCTR_CORE_PACKAGE_NAME, \
     BINTRAY_CONDUCTR_AGENT_PACKAGE_NAME
 import os
+import subprocess
 from subprocess import CalledProcessError
 
 
@@ -24,6 +25,31 @@ def resolve_conductr_info(image_dir):
         'bintray_package_name': BINTRAY_CONDUCTR_AGENT_PACKAGE_NAME
     }
     return core_info, agent_info
+
+
+def find_pids(core_run_dir, agent_run_dir):
+    """
+    Finds the PIDs of ConductR core and agent from the output of the ps process, looking for java process
+    which is running of the sandbox image.
+    :param core_run_dir: directory of where ConductR core is running from.
+    :param agent_run_dir: directory of where ConductR agent is running from.
+    :return: the list of the ConductR core and agent pids.
+    """
+    pids_info = []
+    ps_output = subprocess.getoutput('ps ax')
+    for line in ps_output.split('\n'):
+        pid = line.split()[0]
+        if core_run_dir in line:
+            pids_info.append({
+                'type': 'core',
+                'id': int(pid)
+            })
+        if agent_run_dir in line:
+            pids_info.append({
+                'type': 'agent',
+                'id': int(pid)
+            })
+    return pids_info
 
 
 def resolve_running_docker_containers():

--- a/conductr_cli/sandbox_main.py
+++ b/conductr_cli/sandbox_main.py
@@ -5,7 +5,7 @@ import re
 from conductr_cli.sandbox_common import CONDUCTR_DEV_IMAGE, major_version
 from conductr_cli.sandbox_features import feature_names
 from conductr_cli.constants import DEFAULT_SANDBOX_ADDR_RANGE, DEFAULT_SANDBOX_IMAGE_DIR
-from conductr_cli import sandbox_run, sandbox_stop, sandbox_common, logging_setup, docker, version
+from conductr_cli import sandbox_run, sandbox_stop, sandbox_common, sandbox_ps, logging_setup, docker, version
 from conductr_cli.sandbox_run_jvm import NR_OF_INSTANCE_EXPRESSION
 
 
@@ -114,6 +114,29 @@ def build_parser():
     add_image_dir(stop_parser)
     add_default_arguments(stop_parser)
     stop_parser.set_defaults(func=sandbox_stop.stop)
+
+    # Sub-parser for `ps` sub-command
+    ps_parser = subparsers.add_parser('ps',
+                                      help='List the pids for ConductR core and agent sandbox processes')
+    add_image_dir(ps_parser)
+    add_default_arguments(ps_parser)
+    ps_parser.add_argument('--core',
+                           help='Displays ConductR core sandbox process only.',
+                           default=False,
+                           dest='is_filter_core',
+                           action='store_true')
+    ps_parser.add_argument('--agent',
+                           help='Displays ConductR agent sandbox process only.',
+                           default=False,
+                           dest='is_filter_agent',
+                           action='store_true')
+    ps_parser.add_argument('-q', '--quiet',
+                           help='Displays only the pids without the column headers.',
+                           default=False,
+                           dest='is_quiet',
+                           action='store_true')
+    ps_parser.set_defaults(func=sandbox_ps.ps)
+
     return parser
 
 

--- a/conductr_cli/sandbox_ps.py
+++ b/conductr_cli/sandbox_ps.py
@@ -1,0 +1,29 @@
+from conductr_cli import sandbox_common, screen_utils
+import logging
+
+
+def ps(args):
+    log = logging.getLogger(__name__)
+    core_info, agent_info = sandbox_common.resolve_conductr_info(args.image_dir)
+    pids_info = sandbox_common.find_pids(core_info['extraction_dir'], agent_info['extraction_dir'])
+
+    if args.is_filter_core:
+        data = [pid_info for pid_info in pids_info if pid_info['type'] == 'core']
+    elif args.is_filter_agent:
+        data = [pid_info for pid_info in pids_info if pid_info['type'] == 'agent']
+    else:
+        data = [pid_info for pid_info in pids_info]
+
+    if args.is_quiet:
+        for row in data:
+            log.info(row['id'])
+    else:
+        data.insert(0, {'id': 'PID', 'type': 'TYPE'})
+        padding = 2
+        column_widths = dict(screen_utils.calc_column_widths(data), **{'padding': ' ' * padding})
+        for row in data:
+            log.screen('''\
+{id: <{id_width}}{padding}\
+{type: >{type_width}}'''.format(**dict(row, **column_widths)).rstrip())
+
+    return True

--- a/conductr_cli/test/test_sandbox_common.py
+++ b/conductr_cli/test/test_sandbox_common.py
@@ -12,3 +12,42 @@ class TestSandboxCommon(CliTestCase):
 
         self.assertEqual(result, port_number)
         getenv_mock.assert_called_with('BUNDLE_HTTP_PORT', 9000)
+
+
+class TestFindPids(CliTestCase):
+    image_dir = '/Users/mj/.conductr/images'
+    core_run_dir = '{}/core'.format(image_dir)
+    agent_run_dir = '{}/agent'.format(image_dir)
+
+    def test_pids_found(self):
+        ps_output = '58001   ??  Ss     0:36.97 /sbin/launchd\n' \
+                    '58002   ??  Ss     0:30.48 /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java -Dconductr.ip=192.168.10.1 -cp /Users/mj/.conductr/images/core/lib/com.typesafe.conductr.conductr-2.0.0-rc.2.jar:/dependent-libs com.typesafe.conductr.ConductR\n' \
+                    '58003   ??  Ss     1:17.36 /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java -Dconductr.agent.ip=192.168.10.1 -cp /Users/mj/.conductr/images/agent/lib/com.typesafe.conductr.conductr-agent-2.0.0-rc.2.jar:/dependent-libs com.typesafe.conductr.agent.ConductRAgent --core-node 192.168.10.1:9004\n' \
+                    '58004   ??  Ss     0:30.48 /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java -Dconductr.ip=192.168.10.2 -cp /Users/mj/.conductr/images/core/lib/com.typesafe.conductr.conductr-2.0.0-rc.2.jar:/dependent-libs com.typesafe.conductr.ConductR\n' \
+                    '58005   ??  Ss     1:17.36 /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java -Dconductr.agent.ip=192.168.10.2 -cp /Users/mj/.conductr/images/agent/lib/com.typesafe.conductr.conductr-agent-2.0.0-rc.2.jar:/dependent-libs com.typesafe.conductr.agent.ConductRAgent --core-node 192.168.10.2:9004\n' \
+                    '58006   ??  Ss     0:30.48 /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java -Dconductr.ip=192.168.10.3 -cp /Users/mj/.conductr/images/core/lib/com.typesafe.conductr.conductr-2.0.0-rc.2.jar:/dependent-libs com.typesafe.conductr.ConductR\n' \
+                    '58007   ??  Ss     1:17.36 /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java -Dconductr.agent.ip=192.168.10.3 -cp /Users/mj/.conductr/images/agent/lib/com.typesafe.conductr.conductr-agent-2.0.0-rc.2.jar:/dependent-libs com.typesafe.conductr.agent.ConductRAgent --core-node 192.168.10.3:9004\n' \
+                    '58008   ??  Ss     0:36.97 /usr/libexec/logd'
+
+        mock_getoutput = MagicMock(return_value=ps_output)
+
+        with patch('subprocess.getoutput', mock_getoutput):
+            result = sandbox_common.find_pids(self.core_run_dir, self.agent_run_dir)
+            self.assertEqual([
+                {'id': 58002, 'type': 'core'},
+                {'id': 58003, 'type': 'agent'},
+                {'id': 58004, 'type': 'core'},
+                {'id': 58005, 'type': 'agent'},
+                {'id': 58006, 'type': 'core'},
+                {'id': 58007, 'type': 'agent'}
+            ], result)
+
+    def test_no_pids(self):
+        ps_output = '58001   ??  Ss     0:36.97 /sbin/launchd\n' \
+                    '58008   ??  Ss     0:36.97 /usr/libexec/logd'
+
+        mock_getoutput = MagicMock(return_value=ps_output)
+
+        with patch('subprocess.getoutput', mock_getoutput):
+            result = sandbox_common.find_pids(self.core_run_dir, self.agent_run_dir)
+            self.assertEqual([], result)

--- a/conductr_cli/test/test_sandbox_main.py
+++ b/conductr_cli/test/test_sandbox_main.py
@@ -83,6 +83,31 @@ class TestSandbox(CliTestCase):
         self.assertEqual(args.local_connection, True)
         self.assertEqual(args.resolve_ip, True)
 
+    def test_parser_ps(self):
+        args = self.parser.parse_args('ps'.split())
+        self.assertEqual(args.func.__name__, 'ps')
+        self.assertEqual(args.local_connection, True)
+        self.assertEqual(args.resolve_ip, True)
+        self.assertEqual(args.is_filter_core, False)
+        self.assertEqual(args.is_filter_agent, False)
+        self.assertEqual(args.is_quiet, False)
+
+    def test_parser_ps_core(self):
+        args = self.parser.parse_args('ps --core --quiet'.split())
+        self.assertEqual(args.func.__name__, 'ps')
+        self.assertEqual(args.local_connection, True)
+        self.assertEqual(args.is_filter_core, True)
+        self.assertEqual(args.is_filter_agent, False)
+        self.assertEqual(args.is_quiet, True)
+
+    def test_parser_ps_agent(self):
+        args = self.parser.parse_args('ps --agent --quiet'.split())
+        self.assertEqual(args.func.__name__, 'ps')
+        self.assertEqual(args.local_connection, True)
+        self.assertEqual(args.is_filter_core, False)
+        self.assertEqual(args.is_filter_agent, True)
+        self.assertEqual(args.is_quiet, True)
+
     def test_parser_version(self):
         args = self.parser.parse_args('version'.split())
         self.assertEqual(args.func.__name__, 'version')

--- a/conductr_cli/test/test_sandbox_ps.py
+++ b/conductr_cli/test/test_sandbox_ps.py
@@ -1,0 +1,178 @@
+from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
+from conductr_cli import logging_setup, sandbox_ps
+from unittest.mock import patch, MagicMock
+
+
+class TestSandboxPs(CliTestCase):
+    image_dir = 'image_dir'
+
+    core_extraction_dir = 'core_extraction_dir'
+
+    core_info = {
+        'extraction_dir': core_extraction_dir
+    }
+
+    agent_extraction_dir = 'agent_extraction_dir'
+
+    agent_info = {
+        'extraction_dir': agent_extraction_dir
+    }
+
+    pid_infos = [
+        {'id': 58002, 'type': 'core'},
+        {'id': 58003, 'type': 'agent'}
+    ]
+
+    default_args = {
+        'image_dir': image_dir,
+        'is_filter_core': False,
+        'is_filter_agent': False,
+        'is_quiet': False
+    }
+
+    def test_default(self):
+        stdout = MagicMock()
+
+        mock_resolve_conductr_info = MagicMock(return_value=(self.core_info, self.agent_info))
+        mock_find_pids = MagicMock(return_value=self.pid_infos)
+
+        input_args = MagicMock(**self.default_args)
+
+        with patch('conductr_cli.sandbox_common.resolve_conductr_info', mock_resolve_conductr_info), \
+                patch('conductr_cli.sandbox_common.find_pids', mock_find_pids):
+            logging_setup.configure_logging(input_args, stdout)
+            sandbox_ps.ps(input_args)
+
+        mock_resolve_conductr_info.assert_called_once_with(self.image_dir)
+        mock_find_pids.assert_called_once_with(self.core_extraction_dir, self.agent_extraction_dir)
+
+        expected_output = strip_margin("""|PID     TYPE
+                                          |58002   core
+                                          |58003  agent
+                                          |""")
+        self.assertEqual(expected_output, self.output(stdout))
+
+    def test_quiet(self):
+        stdout = MagicMock()
+
+        mock_resolve_conductr_info = MagicMock(return_value=(self.core_info, self.agent_info))
+        mock_find_pids = MagicMock(return_value=self.pid_infos)
+
+        args = self.default_args.copy()
+        args.update({
+            'is_quiet': True
+        })
+        input_args = MagicMock(**args)
+
+        with patch('conductr_cli.sandbox_common.resolve_conductr_info', mock_resolve_conductr_info), \
+                patch('conductr_cli.sandbox_common.find_pids', mock_find_pids):
+            logging_setup.configure_logging(input_args, stdout)
+            sandbox_ps.ps(input_args)
+
+        mock_resolve_conductr_info.assert_called_once_with(self.image_dir)
+        mock_find_pids.assert_called_once_with(self.core_extraction_dir, self.agent_extraction_dir)
+
+        expected_output = strip_margin("""|58002
+                                          |58003
+                                          |""")
+        self.assertEqual(expected_output, self.output(stdout))
+
+    def test_filter_core(self):
+        stdout = MagicMock()
+
+        mock_resolve_conductr_info = MagicMock(return_value=(self.core_info, self.agent_info))
+        mock_find_pids = MagicMock(return_value=self.pid_infos)
+
+        args = self.default_args.copy()
+        args.update({
+            'is_filter_core': True
+        })
+        input_args = MagicMock(**args)
+
+        with patch('conductr_cli.sandbox_common.resolve_conductr_info', mock_resolve_conductr_info), \
+                patch('conductr_cli.sandbox_common.find_pids', mock_find_pids):
+            logging_setup.configure_logging(input_args, stdout)
+            sandbox_ps.ps(input_args)
+
+        mock_resolve_conductr_info.assert_called_once_with(self.image_dir)
+        mock_find_pids.assert_called_once_with(self.core_extraction_dir, self.agent_extraction_dir)
+
+        expected_output = strip_margin("""|PID    TYPE
+                                          |58002  core
+                                          |""")
+        self.assertEqual(expected_output, self.output(stdout))
+
+    def test_filter_core_quiet(self):
+        stdout = MagicMock()
+
+        mock_resolve_conductr_info = MagicMock(return_value=(self.core_info, self.agent_info))
+        mock_find_pids = MagicMock(return_value=self.pid_infos)
+
+        args = self.default_args.copy()
+        args.update({
+            'is_filter_core': True,
+            'is_quiet': True
+        })
+        input_args = MagicMock(**args)
+
+        with patch('conductr_cli.sandbox_common.resolve_conductr_info', mock_resolve_conductr_info), \
+                patch('conductr_cli.sandbox_common.find_pids', mock_find_pids):
+            logging_setup.configure_logging(input_args, stdout)
+            sandbox_ps.ps(input_args)
+
+        mock_resolve_conductr_info.assert_called_once_with(self.image_dir)
+        mock_find_pids.assert_called_once_with(self.core_extraction_dir, self.agent_extraction_dir)
+
+        expected_output = strip_margin("""|58002
+                                          |""")
+        self.assertEqual(expected_output, self.output(stdout))
+
+    def test_filter_agent(self):
+        stdout = MagicMock()
+
+        mock_resolve_conductr_info = MagicMock(return_value=(self.core_info, self.agent_info))
+        mock_find_pids = MagicMock(return_value=self.pid_infos)
+
+        args = self.default_args.copy()
+        args.update({
+            'is_filter_agent': True
+        })
+        input_args = MagicMock(**args)
+
+        with patch('conductr_cli.sandbox_common.resolve_conductr_info', mock_resolve_conductr_info), \
+                patch('conductr_cli.sandbox_common.find_pids', mock_find_pids):
+            logging_setup.configure_logging(input_args, stdout)
+            sandbox_ps.ps(input_args)
+
+        mock_resolve_conductr_info.assert_called_once_with(self.image_dir)
+        mock_find_pids.assert_called_once_with(self.core_extraction_dir, self.agent_extraction_dir)
+
+        expected_output = strip_margin("""|PID     TYPE
+                                          |58003  agent
+                                          |""")
+        self.assertEqual(expected_output, self.output(stdout))
+
+    def test_filter_agent_quiet(self):
+        stdout = MagicMock()
+
+        mock_resolve_conductr_info = MagicMock(return_value=(self.core_info, self.agent_info))
+        mock_find_pids = MagicMock(return_value=self.pid_infos)
+
+        args = self.default_args.copy()
+        args.update({
+            'is_filter_agent': True,
+            'is_quiet': True
+        })
+        input_args = MagicMock(**args)
+
+        with patch('conductr_cli.sandbox_common.resolve_conductr_info', mock_resolve_conductr_info), \
+                patch('conductr_cli.sandbox_common.find_pids', mock_find_pids):
+            logging_setup.configure_logging(input_args, stdout)
+            sandbox_ps.ps(input_args)
+
+        mock_resolve_conductr_info.assert_called_once_with(self.image_dir)
+        mock_find_pids.assert_called_once_with(self.core_extraction_dir, self.agent_extraction_dir)
+
+        expected_output = strip_margin("""|58003
+                                          |""")
+        self.assertEqual(expected_output, self.output(stdout))


### PR DESCRIPTION
Introduce sandbox ps which will displays the pids of the ConductR core and agent:
* `--core` flag will filter for ConductR core pids.
* `--agent` flag will filter for ConductR core pids.
* `--quiet` flag will display just the pids.