### PR TITLE
Fix sandbox image not found error

### DIFF
--- a/conductr_cli/validation.py
+++ b/conductr_cli/validation.py
@@ -255,7 +255,7 @@ def handle_sandbox_image_not_found_error(func):
             return func(*args, **kwargs)
         except SandboxImageNotFoundError as e:
             log = get_logger_for_func(func)
-            log.error('ConductR {} artefact {} cannot be found on Bintray.'.format(e.component_type, e.artefact_name))
+            log.error('ConductR {} artifact {} cannot be found on Bintray.'.format(e.component_type, e.image_version))
             log.error('Please specify a valid ConductR version.')
             log.error('The latest version can be found on: https://www.lightbend.com/product/conductr/developer')
             return False


### PR DESCRIPTION
When running the sandbox with an invalid version an expcetion was thrown to the user:

```
$ sandbox run 2.0.0
|------------------------------------------------|
| Starting ConductR                              |
|------------------------------------------------|
Bintray credentials loaded from /Users/mj/.lightbend/commercial.credentials
Error: Encountered unexpected error.
Error: Reason: AttributeError 'SandboxImageNotFoundError' object has no attribute 'artefact_name'
Error: Further information of the error can be found in the error log file: /Users/mj/.conductr/errors.log
```

This occurred because the validation logic was broken. With this PR the correct error message is displayed:

```
$ sandbox run 2.0.0
|------------------------------------------------|
| Starting ConductR                              |
|------------------------------------------------|
Bintray credentials loaded from /Users/mj/.lightbend/commercial.credentials
Error: ConductR core artifact 2.0.0 cannot be found on Bintray.
Error: Please specify a valid ConductR version.
Error: The latest version can be found on: https://www.lightbend.com/product/conductr/developer
```