### PR TITLE
Relax the Docker checks

### DIFF
--- a/conductr_cli/docker.py
+++ b/conductr_cli/docker.py
@@ -5,8 +5,8 @@ from conductr_cli import terminal
 from conductr_cli.exceptions import DockerValidationError
 from subprocess import CalledProcessError
 
-DEFAULT_DOCKER_RAM_SIZE = 3.8
-DEFAULT_DOCKER_CPU_COUNT = 4
+DEFAULT_DOCKER_RAM_SIZE = 1.9
+DEFAULT_DOCKER_CPU_COUNT = 2
 
 
 class DockerVmType:

--- a/conductr_cli/test/test_docker.py
+++ b/conductr_cli/test/test_docker.py
@@ -40,7 +40,7 @@ class TestDocker(CliTestCase):
 
     def test_docker_insufficient_cpu(self):
         stdout_mock = MagicMock()
-        docker_info_mock = MagicMock(return_value=b'\nTotal Memory: 3.8 GiB\nCPUs: 3')
+        docker_info_mock = MagicMock(return_value=b'\nTotal Memory: 3.8 GiB\nCPUs: 1')
 
         logging_setup.configure_logging(MagicMock(), output=stdout_mock)
 
@@ -49,7 +49,7 @@ class TestDocker(CliTestCase):
 
         docker_info_mock.assert_called_with()
         self.assertEqual(
-            as_warn('Warning: Docker has an insufficient no. of CPUs 3 - please increase to a minimum of 4 CPUs\n'),
+            as_warn('Warning: Docker has an insufficient no. of CPUs 1 - please increase to a minimum of 2 CPUs\n'),
             self.output(stdout_mock))
 
     def test_docker_sufficient_ram_and_cpu(self):


### PR DESCRIPTION
The Docker checks now check for the defaults that Docker on OS X comes with... which turns out now to be more than sufficient. Having started all of ConductR features, including monitoring, there is plenty of memory left over from 2GiB.