### PR TITLE
Wait longer for Docker based features

### DIFF
--- a/conductr_cli/sandbox_features.py
+++ b/conductr_cli/sandbox_features.py
@@ -124,7 +124,7 @@ class LoggingFeature:
             kibana_load_command = ['load', kibana['bundle'], '--disable-instructions'] + \
                 parse_offline_mode_arg(self.offline_mode)
             conduct_main.run(kibana_load_command, configure_logging=False)
-            conduct_main.run(['run', kibana['name'], '--disable-instructions'], configure_logging=False)
+            conduct_main.run(['run', kibana['name'], '--disable-instructions', '--wait-timeout', '600'], configure_logging=False)
 
 
 class LiteLoggingFeature:
@@ -220,7 +220,7 @@ class MonitoringFeature:
         load_command = ['load', grafana['bundle'], '--disable-instructions'] + \
             parse_offline_mode_arg(self.offline_mode)
         conduct_main.run(load_command, configure_logging=False)
-        conduct_main.run(['run', grafana['name'], '--disable-instructions'], configure_logging=False)
+        conduct_main.run(['run', grafana['name'], '--disable-instructions', '--wait-timeout', '600'], configure_logging=False)
 
 
 feature_classes = [VisualizationFeature, LoggingFeature, LiteLoggingFeature, MonitoringFeature]

--- a/conductr_cli/test/test_sandbox_features.py
+++ b/conductr_cli/test/test_sandbox_features.py
@@ -105,7 +105,7 @@ class TestLoggingFeature(TestCase):
             call(['load', 'conductr-elasticsearch', '--disable-instructions'], configure_logging=False),
             call(['run', 'conductr-elasticsearch', '--disable-instructions'], configure_logging=False),
             call(['load', 'conductr-kibana', '--disable-instructions'], configure_logging=False),
-            call(['run', 'conductr-kibana', '--disable-instructions'], configure_logging=False)
+            call(['run', 'conductr-kibana', '--disable-instructions', '--wait-timeout', '600'], configure_logging=False)
         ])
 
     def test_start_v2_docker_validation_failed(self):
@@ -135,7 +135,7 @@ class TestLoggingFeature(TestCase):
             call(['load', 'conductr-elasticsearch', '--disable-instructions', '--offline'], configure_logging=False),
             call(['run', 'conductr-elasticsearch', '--disable-instructions'], configure_logging=False),
             call(['load', 'conductr-kibana', '--disable-instructions', '--offline'], configure_logging=False),
-            call(['run', 'conductr-kibana', '--disable-instructions'], configure_logging=False)
+            call(['run', 'conductr-kibana', '--disable-instructions', '--wait-timeout', '600'], configure_logging=False)
         ])
 
 
@@ -180,7 +180,7 @@ class TestMonitoringFeature(TestCase):
 
         self.assertEqual(run_mock.call_args_list, [
             call(['load', 'cinnamon-grafana', '--disable-instructions'], configure_logging=False),
-            call(['run', 'cinnamon-grafana', '--disable-instructions'], configure_logging=False)
+            call(['run', 'cinnamon-grafana', '--disable-instructions', '--wait-timeout', '600'], configure_logging=False)
         ])
 
     def test_start_v2(self):
@@ -191,7 +191,7 @@ class TestMonitoringFeature(TestCase):
 
         self.assertEqual(run_mock.call_args_list, [
             call(['load', 'cinnamon-grafana-docker', '--disable-instructions'], configure_logging=False),
-            call(['run', 'cinnamon-grafana-docker', '--disable-instructions'], configure_logging=False)
+            call(['run', 'cinnamon-grafana-docker', '--disable-instructions', '--wait-timeout', '600'], configure_logging=False)
         ])
 
     def test_start_offline_mode(self):
@@ -202,5 +202,5 @@ class TestMonitoringFeature(TestCase):
 
         self.assertEqual(run_mock.call_args_list, [
             call(['load', 'cinnamon-grafana-docker', '--disable-instructions', '--offline'], configure_logging=False),
-            call(['run', 'cinnamon-grafana-docker', '--disable-instructions'], configure_logging=False)
+            call(['run', 'cinnamon-grafana-docker', '--disable-instructions', '--wait-timeout', '600'], configure_logging=False)
         ])


### PR DESCRIPTION
Docker based features can take more than a minute to download. Waiting for 10 minutes is inline with ConductR core itself and appears to be a nicer default for them...