### PR TITLE
add ip to sandbox ps

### DIFF
--- a/conductr_cli/sandbox_common.py
+++ b/conductr_cli/sandbox_common.py
@@ -2,6 +2,7 @@ from conductr_cli import terminal
 from conductr_cli.resolvers.bintray_resolver import BINTRAY_CONDUCTR_CORE_PACKAGE_NAME, \
     BINTRAY_CONDUCTR_AGENT_PACKAGE_NAME
 import os
+import re
 import subprocess
 from subprocess import CalledProcessError
 
@@ -38,16 +39,24 @@ def find_pids(core_run_dir, agent_run_dir):
     pids_info = []
     ps_output = subprocess.getoutput('ps ax')
     for line in ps_output.split('\n'):
+        def extract_param(regex, default):
+            try:
+                return re.search(regex, line).group(1)
+            except AttributeError:
+                return default
+
         pid = line.split()[0]
         if core_run_dir in line:
             pids_info.append({
                 'type': 'core',
-                'id': int(pid)
+                'id': int(pid),
+                'ip': extract_param('-Dconductr.ip=(\S+)', '')
             })
         if agent_run_dir in line:
             pids_info.append({
                 'type': 'agent',
-                'id': int(pid)
+                'id': int(pid),
+                'ip': extract_param('-Dconductr.agent.ip=(\S+)', '')
             })
     return pids_info
 

--- a/conductr_cli/sandbox_ps.py
+++ b/conductr_cli/sandbox_ps.py
@@ -18,12 +18,13 @@ def ps(args):
         for row in data:
             log.info(row['id'])
     else:
-        data.insert(0, {'id': 'PID', 'type': 'TYPE'})
+        data.insert(0, {'id': 'PID', 'type': 'TYPE', 'ip': 'IP'})
         padding = 2
         column_widths = dict(screen_utils.calc_column_widths(data), **{'padding': ' ' * padding})
         for row in data:
             log.screen('''\
 {id: <{id_width}}{padding}\
-{type: >{type_width}}'''.format(**dict(row, **column_widths)).rstrip())
+{type: >{type_width}}{padding}\
+{ip: >{ip_width}}'''.format(**dict(row, **column_widths)).rstrip())
 
     return True

--- a/conductr_cli/test/test_sandbox_common.py
+++ b/conductr_cli/test/test_sandbox_common.py
@@ -34,12 +34,12 @@ class TestFindPids(CliTestCase):
         with patch('subprocess.getoutput', mock_getoutput):
             result = sandbox_common.find_pids(self.core_run_dir, self.agent_run_dir)
             self.assertEqual([
-                {'id': 58002, 'type': 'core'},
-                {'id': 58003, 'type': 'agent'},
-                {'id': 58004, 'type': 'core'},
-                {'id': 58005, 'type': 'agent'},
-                {'id': 58006, 'type': 'core'},
-                {'id': 58007, 'type': 'agent'}
+                {'id': 58002, 'type': 'core', 'ip': '192.168.10.1'},
+                {'id': 58003, 'type': 'agent', 'ip': '192.168.10.1'},
+                {'id': 58004, 'type': 'core', 'ip': '192.168.10.2'},
+                {'id': 58005, 'type': 'agent', 'ip': '192.168.10.2'},
+                {'id': 58006, 'type': 'core', 'ip': '192.168.10.3'},
+                {'id': 58007, 'type': 'agent', 'ip': '192.168.10.3'}
             ], result)
 
     def test_no_pids(self):

--- a/conductr_cli/test/test_sandbox_ps.py
+++ b/conductr_cli/test/test_sandbox_ps.py
@@ -19,8 +19,8 @@ class TestSandboxPs(CliTestCase):
     }
 
     pid_infos = [
-        {'id': 58002, 'type': 'core'},
-        {'id': 58003, 'type': 'agent'}
+        {'id': 58002, 'type': 'core', 'ip': '192.168.10.1'},
+        {'id': 58003, 'type': 'agent', 'ip': '192.168.10.1'}
     ]
 
     default_args = {
@@ -46,9 +46,9 @@ class TestSandboxPs(CliTestCase):
         mock_resolve_conductr_info.assert_called_once_with(self.image_dir)
         mock_find_pids.assert_called_once_with(self.core_extraction_dir, self.agent_extraction_dir)
 
-        expected_output = strip_margin("""|PID     TYPE
-                                          |58002   core
-                                          |58003  agent
+        expected_output = strip_margin("""|PID     TYPE            IP
+                                          |58002   core  192.168.10.1
+                                          |58003  agent  192.168.10.1
                                           |""")
         self.assertEqual(expected_output, self.output(stdout))
 
@@ -97,8 +97,8 @@ class TestSandboxPs(CliTestCase):
         mock_resolve_conductr_info.assert_called_once_with(self.image_dir)
         mock_find_pids.assert_called_once_with(self.core_extraction_dir, self.agent_extraction_dir)
 
-        expected_output = strip_margin("""|PID    TYPE
-                                          |58002  core
+        expected_output = strip_margin("""|PID    TYPE            IP
+                                          |58002  core  192.168.10.1
                                           |""")
         self.assertEqual(expected_output, self.output(stdout))
 
@@ -147,8 +147,8 @@ class TestSandboxPs(CliTestCase):
         mock_resolve_conductr_info.assert_called_once_with(self.image_dir)
         mock_find_pids.assert_called_once_with(self.core_extraction_dir, self.agent_extraction_dir)
 
-        expected_output = strip_margin("""|PID     TYPE
-                                          |58003  agent
+        expected_output = strip_margin("""|PID     TYPE            IP
+                                          |58003  agent  192.168.10.1
                                           |""")
         self.assertEqual(expected_output, self.output(stdout))
 


### PR DESCRIPTION
Adds `IP` to `sandbox ps`. This is extracted from `ps aux` output by testing for `-Dconductr.ip` and `-Dconductr.agent.ip`.