### PR TITLE
Offline mode

### DIFF
--- a/conductr_cli/conduct_load.py
+++ b/conductr_cli/conduct_load.py
@@ -47,14 +47,16 @@ def load_v1(args):
 
     validate_cache_dir_permissions(resolve_cache_dir, log)
 
-    bundle_file_name, bundle_file = resolver.resolve_bundle(custom_settings, resolve_cache_dir, args.bundle)
+    bundle_file_name, bundle_file = resolver.resolve_bundle(custom_settings, resolve_cache_dir,
+                                                            args.bundle, args.offline_mode)
 
     configuration_file_name, configuration_file = (None, None)
     if args.configuration is not None:
         log.info('Retrieving configuration..')
         configuration_file_name, configuration_file = resolver.resolve_bundle_configuration(custom_settings,
                                                                                             resolve_cache_dir,
-                                                                                            args.configuration)
+                                                                                            args.configuration,
+                                                                                            args.offline_mode)
 
     bundle_conf = ConfigFactory.parse_string(bundle_utils.conf(bundle_file))
     overlay_bundle_conf = None if configuration_file is None else \
@@ -150,7 +152,8 @@ def load_v2(args):
 
     validate_cache_dir_permissions(resolve_cache_dir, log)
 
-    bundle_file_name, bundle_file = resolver.resolve_bundle(custom_settings, resolve_cache_dir, args.bundle)
+    bundle_file_name, bundle_file = resolver.resolve_bundle(custom_settings, resolve_cache_dir,
+                                                            args.bundle, args.offline_mode)
     bundle_conf = bundle_utils.conf(bundle_file)
 
     if bundle_conf is None:
@@ -161,7 +164,8 @@ def load_v2(args):
             log.info('Retrieving configuration..')
             configuration_file_name, configuration_file = resolver.resolve_bundle_configuration(custom_settings,
                                                                                                 resolve_cache_dir,
-                                                                                                args.configuration)
+                                                                                                args.configuration,
+                                                                                                args.offline_mode)
             bundle_conf_overlay = bundle_utils.conf(configuration_file)
 
         files = [('bundleConf', ('bundle.conf', string_io(bundle_conf)))]

--- a/conductr_cli/conduct_main.py
+++ b/conductr_cli/conduct_main.py
@@ -1,15 +1,15 @@
 import argcomplete
 import argparse
 from conductr_cli import \
-    conduct_deploy, conduct_info, conduct_load, conduct_run, conduct_service_names,\
-    conduct_stop, conduct_unload, version, conduct_logs,\
-    conduct_events, conduct_acls, conduct_dcos, host, logging_setup,\
+    conduct_deploy, conduct_info, conduct_load, conduct_run, conduct_service_names, \
+    conduct_stop, conduct_unload, version, conduct_logs, \
+    conduct_events, conduct_acls, conduct_dcos, host, logging_setup, \
     conduct_url, custom_settings
 from conductr_cli.constants import \
     DEFAULT_SCHEME, DEFAULT_PORT, DEFAULT_BASE_PATH, \
-    DEFAULT_API_VERSION, DEFAULT_DCOS_SERVICE, DEFAULT_CLI_SETTINGS_DIR,\
-    DEFAULT_CUSTOM_SETTINGS_FILE, DEFAULT_CUSTOM_PLUGINS_DIR,\
-    DEFAULT_BUNDLE_RESOLVE_CACHE_DIR, DEFAULT_WAIT_TIMEOUT
+    DEFAULT_API_VERSION, DEFAULT_DCOS_SERVICE, DEFAULT_CLI_SETTINGS_DIR, \
+    DEFAULT_CUSTOM_SETTINGS_FILE, DEFAULT_CUSTOM_PLUGINS_DIR, \
+    DEFAULT_BUNDLE_RESOLVE_CACHE_DIR, DEFAULT_WAIT_TIMEOUT, DEFAULT_OFFLINE_MODE
 from dcos import config, constants
 
 from pathlib import Path
@@ -24,15 +24,15 @@ def add_scheme_host_ip_port_and_base_path(sub_parser):
                             help='The optional ConductR scheme, defaults to `http`',
                             default=DEFAULT_SCHEME)
     sub_parser.add_argument('--host',
-                            help='The optional ConductR IP, defaults to one of the value in this order:'
+                            help='The optional ConductR IP, defaults to one of the value in this order: '
                                  '$CONDUCTR_HOST or'
                                  '$CONDUCTR_IP or'
                                  'IP address of the docker VM or'
                                  '`127.0.0.1`',
                             default=None)  # Default is determined given the Docker environment
     sub_parser.add_argument('-i', '--ip',
-                            help='The optional ConductR IP, defaults to one of the value in this order:'
-                                 '$CONDUCTR_IP or'
+                            help='The optional ConductR IP, defaults to one of the value in this order: '
+                                 '$CONDUCTR_IP or '
                                  'IP address of the docker VM or'
                                  '`127.0.0.1`',
                             default=None)  # Default is determined given the Docker environment
@@ -93,7 +93,7 @@ def add_cli_settings_dir(sub_parser):
 def add_custom_settings_file(sub_parser):
     sub_parser.add_argument('--custom-settings-file',
                             help='Configuration where custom settings for ConductR CLI are stored in HOCON format,'
-                            'defaults to {}'.format(DEFAULT_CUSTOM_SETTINGS_FILE),
+                                 'defaults to {}'.format(DEFAULT_CUSTOM_SETTINGS_FILE),
                             default=DEFAULT_CUSTOM_SETTINGS_FILE,
                             dest='custom_settings_file')
 
@@ -143,7 +143,7 @@ def add_wait_timeout(sub_parser, wait_timeout=DEFAULT_WAIT_TIMEOUT):
 def add_no_wait(sub_parser):
     sub_parser.add_argument('--no-wait',
                             help='Disables waiting for bundle scale to be achieved in conduct run, or bundle to be '
-                                 'stopped in conduct stop, defaults to',
+                                 'stopped in conduct stop, defaults to False.',
                             default=False,
                             dest='no_wait',
                             action='store_true')
@@ -215,6 +215,14 @@ def build_parser(dcos_mode):
                              nargs='?',
                              default=None,
                              help='The optional configuration for the bundle')
+    load_parser.add_argument('--offline',
+                             default=DEFAULT_OFFLINE_MODE,
+                             dest='offline_mode',
+                             action='store_true',
+                             help='Enables offline mode to resolve bundles only locally '
+                                  'either by file uri or from the cache directory. '
+                                  'Defaults to environment variable CONDUCTR_OFFLINE_MODE. '
+                                  'If not set the default is False.')
     add_default_arguments(load_parser, dcos_mode)
     add_bundle_resolve_cache_dir(load_parser)
     add_wait_timeout(load_parser)
@@ -297,8 +305,8 @@ def build_parser(dcos_mode):
     # Sub-parser for `setup-dcos` sub-command
     dcos_parser = subparsers.add_parser('setup-dcos',
                                         help='setup integration with the DC/OS CLI '
-                                        'so that \'dcos conduct ..\' commands can '
-                                        'be used to access ConductR via DC/OS')
+                                             'so that \'dcos conduct ..\' commands can '
+                                             'be used to access ConductR via DC/OS')
     dcos_parser.set_defaults(func=conduct_dcos.setup)
 
     # Sub-parser for `deploy` sub-command

--- a/conductr_cli/constants.py
+++ b/conductr_cli/constants.py
@@ -14,6 +14,7 @@ DEFAULT_CUSTOM_SETTINGS_FILE = os.getenv('CONDUCTR_CUSTOM_SETTINGS_FILE',
                                          '{}/settings.conf'.format(DEFAULT_CLI_SETTINGS_DIR))
 DEFAULT_CUSTOM_PLUGINS_DIR = os.getenv('CONDUCTR_CUSTOM_PLUGINS_DIR',
                                        '{}/plugins'.format(DEFAULT_CLI_SETTINGS_DIR))
+DEFAULT_OFFLINE_MODE = os.getenv('CONDUCTR_OFFLINE_MODE', False)
 DEFAULT_SANDBOX_IMAGE_DIR = os.path.abspath(os.getenv('CONDUCTR_SANDBOX_IMAGE_DIR',
                                                       '{}/images'.format(DEFAULT_CLI_SETTINGS_DIR)))
 DEFAULT_SANDBOX_ADDR_RANGE = os.getenv('CONDUCTR_SANDBOX_ADDR_RANGE', '192.168.10.0/24')

--- a/conductr_cli/resolvers/bintray_resolver.py
+++ b/conductr_cli/resolvers/bintray_resolver.py
@@ -36,7 +36,7 @@ def resolve_bundle(cache_dir, uri):
         return False, None, None
 
 
-def load_bundle_from_cache(cache_dir, uri):
+def load_bundle_from_cache(cache_dir, uri, offline_mode=False):
     # When the supplied uri points to a local file, don't load from cache so file can be used as is.
     if is_local_file(uri):
         return False, None, None
@@ -49,7 +49,7 @@ def load_bundle_from_cache(cache_dir, uri):
                                                                  compatibility_version=compatibility_version,
                                                                  digest=digest)
             if bundle_download_url:
-                return uri_resolver.load_bundle_from_cache(cache_dir, bundle_download_url)
+                return uri_resolver.load_bundle_from_cache(cache_dir, bundle_download_url, offline_mode)
             else:
                 return False, None, None
         except MalformedBundleUriError:
@@ -75,7 +75,7 @@ def resolve_bundle_configuration(cache_dir, uri):
         return False, None, None
 
 
-def load_bundle_configuration_from_cache(cache_dir, uri):
+def load_bundle_configuration_from_cache(cache_dir, uri, offline_mode=False):
     # When the supplied uri points to a local file, don't load from cache so file can be used as is.
     if is_local_file(uri):
         return False, None, None
@@ -89,7 +89,7 @@ def load_bundle_configuration_from_cache(cache_dir, uri):
                                                                  compatibility_version=compatibility_version,
                                                                  digest=digest)
             if bundle_download_url:
-                return uri_resolver.load_bundle_from_cache(cache_dir, bundle_download_url)
+                return uri_resolver.load_bundle_from_cache(cache_dir, bundle_download_url, offline_mode)
             else:
                 return False, None, None
         except MalformedBundleUriError:

--- a/conductr_cli/resolvers/test/test_bintray_resolver.py
+++ b/conductr_cli/resolvers/test/test_bintray_resolver.py
@@ -271,7 +271,8 @@ class TestLoadBundleFromCache(TestCase):
         bintray_resolve_version_mock.assert_called_with('username', 'password', 'typesafe', 'bundle', 'bundle-name',
                                                         None, 'v1', 'digest')
         load_bundle_from_cache_mock.assert_called_with('/cache-dir',
-                                                       'https://dl.bintray.com/typesafe/bundle/download.zip')
+                                                       'https://dl.bintray.com/typesafe/bundle/download.zip',
+                                                       False)
 
     def test_bintray_version_not_found(self):
         exists_mock = MagicMock(return_value=False)
@@ -404,7 +405,8 @@ class TestLoadBundleConfigurationFromCache(TestCase):
         bintray_resolve_version_mock.assert_called_with('username', 'password', 'typesafe', 'bundle-configuration',
                                                         'bundle-name', None, 'v1', 'digest')
         load_bundle_from_cache_mock.assert_called_with('/cache-dir',
-                                                       'https://dl.bintray.com/typesafe/bundle-configuration/download.zip')
+                                                       'https://dl.bintray.com/typesafe/bundle-configuration/download.zip',
+                                                       False)
 
     def test_bintray_version_not_found(self):
         exists_mock = MagicMock(return_value=False)

--- a/conductr_cli/resolvers/test/test_uri_resolver.py
+++ b/conductr_cli/resolvers/test/test_uri_resolver.py
@@ -271,6 +271,22 @@ class TestLoadBundleFromCache(TestCase):
 
         exists_mock.assert_not_called()
 
+    def test_offline_mode(self):
+        glob_mock = MagicMock(return_value=['/cache_dir/bundle-old.zip', '/cache_dir/bundle-new.zip'])
+        os_path_getctime_mock = MagicMock(side_effect=[1484822907.0, 1484822908.0])
+
+        with patch('glob.glob', glob_mock), \
+                patch('os.path.getctime', os_path_getctime_mock):
+            is_resolved, bundle_name, bundle_file = uri_resolver.load_bundle_from_cache('/cache-dir',
+                                                                                        'bundle',
+                                                                                        True)
+            self.assertTrue(is_resolved)
+            self.assertEqual(bundle_name, 'bundle-new.zip')
+            self.assertEqual(bundle_file, '/cache_dir/bundle-new.zip')
+
+        glob_mock.assert_called_once_with('/cache-dir/bundle*')
+        os_path_getctime_mock.assert_has_calls([call('/cache_dir/bundle-old.zip'), call('/cache_dir/bundle-new.zip')])
+
     def test_uri_found(self):
         exists_mock = MagicMock(return_value=True)
 
@@ -316,6 +332,23 @@ class TestLoadBundleConfigurationFromCache(TestCase):
             self.assertIsNone(bundle_file)
 
         exists_mock.assert_not_called()
+
+    def test_offline_mode(self):
+        glob_mock = MagicMock(return_value=['/cache_dir/bundle-config-old.zip', '/cache_dir/bundle-config-new.zip'])
+        os_path_getctime_mock = MagicMock(side_effect=[1484822907.0, 1484822908.0])
+
+        with patch('glob.glob', glob_mock), \
+                patch('os.path.getctime', os_path_getctime_mock):
+            is_resolved, bundle_name, bundle_file = uri_resolver.load_bundle_configuration_from_cache('/cache-dir',
+                                                                                                      'bundle-config',
+                                                                                                      True)
+            self.assertTrue(is_resolved)
+            self.assertEqual(bundle_name, 'bundle-config-new.zip')
+            self.assertEqual(bundle_file, '/cache_dir/bundle-config-new.zip')
+
+        glob_mock.assert_called_once_with('/cache-dir/bundle-config*')
+        os_path_getctime_mock.assert_has_calls([call('/cache_dir/bundle-config-old.zip'),
+                                                call('/cache_dir/bundle-config-new.zip')])
 
     def test_uri_found(self):
         exists_mock = MagicMock(return_value=True)

--- a/conductr_cli/sandbox_main.py
+++ b/conductr_cli/sandbox_main.py
@@ -4,7 +4,7 @@ import ipaddress
 import re
 from conductr_cli.sandbox_common import CONDUCTR_DEV_IMAGE, major_version
 from conductr_cli.sandbox_features import feature_names
-from conductr_cli.constants import DEFAULT_SANDBOX_ADDR_RANGE, DEFAULT_SANDBOX_IMAGE_DIR
+from conductr_cli.constants import DEFAULT_SANDBOX_ADDR_RANGE, DEFAULT_SANDBOX_IMAGE_DIR, DEFAULT_OFFLINE_MODE
 from conductr_cli import sandbox_run, sandbox_stop, sandbox_common, sandbox_ps, logging_setup, docker, version
 from conductr_cli.sandbox_run_jvm import NR_OF_INSTANCE_EXPRESSION
 
@@ -75,6 +75,14 @@ def build_parser():
                                  'and y is a number of agent instances\n'
                                  'For ConductR 1, this corresponds to the number of nodes.',
                             metavar='')
+    run_parser.add_argument('--offline',
+                            default=DEFAULT_OFFLINE_MODE,
+                            dest='offline_mode',
+                            action='store_true',
+                            help='Enables offline mode to resolve bundles only locally '
+                                 'either by file uri or from the cache directory. '
+                                 'Defaults to environment variable CONDUCTR_OFFLINE_MODE. '
+                                 'If not set the default is False.')
     run_parser.add_argument('-p', '--port',
                             dest='ports',
                             action='append',

--- a/conductr_cli/sandbox_run.py
+++ b/conductr_cli/sandbox_run.py
@@ -26,7 +26,7 @@ DEFAULT_WAIT_RETRY_INTERVAL = 2.0
 def run(args):
     """`sandbox run` command"""
     is_conductr_v1 = major_version(args.image_version) == 1
-    features = sandbox_features.collect_features(args.features, args.image_version)
+    features = sandbox_features.collect_features(args.features, args.image_version, args.offline_mode)
     sandbox = sandbox_run_docker if is_conductr_v1 else sandbox_run_jvm
 
     run_result = sandbox.run(args, features)

--- a/conductr_cli/test/conduct_load_test_base.py
+++ b/conductr_cli/test/conduct_load_test_base.py
@@ -30,6 +30,7 @@ class ConductLoadTestBase(CliTestCase):
         self.nr_of_cpus = None
         self.roles = []
         self.custom_settings = None
+        self.offline_mode = False
         self.bundle_resolve_cache_dir = None
         self.mock_headers = {'pretend': 'header'}
         self.multipart_content_type = "multipart/form-data"
@@ -75,7 +76,8 @@ class ConductLoadTestBase(CliTestCase):
             self.assertTrue(result)
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
-        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
+                                               self.bundle_file, self.offline_mode)
         create_multipart_mock.assert_called_with(self.conduct_load_logger, self.default_files)
         http_method.assert_called_with(self.default_url,
                                        data=self.multipart_mock,
@@ -112,7 +114,8 @@ class ConductLoadTestBase(CliTestCase):
             self.assertTrue(result)
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
-        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
+                                               self.bundle_file, self.offline_mode)
         create_multipart_mock.assert_called_with(self.conduct_load_logger, self.default_files)
         http_method.assert_called_with(self.default_url,
                                        data=self.multipart_mock,
@@ -149,7 +152,8 @@ class ConductLoadTestBase(CliTestCase):
             self.assertTrue(result)
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
-        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
+                                               self.bundle_file, self.offline_mode)
         create_multipart_mock.assert_called_with(self.conduct_load_logger, self.default_files)
         http_method.assert_called_with(self.default_url,
                                        data=self.multipart_mock,
@@ -186,7 +190,8 @@ class ConductLoadTestBase(CliTestCase):
             self.assertTrue(result)
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
-        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
+                                               self.bundle_file, self.offline_mode)
         create_multipart_mock.assert_called_with(self.conduct_load_logger, self.default_files)
         http_method.assert_called_with(self.default_url,
                                        data=self.multipart_mock,
@@ -223,7 +228,8 @@ class ConductLoadTestBase(CliTestCase):
             self.assertTrue(result)
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
-        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
+                                               self.bundle_file, self.offline_mode)
         create_multipart_mock.assert_called_with(self.conduct_load_logger, self.default_files)
         http_method.assert_called_with(self.default_url,
                                        data=self.multipart_mock,
@@ -261,7 +267,8 @@ class ConductLoadTestBase(CliTestCase):
             self.assertTrue(result)
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
-        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
+                                               self.bundle_file, self.offline_mode)
         create_multipart_mock.assert_called_with(self.conduct_load_logger, self.default_files)
         http_method.assert_called_with(self.default_url,
                                        data=self.multipart_mock,
@@ -301,7 +308,8 @@ class ConductLoadTestBase(CliTestCase):
             self.assertTrue(result)
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
-        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
+                                               self.bundle_file, self.offline_mode)
         create_multipart_mock.assert_called_with(self.conduct_load_logger, self.default_files)
         http_method.assert_called_with(self.default_url,
                                        data=self.multipart_mock,
@@ -342,7 +350,8 @@ class ConductLoadTestBase(CliTestCase):
             self.assertTrue(result)
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
-        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
+                                               self.bundle_file, self.offline_mode)
         create_multipart_mock.assert_called_with(self.conduct_load_logger, self.default_files)
         http_method.assert_called_with(self.default_url,
                                        data=self.multipart_mock,
@@ -377,7 +386,45 @@ class ConductLoadTestBase(CliTestCase):
             self.assertTrue(result)
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
-        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
+                                               self.bundle_file, self.offline_mode)
+        create_multipart_mock.assert_called_with(self.conduct_load_logger, self.default_files)
+        http_method.assert_called_with(self.default_url,
+                                       data=self.multipart_mock,
+                                       auth=self.conductr_auth,
+                                       verify=self.server_verification_file,
+                                       headers={'Content-Type': self.multipart_content_type, 'Host': '127.0.0.1'})
+        cleanup_old_bundles_mock.assert_called_with(self.bundle_resolve_cache_dir, self.bundle_file_name,
+                                                    excluded=self.bundle_file)
+
+        self.assertEqual(self.default_output(), self.output(stdout))
+
+    def base_test_success_offline_mode(self):
+        resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, self.bundle_file))
+        create_multipart_mock = MagicMock(return_value=self.multipart_mock)
+        http_method = self.respond_with(200, self.default_response)
+        stdout = MagicMock()
+        open_mock = MagicMock(return_value=1)
+        cleanup_old_bundles_mock = MagicMock()
+        wait_for_installation_mock = MagicMock()
+
+        args = self.default_args.copy()
+        args.update({'offline_mode': True})
+        input_args = MagicMock(**args)
+
+        with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
+                patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
+                patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
+                patch('requests.post', http_method), \
+                patch('builtins.open', open_mock), \
+                patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_load.load(input_args)
+            self.assertTrue(result)
+
+        open_mock.assert_called_with(self.bundle_file, 'rb')
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
+                                               self.bundle_file, True)
         create_multipart_mock.assert_called_with(self.conduct_load_logger, self.default_files)
         http_method.assert_called_with(self.default_url,
                                        data=self.multipart_mock,
@@ -407,7 +454,8 @@ class ConductLoadTestBase(CliTestCase):
             self.assertFalse(result)
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
-        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
+                                               self.bundle_file, self.offline_mode)
         create_multipart_mock.assert_called_with(self.conduct_load_logger, self.default_files)
         http_method.assert_called_with(self.default_url,
                                        data=self.multipart_mock,
@@ -438,7 +486,8 @@ class ConductLoadTestBase(CliTestCase):
             self.assertFalse(result)
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
-        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
+                                               self.bundle_file, self.offline_mode)
         create_multipart_mock.assert_called_with(self.conduct_load_logger, self.default_files)
         http_method.assert_called_with(self.default_url,
                                        data=self.multipart_mock,
@@ -468,7 +517,8 @@ class ConductLoadTestBase(CliTestCase):
             self.assertFalse(result)
 
         open_mock.assert_called_with(self.bundle_file, 'rb')
-        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
+                                               self.bundle_file, self.offline_mode)
         create_multipart_mock.assert_called_with(self.conduct_load_logger, self.default_files)
         http_method.assert_called_with(self.default_url,
                                        data=self.multipart_mock,
@@ -495,7 +545,8 @@ class ConductLoadTestBase(CliTestCase):
             result = conduct_load.load(MagicMock(**args))
             self.assertFalse(result)
 
-        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, 'no_such.bundle')
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
+                                               'no_such.bundle', self.offline_mode)
 
         self.assertEqual(
             as_error(strip_margin("""|Error: Bundle not found: some message
@@ -516,9 +567,10 @@ class ConductLoadTestBase(CliTestCase):
             result = conduct_load.load(MagicMock(**args))
             self.assertFalse(result)
 
-        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
+                                               self.bundle_file, self.offline_mode)
         resolve_bundle_configuration_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
-                                                             'no_such.conf')
+                                                             'no_such.conf', self.offline_mode)
 
         self.assertEqual(
             as_error(strip_margin("""|Error: Bundle not found: some message
@@ -536,7 +588,8 @@ class ConductLoadTestBase(CliTestCase):
             result = conduct_load.load(MagicMock(**self.default_args))
             self.assertFalse(result)
 
-        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
+                                               self.bundle_file, self.offline_mode)
         open_mock.assert_called_with(self.bundle_file, 'rb')
 
         self.assertEqual(
@@ -554,7 +607,8 @@ class ConductLoadTestBase(CliTestCase):
             result = conduct_load.load(MagicMock(**self.default_args))
             self.assertFalse(result)
 
-        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
+                                               self.bundle_file, self.offline_mode)
 
         self.assertEqual(
             as_error(strip_margin("""|Error: Resource not found: url
@@ -570,7 +624,8 @@ class ConductLoadTestBase(CliTestCase):
             result = conduct_load.load(MagicMock(**self.default_args))
             self.assertFalse(result)
 
-        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
+                                               self.bundle_file, self.offline_mode)
 
         self.assertEqual(
             as_error(strip_margin("""|Error: File not found: reason

--- a/conductr_cli/test/test_conduct_load_v1.py
+++ b/conductr_cli/test/test_conduct_load_v1.py
@@ -45,6 +45,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
             'verbose': False,
             'quiet': False,
             'no_wait': False,
+            'offline_mode': False,
             'long_ids': False,
             'command': 'conduct',
             'cli_parameters': '',
@@ -125,9 +126,10 @@ class TestConductLoadCommand(ConductLoadTestBase):
             [call(self.bundle_file, 'rb'), call(config_file, 'rb')]
         )
 
-        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
+                                               self.bundle_file, self.offline_mode)
         resolve_bundle_configuration_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
-                                                             config_file)
+                                                             config_file, self.offline_mode)
         expected_files = self.default_files + [('configuration', ('config.zip', 1))]
         expected_files[4] = ('bundleName', 'overlaid-name')
         create_multipart_mock.assert_called_with(self.conduct_load_logger, expected_files)
@@ -143,6 +145,9 @@ class TestConductLoadCommand(ConductLoadTestBase):
 
     def test_success_no_wait(self):
         self.base_test_success_no_wait()
+
+    def test_success_offline_mode(self):
+        self.base_test_success_offline_mode()
 
     def test_failure(self):
         self.base_test_failure()
@@ -176,7 +181,8 @@ class TestConductLoadCommand(ConductLoadTestBase):
             result = conduct_load.load(MagicMock(**args))
             self.assertFalse(result)
 
-        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
+                                               bundle_file, self.offline_mode)
 
         self.assertEqual(
             as_error(strip_margin("""|Error: Unable to parse bundle.conf.
@@ -203,7 +209,8 @@ class TestConductLoadCommand(ConductLoadTestBase):
             result = conduct_load.load(MagicMock(**args))
             self.assertFalse(result)
 
-        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
+                                               bundle_file, self.offline_mode)
 
         self.assertEqual(
             as_error(strip_margin("""|Error: Unable to parse bundle.conf.
@@ -230,7 +237,8 @@ class TestConductLoadCommand(ConductLoadTestBase):
             result = conduct_load.load(MagicMock(**args))
             self.assertFalse(result)
 
-        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
+                                               bundle_file, self.offline_mode)
 
         self.assertEqual(
             as_error(strip_margin("""|Error: Unable to parse bundle.conf.
@@ -257,7 +265,8 @@ class TestConductLoadCommand(ConductLoadTestBase):
             result = conduct_load.load(MagicMock(**args))
             self.assertFalse(result)
 
-        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
+                                               bundle_file, self.offline_mode)
 
         self.assertEqual(
             as_error(strip_margin("""|Error: Unable to parse bundle.conf.
@@ -285,7 +294,8 @@ class TestConductLoadCommand(ConductLoadTestBase):
             result = conduct_load.load(MagicMock(**args))
             self.assertFalse(result)
 
-        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
+                                               bundle_file, self.offline_mode)
 
         self.assertEqual(
             as_error(strip_margin("""|Error: Unable to parse bundle.conf.

--- a/conductr_cli/test/test_conduct_load_v2.py
+++ b/conductr_cli/test/test_conduct_load_v2.py
@@ -50,6 +50,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
             'verbose': False,
             'quiet': False,
             'no_wait': False,
+            'offline_mode': False,
             'long_ids': False,
             'command': 'conduct',
             'cli_parameters': '',
@@ -173,9 +174,10 @@ class TestConductLoadCommand(ConductLoadTestBase):
             result = conduct_load.load(input_args)
             self.assertTrue(result)
 
-        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
+                                               self.bundle_file, self.offline_mode)
         resolve_bundle_configuration_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
-                                                             config_file)
+                                                             config_file, self.offline_mode)
         self.assertEqual(
             conf_mock.call_args_list,
             [
@@ -248,9 +250,10 @@ class TestConductLoadCommand(ConductLoadTestBase):
             result = conduct_load.load(input_args)
             self.assertTrue(result)
 
-        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
+                                               self.bundle_file, self.offline_mode)
         resolve_bundle_configuration_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
-                                                             config_file)
+                                                             config_file, self.offline_mode)
 
         self.assertEqual(
             conf_mock.call_args_list,
@@ -291,6 +294,15 @@ class TestConductLoadCommand(ConductLoadTestBase):
         with patch('conductr_cli.bundle_utils.conf', conf_mock), \
                 patch('conductr_cli.conduct_load.string_io', string_io_mock):
             self.base_test_success_no_wait()
+        conf_mock.assert_called_with(self.bundle_file)
+        string_io_mock.assert_called_with('mock bundle.conf')
+
+    def test_success_offline_mode(self):
+        conf_mock = MagicMock(return_value='mock bundle.conf')
+        string_io_mock = MagicMock(return_value='mock bundle.conf - string i/o')
+        with patch('conductr_cli.bundle_utils.conf', conf_mock), \
+                patch('conductr_cli.conduct_load.string_io', string_io_mock):
+            self.base_test_success_offline_mode()
         conf_mock.assert_called_with(self.bundle_file)
         string_io_mock.assert_called_with('mock bundle.conf')
 
@@ -345,7 +357,8 @@ class TestConductLoadCommand(ConductLoadTestBase):
             result = conduct_load.load(MagicMock(**args))
             self.assertFalse(result)
 
-        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir, self.bundle_file)
+        resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
+                                               self.bundle_file, self.offline_mode)
 
         self.assertEqual(
             as_error(strip_margin("""|Error: Problem with the bundle: Unable to find bundle.conf within the bundle file

--- a/conductr_cli/test/test_resolver.py
+++ b/conductr_cli/test/test_resolver.py
@@ -27,7 +27,7 @@ class TestResolver(TestCase):
             self.assertEqual('bundle_name', bundle_name)
             self.assertEqual('mock bundle_file', bundle_file)
 
-        resolver_chain_mock.assert_called_with(custom_settings)
+        resolver_chain_mock.assert_called_with(custom_settings, False)
 
         first_resolver_mock.load_from_cache('/some-cache-dir', '/some-bundle-path')
         first_resolver_mock.resolve_bundle.assert_called_with('/some-cache-dir', '/some-bundle-path')
@@ -47,7 +47,7 @@ class TestResolver(TestCase):
             self.assertRaises(BundleResolutionError, resolver.resolve_bundle, custom_settings, '/some-cache-dir',
                               '/some-bundle-path')
 
-        resolver_chain_mock.assert_called_with(custom_settings)
+        resolver_chain_mock.assert_called_with(custom_settings, False)
 
         first_resolver_mock.load_from_cache('/some-cache-dir', '/some-bundle-path')
         first_resolver_mock.resolve_bundle.assert_called_with('/some-cache-dir', '/some-bundle-path')
@@ -65,7 +65,7 @@ class TestResolver(TestCase):
             self.assertEqual('bundle_name', bundle_name)
             self.assertEqual('mock bundle_file', bundle_file)
 
-        resolver_chain_mock.assert_called_with(custom_settings)
+        resolver_chain_mock.assert_called_with(custom_settings, False)
 
         first_resolver_mock.load_from_cache('/some-cache-dir', '/some-bundle-path')
 
@@ -180,7 +180,7 @@ class TestResolverChain(TestCase):
         get_logger_mock, log_mock = create_mock_logger()
 
         with patch('logging.getLogger', get_logger_mock):
-            result = resolver.resolver_chain(custom_settings)
+            result = resolver.resolver_chain(custom_settings, False)
             expected_result = [uri_resolver]
             self.assertEqual(expected_result, result)
 
@@ -188,7 +188,7 @@ class TestResolverChain(TestCase):
         log_mock.info.assert_called_with('Using custom bundle resolver chain [\'conductr_cli.resolvers.uri_resolver\']')
 
     def test_none_input(self):
-        result = resolver.resolver_chain(None)
+        result = resolver.resolver_chain(None, False)
         expected_result = [uri_resolver, bintray_resolver]
         self.assertEqual(expected_result, result)
 
@@ -197,6 +197,11 @@ class TestResolverChain(TestCase):
             strip_margin("""|dummy = foo
                             |""")
         )
-        result = resolver.resolver_chain(custom_settings)
+        result = resolver.resolver_chain(custom_settings, False)
         expected_result = [uri_resolver, bintray_resolver]
+        self.assertEqual(expected_result, result)
+
+    def test_offline_mode(self):
+        result = resolver.resolver_chain(None, True)
+        expected_result = [uri_resolver]
         self.assertEqual(expected_result, result)

--- a/conductr_cli/test/test_sandbox_run.py
+++ b/conductr_cli/test/test_sandbox_run.py
@@ -18,6 +18,7 @@ class TestSandboxRunCommand(CliTestCase):
         'image': CONDUCTR_DEV_IMAGE,
         'log_level': 'info',
         'nr_of_containers': 1,
+        'offline_mode': False,
         'ports': [],
         'bundle_http_port': 9000,
         'features': [],

--- a/conductr_cli/test/test_sandbox_run_docker.py
+++ b/conductr_cli/test/test_sandbox_run_docker.py
@@ -135,8 +135,8 @@ class TestRun(CliTestCase):
         nr_of_containers = 1
         ports = [3000, 3001]
         features = [
-            VisualizationFeature(version_args=[], image_version=image_version),
-            LoggingFeature(version_args=[], image_version=image_version)
+            VisualizationFeature(version_args=[], image_version=image_version, offline_mode=False),
+            LoggingFeature(version_args=[], image_version=image_version, offline_mode=False)
         ]
 
         with \


### PR DESCRIPTION
**Issue description**
In the past the `conduct load` command always retrieved the version of a specified bundle name from Bintray. With the resolved version it checked if the bundle is part of the cache directory. As a result, when specifying a bundle name and not a file URI, it was not possible to load a bundle without an internet connection. This especially turned out to be an issue when starting the sandbox with certain features, because the feature logic uses bundle names and not file URIs to load bundle to ConductR.

**Solution description**
This PR introduces a `—ofline` flag for the `conduct load` and `sandbox run` command to enable the offline mode. It is also possible to set the environment variable `CONDUCTR_OFFLINE_MODE=true`. Then the `—offline` flag is not necessary.

If the offline mode is enabled, then:
- The bundle is never retrieved from bintray resolver
- The `load_bundle_from_cache` and `load_bundle_configuration_from_cache` methods are resolving the last modified file for a given bundle name, e.g. visualizer. This logic is only executed if the `conduct load` command specifies a bundle name, e.g. `conduct load visualizer`, not if a file URI is specified, e.g. `conduct load /dir/my-bundle.zip`.

As a result, the sandbox and the conduct load command can be used without an internet connection in case the bundles are part of the cache directory.