### PR TITLE
CLI now supports OpenJDK 8 again

### DIFF
--- a/conductr_cli/sandbox_run_jvm.py
+++ b/conductr_cli/sandbox_run_jvm.py
@@ -22,7 +22,7 @@ NR_OF_INSTANCE_EXPRESSION = '[0-9]+\\:[0-9]+'
 BIND_TEST_PORT = 19991  # The port used for testing if an address can be bound.
 CONDUCTR_AKKA_REMOTING_PORT = 9004  # The port used by ConductR's Akka remoting.
 NR_OF_PROXY_INSTANCE = 1  # Only run 1 instance of ConductR HAProxy since there's only one HAProxy running per machine.
-SUPPORTED_JVM_VENDOR = "java"  # Oracle JVM vendor is `java`.
+SUPPORTED_JVM_VENDOR = ["java", "openjdk"]  # Oracle JVM vendor is `java`, OpenJDK is `openjdk`
 SUPPORTED_JVM_VERSION = (1, 8)  # Supports JVM version 1.8 and above.
 
 
@@ -143,7 +143,8 @@ def instance_count(image_version, instance_expression):
 
 def validate_jvm_support():
     """
-    Validates for the presence of supported JVM (i.e. Oracle JVM 8), else raise an exception to fail the sandbox run.
+    Validates for the presence of supported JVM (i.e. Oracle or OpenJDK JVM 8),
+    else raise an exception to fail the sandbox run.
     """
     try:
         raw_output = subprocess.getoutput('java -version')
@@ -154,7 +155,7 @@ def validate_jvm_support():
             if len(parts) == 3:
                 jvm_vendor = parts[0]
 
-                if jvm_vendor == SUPPORTED_JVM_VENDOR:
+                if jvm_vendor in SUPPORTED_JVM_VENDOR:
                     jvm_version = parts[2].replace('"', '')
                     jvm_version_parts = jvm_version.split('.')
                     if len(jvm_version_parts) >= 2:

--- a/conductr_cli/test/test_sandbox_run_jvm.py
+++ b/conductr_cli/test/test_sandbox_run_jvm.py
@@ -668,7 +668,7 @@ class TestLogRunAttempt(CliTestCase):
 
 
 class TestValidateJvm(CliTestCase):
-    def test_supported(self):
+    def test_supported_oracle(self):
         cmd_output = strip_margin("""|java version "1.8.0_72"
                                      |Java(TM) SE Runtime Environment (build 1.8.0_72-b15)
                                      |Java HotSpot(TM) 64-Bit Server VM (build 25.72-b15, mixed mode)
@@ -680,10 +680,22 @@ class TestValidateJvm(CliTestCase):
 
         mock_getoutput.assert_called_once_with('java -version')
 
+    def test_supported_open_jdk(self):
+        cmd_output = strip_margin("""|openjdk version "1.8.0_111"
+                                     |OpenJDK Runtime Environment (build 1.8.0_111-8u111-b14-3-b14)
+                                     |OpenJDK 64-Bit Server VM (build 25.111-b14, mixed mode)
+                                     |""")
+        mock_getoutput = MagicMock(return_value=cmd_output)
+
+        with patch('subprocess.getoutput', mock_getoutput):
+            sandbox_run_jvm.validate_jvm_support()
+
+        mock_getoutput.assert_called_once_with('java -version')
+
     def test_unsupported_vendor(self):
-        cmd_output = strip_margin("""|openjdk version "1.8.0_66-internal"
-                                     |OpenJDK Runtime Environment (build 1.8.0_66-internal-b17)
-                                     |OpenJDK 64-Bit Server VM (build 25.66-b17, mixed mode)
+        cmd_output = strip_margin("""|unsupported version "1.2.3.4"
+                                     |UnsupportedJDK Runtime Environment (build 1.2.3.4)
+                                     |UnsupportedJDK 64-Bit Server VM (build 1.2.3.4, mixed mode)
                                      |""")
         mock_getoutput = MagicMock(return_value=cmd_output)
 


### PR DESCRIPTION
Changed the vendor check to test a white-list of vendors instead of only supporting Oracle. Per @huntc we should indeed support OpenJDK 8.