### PR TITLE
implement `sandbox logs`

### DIFF
--- a/conductr_cli/sandbox_logs.py
+++ b/conductr_cli/sandbox_logs.py
@@ -1,5 +1,6 @@
 import os
 
+
 def logs_args(args):
     core_log = os.path.abspath('{}/core/logs/conductr.log'.format(args.image_dir))
     agent_log = os.path.abspath('{}/agent/logs/conductr-agent.log'.format(args.image_dir))
@@ -19,6 +20,7 @@ def logs_args(args):
     tail_args.append(agent_log)
 
     return tail_args
+
 
 def logs(args):
     os.execv('/usr/bin/env', logs_args(args))

--- a/conductr_cli/sandbox_logs.py
+++ b/conductr_cli/sandbox_logs.py
@@ -1,0 +1,24 @@
+import os
+
+def logs_args(args):
+    core_log = os.path.abspath('{}/core/logs/conductr.log'.format(args.image_dir))
+    agent_log = os.path.abspath('{}/agent/logs/conductr-agent.log'.format(args.image_dir))
+
+    tail_args = ['/usr/bin/env', 'tail', '-q']
+
+    if args.follow:
+        tail_args.append('-f')
+        tail_args.append('--follow=name')
+        tail_args.append('--retry')
+
+    if args.lines:
+        tail_args.append('-n')
+        tail_args.append(str(args.lines))
+
+    tail_args.append(core_log)
+    tail_args.append(agent_log)
+
+    return tail_args
+
+def logs(args):
+    os.execv('/usr/bin/env', logs_args(args))

--- a/conductr_cli/sandbox_main.py
+++ b/conductr_cli/sandbox_main.py
@@ -5,7 +5,7 @@ import re
 from conductr_cli.sandbox_common import CONDUCTR_DEV_IMAGE, major_version
 from conductr_cli.sandbox_features import feature_names
 from conductr_cli.constants import DEFAULT_SANDBOX_ADDR_RANGE, DEFAULT_SANDBOX_IMAGE_DIR, DEFAULT_OFFLINE_MODE
-from conductr_cli import sandbox_run, sandbox_stop, sandbox_common, sandbox_ps, logging_setup, docker, version
+from conductr_cli import sandbox_run, sandbox_stop, sandbox_common, sandbox_logs, sandbox_ps, logging_setup, docker, version
 from conductr_cli.sandbox_run_jvm import NR_OF_INSTANCE_EXPRESSION
 
 
@@ -61,9 +61,7 @@ def build_parser():
                             default='info',
                             help='Log level of ConductR.\n'
                                  'Defaults to `info`.\n'
-                                 'You can observe ConductRs logging via the `docker logs` command. \n'
-                                 'For example `docker logs -f cond-0` will follow the logs of the first '
-                                 'ConductR container.\n'
+                                 'ConductR logs can be inspected via the `sandbox logs` command.\n'
                                  'Available log levels: ' + ', '.join(log_levels),
                             choices=log_levels,
                             metavar='')
@@ -149,6 +147,23 @@ def build_parser():
                            dest='is_quiet',
                            action='store_true')
     ps_parser.set_defaults(func=sandbox_ps.ps)
+
+    # Sub-parser for `logs` sub-command
+    logs_parser = subparsers.add_parser('logs',
+                                        help='Fetches the logs of ConductR core and agent processes')
+    add_image_dir(logs_parser)
+    add_default_arguments(logs_parser)
+    logs_parser.add_argument('-f', '--follow',
+                             help='Output appended as the log files grow',
+                             default=False,
+                             dest='follow',
+                             action='store_true')
+    logs_parser.add_argument('-n', '--lines',
+                             help='Output the last NUM lines (default 10)',
+                             default=10,
+                             type=int,
+                             dest='lines')
+    logs_parser.set_defaults(func=sandbox_logs.logs)
 
     return parser
 

--- a/conductr_cli/test/test_sandbox_common.py
+++ b/conductr_cli/test/test_sandbox_common.py
@@ -20,37 +20,36 @@ class TestFindPids(CliTestCase):
     agent_run_dir = '{}/agent'.format(image_dir)
 
     def test_pids_found(self):
-        ps_output = '58001   ??  Ss     0:36.97 /sbin/launchd\n' \
-                    '58002   ??  Ss     0:30.48 /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java -Dconductr.ip=192.168.10.1 -cp /Users/mj/.conductr/images/core/lib/com.typesafe.conductr.conductr-2.0.0-rc.2.jar:/dependent-libs com.typesafe.conductr.ConductR\n' \
-                    '58003   ??  Ss     1:17.36 /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java -Dconductr.agent.ip=192.168.10.1 -cp /Users/mj/.conductr/images/agent/lib/com.typesafe.conductr.conductr-agent-2.0.0-rc.2.jar:/dependent-libs com.typesafe.conductr.agent.ConductRAgent --core-node 192.168.10.1:9004\n' \
-                    '58004   ??  Ss     0:30.48 /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java -Dconductr.ip=192.168.10.2 -cp /Users/mj/.conductr/images/core/lib/com.typesafe.conductr.conductr-2.0.0-rc.2.jar:/dependent-libs com.typesafe.conductr.ConductR\n' \
-                    '58005   ??  Ss     1:17.36 /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java -Dconductr.agent.ip=192.168.10.2 -cp /Users/mj/.conductr/images/agent/lib/com.typesafe.conductr.conductr-agent-2.0.0-rc.2.jar:/dependent-libs com.typesafe.conductr.agent.ConductRAgent --core-node 192.168.10.2:9004\n' \
-                    '58006   ??  Ss     0:30.48 /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java -Dconductr.ip=192.168.10.3 -cp /Users/mj/.conductr/images/core/lib/com.typesafe.conductr.conductr-2.0.0-rc.2.jar:/dependent-libs com.typesafe.conductr.ConductR\n' \
-                    '58007   ??  Ss     1:17.36 /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java -Dconductr.agent.ip=192.168.10.3 -cp /Users/mj/.conductr/images/agent/lib/com.typesafe.conductr.conductr-agent-2.0.0-rc.2.jar:/dependent-libs com.typesafe.conductr.agent.ConductRAgent --core-node 192.168.10.3:9004\n' \
-                    '58008   ??  Ss     0:36.97 /usr/libexec/logd'
+        ps = [
+            {'pid': 58001, 'name': 'launchd', 'cmdline': ['/sbin/launchd']},
+            {'pid': 58002, 'name': 'java', 'cmdline': ['/Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java', '-Dconductr.ip=192.168.10.1', '-cp', '/Users/mj/.conductr/images/core/lib/com.typesafe.conductr.conductr-2.0.0-rc.2.jar:/dependent-libs', 'com.typesafe.conductr.ConductR']},
+            {'pid': 58003, 'name': 'java', 'cmdline': ['/Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java', '-Dconductr.agent.ip=192.168.10.1', '-cp', '/Users/mj/.conductr/images/agent/lib/com.typesafe.conductr.conductr-agent-2.0.0-rc.2.jar:/dependent-libs', 'com.typesafe.conductr.agent.ConductRAgent', '--core-node', '192.168.10.1:9004']},
+            {'pid': 58004, 'name': 'java', 'cmdline': ['/Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java', '-Dconductr.ip=192.168.10.2', '-cp', '/Users/mj/.conductr/images/core/lib/com.typesafe.conductr.conductr-2.0.0-rc.2.jar:/dependent-libs', 'com.typesafe.conductr.ConductR']},
+            {'pid': 58005, 'name': 'java', 'cmdline': ['/Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java', '-Dconductr.agent.ip=192.168.10.2', '-cp', '/Users/mj/.conductr/images/agent/lib/com.typesafe.conductr.conductr-agent-2.0.0-rc.2.jar:/dependent-libs', 'com.typesafe.conductr.agent.ConductRAgent', '--core-node', '192.168.10.2:9004']},
+            {'pid': 58006, 'name': 'java', 'cmdline': ['/Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java', '-Dconductr.ip=192.168.10.3', '-cp', '/Users/mj/.conductr/images/core/lib/com.typesafe.conductr.conductr-2.0.0-rc.2.jar:/dependent-libs', 'com.typesafe.conductr.ConductR']},
+            {'pid': 58007, 'name': 'java', 'cmdline': ['/Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java', '-Dconductr.agent.ip=192.168.10.3', '-cp', '/Users/mj/.conductr/images/agent/lib/com.typesafe.conductr.conductr-agent-2.0.0-rc.2.jar:/dependent-libs', 'com.typesafe.conductr.agent.ConductRAgent', '--core-node', '192.168.10.3:9004']},
+            {'pid': 58008, 'name': 'logd', 'cmdline': ['/usr/libexec/logd']}
+        ]
 
-        mock_getoutput = MagicMock(return_value=ps_output)
+        result = sandbox_common.calculate_pids(self.core_run_dir, self.agent_run_dir, ps)
 
-        with patch('subprocess.getoutput', mock_getoutput):
-            result = sandbox_common.find_pids(self.core_run_dir, self.agent_run_dir)
-            self.assertEqual([
-                {'id': 58002, 'type': 'core', 'ip': '192.168.10.1'},
-                {'id': 58003, 'type': 'agent', 'ip': '192.168.10.1'},
-                {'id': 58004, 'type': 'core', 'ip': '192.168.10.2'},
-                {'id': 58005, 'type': 'agent', 'ip': '192.168.10.2'},
-                {'id': 58006, 'type': 'core', 'ip': '192.168.10.3'},
-                {'id': 58007, 'type': 'agent', 'ip': '192.168.10.3'}
-            ], result)
+        self.assertEqual([
+            {'id': 58002, 'type': 'core', 'ip': '192.168.10.1'},
+            {'id': 58003, 'type': 'agent', 'ip': '192.168.10.1'},
+            {'id': 58004, 'type': 'core', 'ip': '192.168.10.2'},
+            {'id': 58005, 'type': 'agent', 'ip': '192.168.10.2'},
+            {'id': 58006, 'type': 'core', 'ip': '192.168.10.3'},
+            {'id': 58007, 'type': 'agent', 'ip': '192.168.10.3'}
+        ], result)
 
     def test_no_pids(self):
-        ps_output = '58001   ??  Ss     0:36.97 /sbin/launchd\n' \
-                    '58008   ??  Ss     0:36.97 /usr/libexec/logd'
+        ps = [
+            {'pid': 58001, 'name': 'launchd', 'cmdline': ['/sbin/launchd']},
+            {'pid': 58008, 'name': 'logd', 'cmdline': ['/usr/libexec/logd']}
+        ]
 
-        mock_getoutput = MagicMock(return_value=ps_output)
-
-        with patch('subprocess.getoutput', mock_getoutput):
-            result = sandbox_common.find_pids(self.core_run_dir, self.agent_run_dir)
-            self.assertEqual([], result)
+        result = sandbox_common.calculate_pids(self.core_run_dir, self.agent_run_dir, ps)
+        self.assertEqual([], result)
 
 
 class TestResolveConductRRolesByInstance(CliTestCase):

--- a/conductr_cli/test/test_sandbox_logs.py
+++ b/conductr_cli/test/test_sandbox_logs.py
@@ -2,6 +2,7 @@ from conductr_cli.test.cli_test_case import CliTestCase
 from conductr_cli import sandbox_logs
 from unittest.mock import MagicMock
 
+
 class TestSandboxLogs(CliTestCase):
     def test_tail_args_built(self):
         self.assertEqual(
@@ -13,7 +14,6 @@ class TestSandboxLogs(CliTestCase):
                 'lines': 15
             }))
         )
-
 
         self.assertEqual(
             ['/usr/bin/env', 'tail', '-q', '-f', '--follow=name', '--retry', '-n', '35', '/some/image/dir/core/logs/conductr.log', '/some/image/dir/agent/logs/conductr-agent.log'],

--- a/conductr_cli/test/test_sandbox_logs.py
+++ b/conductr_cli/test/test_sandbox_logs.py
@@ -1,0 +1,26 @@
+from conductr_cli.test.cli_test_case import CliTestCase
+from conductr_cli import sandbox_logs
+from unittest.mock import MagicMock
+
+class TestSandboxLogs(CliTestCase):
+    def test_tail_args_built(self):
+        self.assertEqual(
+            ['/usr/bin/env', 'tail', '-q', '-n', '15', '/image/dir/core/logs/conductr.log', '/image/dir/agent/logs/conductr-agent.log'],
+
+            sandbox_logs.logs_args(MagicMock(**{
+                'image_dir': '/image/dir',
+                'follow': False,
+                'lines': 15
+            }))
+        )
+
+
+        self.assertEqual(
+            ['/usr/bin/env', 'tail', '-q', '-f', '--follow=name', '--retry', '-n', '35', '/some/image/dir/core/logs/conductr.log', '/some/image/dir/agent/logs/conductr-agent.log'],
+
+            sandbox_logs.logs_args(MagicMock(**{
+                'image_dir': '/some/image/dir',
+                'follow': True,
+                'lines': 35
+            }))
+        )

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ install_requires = [
     'requests>=2.6.0',
     'requests-toolbelt>=0.7.0',
     'argcomplete>=0.8.1',
+    'psutil>=5.0.1, <6.0',
     'pyhocon==0.2.1',
     'arrow>=0.6.0',
     'colorama>=0.3.7',


### PR DESCRIPTION
This adds a `sandbox logs` command that uses `tail` to view the latest core and agent logs and optionally follow them with the provided `-f` argument.

```
~/work/lightbend/conductr-cli#logs-cmd $ sandbox logs --help
usage: sandbox logs [-h] [--image-dir IMAGE_DIR] [-f] [-n LINES]

optional arguments:
  -h, --help            show this help message and exit
  --image-dir IMAGE_DIR
                        Default directory where sandbox images is stored.
  -f, --follow          Output appended as the log files grow
  -n LINES, --lines LINES
                        Output the last NUM lines (default 10)
-> 0

~/work/lightbend/conductr-cli#logs-cmd $ sandbox logs -n 2
2017-01-25T16:25:39Z meddle INFO  RemoteActorRefProvider$RemotingTerminator [sourceThread=conductr-akka.remote.default-remote-dispatcher-7, akkaSource=akka.tcp://conductr@192.168.10.1:9004/system/remoting-terminator, sourceActorSystem=conductr, akkaTimestamp=16:25:39.527UTC] - Remote daemon shut down; proceeding with flushing remote transports.
2017-01-25T16:25:39Z meddle INFO  RemoteActorRefProvider$RemotingTerminator [sourceThread=conductr-akka.remote.default-remote-dispatcher-15, akkaTimestamp=16:25:39.539UTC, akkaSource=akka.tcp://conductr@192.168.10.1:9004/system/remoting-terminator, sourceActorSystem=conductr] - Remoting shut down.
2017-01-25T16:25:39Z meddle INFO  Remoting [sourceThread=conductr-agent-akka.actor.default-dispatcher-4, akkaTimestamp=16:25:39.877UTC, akkaSource=akka.remote.Remoting, sourceActorSystem=conductr-agent] - Remoting shut down
2017-01-25T16:25:39Z meddle INFO  RemoteActorRefProvider$RemotingTerminator [sourceThread=conductr-agent-akka.remote.default-remote-dispatcher-8, akkaTimestamp=16:25:39.877UTC, akkaSource=akka.tcp://conductr-agent@192.168.10.1:2552/system/remoting-terminator, sourceActorSystem=conductr-agent] - Remoting shut down.
-> 0
```