### PR TITLE
Correct message wording when version not specified

### DIFF
--- a/conductr_cli/sandbox_main.py
+++ b/conductr_cli/sandbox_main.py
@@ -180,7 +180,7 @@ def run():
         parser.print_help()
     # Validate image_version
     elif vars(args).get('func').__name__ == 'run' and not args.image_version:
-        parser.exit('The version of the ConductR Docker image must be set.\n'
+        parser.exit('The version of ConductR need to be set.\n'
                     'Please visit https://www.lightbend.com/product/conductr/developer '
                     'to obtain the current version information.')
     # Call sandbox function


### PR DESCRIPTION
Correct message wording when ConductR version not specified with the `sandbox run` command:

**Before**

```
The version of the ConductR Docker image must be set.
Please visit https://www.lightbend.com/product/conductr/developer to obtain the current version information.
```

**Now**

```
The version of ConductR need to be set.
Please visit https://www.lightbend.com/product/conductr/developer to obtain the current version information.
```