### PR TITLE
Default to 1 core instance

### DIFF
--- a/conductr_cli/sandbox_main.py
+++ b/conductr_cli/sandbox_main.py
@@ -67,13 +67,18 @@ def build_parser():
                                  'Available log levels: ' + ', '.join(log_levels),
                             choices=log_levels,
                             metavar='')
-    run_parser.add_argument('-n', '--nr-of-containers',
-                            type=nr_of_containers,
+    run_parser.add_argument('-n', '--nr-of-containers', '--nr-of-instances',
+                            type=nr_of_instances,
                             default='1',
+                            dest='nr_of_instances',
                             help='Number of ConductR core and agent instances. Defaults to 1.\n'
                                  'Also accepts `x:y` format: `x` is a number of core instances, '
                                  'and y is a number of agent instances\n'
-                                 'For ConductR 1, this corresponds to the number of nodes.',
+                                 'If a number instead of the `x:y` format is specified, then the value correlates '
+                                 'to the number of agent instances.\n'
+                                 'The core instance will then be 1.\n'
+                                 'Example: -n 3 converts to -n 1:3\n'
+                                 'For ConductR 1.x, this corresponds to the number of nodes.',
                             metavar='')
     run_parser.add_argument('--offline',
                             default=DEFAULT_OFFLINE_MODE,
@@ -208,7 +213,7 @@ def run():
             exit(1)
 
 
-def nr_of_containers(value):
+def nr_of_instances(value):
     try:
         # Ensure value can be converted into an integer
         int(value)

--- a/conductr_cli/sandbox_run_docker.py
+++ b/conductr_cli/sandbox_run_docker.py
@@ -23,7 +23,7 @@ class SandboxRunResult:
 
 
 def run(args, features):
-    nr_of_containers = instance_count(args.image_version, args.nr_of_containers)
+    nr_of_containers = instance_count(args.image_version, args.nr_of_instances)
     pull_image(args)
     container_names = scale_cluster(args, nr_of_containers, features)
     return SandboxRunResult(container_names, host.DOCKER_IP)

--- a/conductr_cli/sandbox_run_jvm.py
+++ b/conductr_cli/sandbox_run_jvm.py
@@ -53,7 +53,7 @@ def run(args, features):
                      This is only relevant for Docker based sandbox since the features decides what port to expose
     :return: SandboxRunResult
     """
-    nr_of_core_instances, nr_of_agent_instances = instance_count(args.image_version, args.nr_of_containers)
+    nr_of_core_instances, nr_of_agent_instances = instance_count(args.image_version, args.nr_of_instances)
 
     validate_jvm_support()
 
@@ -121,7 +121,7 @@ def instance_count(image_version, instance_expression):
     """
     Parses the instance expressions into number of core and agent instances, i.e.
 
-    The expression `2` translates to 2 core instances and 2 agent instances.
+    The expression `2` translates to 1 core instance and 2 agent instances.
     The expression `2:3` translates to 2 core instances and 3 agent instances.
 
     :param image_version:
@@ -130,7 +130,7 @@ def instance_count(image_version, instance_expression):
     """
     try:
         nr_of_instances = int(instance_expression)
-        return nr_of_instances, nr_of_instances
+        return 1, nr_of_instances
     except ValueError:
         match = re.search(NR_OF_INSTANCE_EXPRESSION, instance_expression)
         if match:

--- a/conductr_cli/test/test_sandbox_main.py
+++ b/conductr_cli/test/test_sandbox_main.py
@@ -19,7 +19,7 @@ class TestSandbox(CliTestCase):
         self.assertEqual(args.envs, [])
         self.assertEqual(args.image, CONDUCTR_DEV_IMAGE)
         self.assertEqual(args.log_level, 'info')
-        self.assertEqual(args.nr_of_containers, '1')
+        self.assertEqual(args.nr_of_instances, '1')
         self.assertEqual(args.ports, [])
         self.assertEqual(args.features, [])
         self.assertEqual(args.local_connection, True)
@@ -45,7 +45,7 @@ class TestSandbox(CliTestCase):
         self.assertEqual(args.envs, ['env1', 'env2'])
         self.assertEqual(args.image, 'my-image')
         self.assertEqual(args.log_level, 'debug')
-        self.assertEqual(args.nr_of_containers, '5')
+        self.assertEqual(args.nr_of_instances, '5')
         self.assertEqual(args.ports, [1000, 1001])
         self.assertEqual(args.features, [['visualization'], ['logging'], ['monitoring', '2.1.0']])
         self.assertEqual(args.local_connection, True)
@@ -70,7 +70,7 @@ class TestSandbox(CliTestCase):
         self.assertEqual(args.envs, ['env1', 'env2'])
         self.assertEqual(args.image, 'my-image')
         self.assertEqual(args.log_level, 'debug')
-        self.assertEqual(args.nr_of_containers, '5:3')
+        self.assertEqual(args.nr_of_instances, '5:3')
         self.assertEqual(args.ports, [1000, 1001])
         self.assertEqual(args.features, [['visualization'], ['logging'], ['monitoring', '2.1.0']])
         self.assertEqual(args.local_connection, True)
@@ -115,13 +115,13 @@ class TestSandbox(CliTestCase):
 
 class TestValidation(CliTestCase):
     def test_nr_of_instances_valid_int(self):
-        self.assertEqual('1', sandbox_main.nr_of_containers('1'))
+        self.assertEqual('1', sandbox_main.nr_of_instances('1'))
 
     def test_nr_of_instances_valid_expression(self):
-        self.assertEqual('1:3', sandbox_main.nr_of_containers('1:3'))
+        self.assertEqual('1:3', sandbox_main.nr_of_instances('1:3'))
 
     def test_nr_of_instances_invalid(self):
-        self.assertRaises(argparse.ArgumentTypeError, sandbox_main.nr_of_containers, 'FOO')
+        self.assertRaises(argparse.ArgumentTypeError, sandbox_main.nr_of_instances, 'FOO')
 
     def test_addr_range_valid(self):
         self.assertEqual(ipaddress.ip_network('192.168.1.0/24', strict=True), sandbox_main.addr_range('192.168.1.0/24'))

--- a/conductr_cli/test/test_sandbox_run_docker.py
+++ b/conductr_cli/test/test_sandbox_run_docker.py
@@ -69,7 +69,7 @@ class TestRun(CliTestCase):
 
     def test_multiple_container(self):
         stdout = MagicMock()
-        nr_of_containers = 3
+        nr_of_instances = 3
 
         with \
                 patch('conductr_cli.terminal.docker_images', return_value='some-image'), \
@@ -79,7 +79,7 @@ class TestRun(CliTestCase):
                 patch('conductr_cli.sandbox_proxy.stop_proxy') as mock_stop_proxy, \
                 patch('conductr_cli.sandbox_common.resolve_running_docker_containers', return_value=[]):
             args = self.default_args.copy()
-            args.update({'nr_of_containers': nr_of_containers})
+            args.update({'nr_of_instances': nr_of_instances})
             input_args = MagicMock(**args)
             logging_setup.configure_logging(input_args, stdout)
             features = []
@@ -184,7 +184,7 @@ class TestRun(CliTestCase):
 
     def test_roles(self):
         stdout = MagicMock()
-        nr_of_containers = 3
+        nr_of_instances = 3
         conductr_roles = [['role1', 'role2'], ['role3']]
         features = []
 
@@ -197,7 +197,7 @@ class TestRun(CliTestCase):
                 patch('conductr_cli.sandbox_common.resolve_running_docker_containers', return_value=[]):
             args = self.default_args.copy()
             args.update({
-                'nr_of_containers': nr_of_containers,
+                'nr_of_instances': nr_of_instances,
                 'conductr_roles': conductr_roles
             })
             input_args = MagicMock(**args)
@@ -316,10 +316,10 @@ class TestRun(CliTestCase):
                                                 expected_image, expected_positional_args)
         mock_stop_proxy.assert_called_once_with()
 
-    def test_invalid_nr_of_containers(self):
+    def test_invalid_nr_of_instances(self):
         args = self.default_args.copy()
         args.update({
-            'nr_of_containers': 'FOO'
+            'nr_of_instances': 'FOO'
         })
         input_args = MagicMock(**args)
         features = []

--- a/conductr_cli/test/test_sandbox_run_jvm.py
+++ b/conductr_cli/test/test_sandbox_run_jvm.py
@@ -90,7 +90,7 @@ class TestRun(CliTestCase):
 
         args = self.default_args.copy()
         args.update({
-            'nr_of_containers': '1:3'
+            'nr_of_instances': '1:3'
         })
         input_args = MagicMock(**args)
         features = []
@@ -174,15 +174,20 @@ class TestRun(CliTestCase):
                                                       features,
                                                       'info')
 
-    def test_invalid_nr_of_containers(self):
-        args = self.default_args.copy()
-        args.update({
-            'nr_of_containers': 'FOO'
-        })
-        input_args = MagicMock(**args)
-        features = []
 
-        self.assertRaises(InstanceCountError, sandbox_run_jvm.run, input_args, features)
+class TestInstanceCount(CliTestCase):
+    def test_x_y_format(self):
+        nr_of_core_instances, nr_of_agent_instances = sandbox_run_jvm.instance_count(2, '2:3')
+        self.assertEqual(nr_of_core_instances, 2)
+        self.assertEqual(nr_of_agent_instances, 3)
+
+    def test_number_format(self):
+        nr_of_core_instances, nr_of_agent_instances = sandbox_run_jvm.instance_count(2, '5')
+        self.assertEqual(nr_of_core_instances, 1)
+        self.assertEqual(nr_of_agent_instances, 5)
+
+    def test_invalid_format(self):
+        self.assertRaises(InstanceCountError, sandbox_run_jvm.instance_count, 2, 'FOO')
 
 
 class TestFindBindAddresses(CliTestCase):


### PR DESCRIPTION
With the sandbox run command it is possible to specify the `nr_of_instances`. When the number format was used, e.g. `-n 3` then prior to this PR 3 core and agent instances were started. Now, only 1 core instance and 3 agent instances are started.

This PR also adds an additional alias `nr-of-instances` to the existing `nr-of-containers` and `-n` arguments to specify the number of core and agent instances. Internally, we are using now the `args.nr_of_instances` arg instead of `args.nr_of_containers`.