### PR TITLE
Reimplement `sandbox ps` to work using cross-platform library psutil

### DIFF
--- a/conductr_cli/test/test_sandbox_common.py
+++ b/conductr_cli/test/test_sandbox_common.py
@@ -20,37 +20,36 @@ class TestFindPids(CliTestCase):
     agent_run_dir = '{}/agent'.format(image_dir)
 
     def test_pids_found(self):
-        ps_output = '58001   ??  Ss     0:36.97 /sbin/launchd\n' \
-                    '58002   ??  Ss     0:30.48 /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java -Dconductr.ip=192.168.10.1 -cp /Users/mj/.conductr/images/core/lib/com.typesafe.conductr.conductr-2.0.0-rc.2.jar:/dependent-libs com.typesafe.conductr.ConductR\n' \
-                    '58003   ??  Ss     1:17.36 /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java -Dconductr.agent.ip=192.168.10.1 -cp /Users/mj/.conductr/images/agent/lib/com.typesafe.conductr.conductr-agent-2.0.0-rc.2.jar:/dependent-libs com.typesafe.conductr.agent.ConductRAgent --core-node 192.168.10.1:9004\n' \
-                    '58004   ??  Ss     0:30.48 /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java -Dconductr.ip=192.168.10.2 -cp /Users/mj/.conductr/images/core/lib/com.typesafe.conductr.conductr-2.0.0-rc.2.jar:/dependent-libs com.typesafe.conductr.ConductR\n' \
-                    '58005   ??  Ss     1:17.36 /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java -Dconductr.agent.ip=192.168.10.2 -cp /Users/mj/.conductr/images/agent/lib/com.typesafe.conductr.conductr-agent-2.0.0-rc.2.jar:/dependent-libs com.typesafe.conductr.agent.ConductRAgent --core-node 192.168.10.2:9004\n' \
-                    '58006   ??  Ss     0:30.48 /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java -Dconductr.ip=192.168.10.3 -cp /Users/mj/.conductr/images/core/lib/com.typesafe.conductr.conductr-2.0.0-rc.2.jar:/dependent-libs com.typesafe.conductr.ConductR\n' \
-                    '58007   ??  Ss     1:17.36 /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java -Dconductr.agent.ip=192.168.10.3 -cp /Users/mj/.conductr/images/agent/lib/com.typesafe.conductr.conductr-agent-2.0.0-rc.2.jar:/dependent-libs com.typesafe.conductr.agent.ConductRAgent --core-node 192.168.10.3:9004\n' \
-                    '58008   ??  Ss     0:36.97 /usr/libexec/logd'
+        ps = [
+            {'pid': 58001, 'name': 'launchd', 'cmdline': ['/sbin/launchd']},
+            {'pid': 58002, 'name': 'java', 'cmdline': ['/Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java', '-Dconductr.ip=192.168.10.1', '-cp', '/Users/mj/.conductr/images/core/lib/com.typesafe.conductr.conductr-2.0.0-rc.2.jar:/dependent-libs', 'com.typesafe.conductr.ConductR']},
+            {'pid': 58003, 'name': 'java', 'cmdline': ['/Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java', '-Dconductr.agent.ip=192.168.10.1', '-cp', '/Users/mj/.conductr/images/agent/lib/com.typesafe.conductr.conductr-agent-2.0.0-rc.2.jar:/dependent-libs', 'com.typesafe.conductr.agent.ConductRAgent', '--core-node', '192.168.10.1:9004']},
+            {'pid': 58004, 'name': 'java', 'cmdline': ['/Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java', '-Dconductr.ip=192.168.10.2', '-cp', '/Users/mj/.conductr/images/core/lib/com.typesafe.conductr.conductr-2.0.0-rc.2.jar:/dependent-libs', 'com.typesafe.conductr.ConductR']},
+            {'pid': 58005, 'name': 'java', 'cmdline': ['/Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java', '-Dconductr.agent.ip=192.168.10.2', '-cp', '/Users/mj/.conductr/images/agent/lib/com.typesafe.conductr.conductr-agent-2.0.0-rc.2.jar:/dependent-libs', 'com.typesafe.conductr.agent.ConductRAgent', '--core-node', '192.168.10.2:9004']},
+            {'pid': 58006, 'name': 'java', 'cmdline': ['/Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java', '-Dconductr.ip=192.168.10.3', '-cp', '/Users/mj/.conductr/images/core/lib/com.typesafe.conductr.conductr-2.0.0-rc.2.jar:/dependent-libs', 'com.typesafe.conductr.ConductR']},
+            {'pid': 58007, 'name': 'java', 'cmdline': ['/Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/bin/java', '-Dconductr.agent.ip=192.168.10.3', '-cp', '/Users/mj/.conductr/images/agent/lib/com.typesafe.conductr.conductr-agent-2.0.0-rc.2.jar:/dependent-libs', 'com.typesafe.conductr.agent.ConductRAgent', '--core-node', '192.168.10.3:9004']},
+            {'pid': 58008, 'name': 'logd', 'cmdline': ['/usr/libexec/logd']}
+        ]
 
-        mock_getoutput = MagicMock(return_value=ps_output)
+        result = sandbox_common.calculate_pids(self.core_run_dir, self.agent_run_dir, ps)
 
-        with patch('subprocess.getoutput', mock_getoutput):
-            result = sandbox_common.find_pids(self.core_run_dir, self.agent_run_dir)
-            self.assertEqual([
-                {'id': 58002, 'type': 'core', 'ip': '192.168.10.1'},
-                {'id': 58003, 'type': 'agent', 'ip': '192.168.10.1'},
-                {'id': 58004, 'type': 'core', 'ip': '192.168.10.2'},
-                {'id': 58005, 'type': 'agent', 'ip': '192.168.10.2'},
-                {'id': 58006, 'type': 'core', 'ip': '192.168.10.3'},
-                {'id': 58007, 'type': 'agent', 'ip': '192.168.10.3'}
-            ], result)
+        self.assertEqual([
+            {'id': 58002, 'type': 'core', 'ip': '192.168.10.1'},
+            {'id': 58003, 'type': 'agent', 'ip': '192.168.10.1'},
+            {'id': 58004, 'type': 'core', 'ip': '192.168.10.2'},
+            {'id': 58005, 'type': 'agent', 'ip': '192.168.10.2'},
+            {'id': 58006, 'type': 'core', 'ip': '192.168.10.3'},
+            {'id': 58007, 'type': 'agent', 'ip': '192.168.10.3'}
+        ], result)
 
     def test_no_pids(self):
-        ps_output = '58001   ??  Ss     0:36.97 /sbin/launchd\n' \
-                    '58008   ??  Ss     0:36.97 /usr/libexec/logd'
+        ps = [
+            {'pid': 58001, 'name': 'launchd', 'cmdline': ['/sbin/launchd']},
+            {'pid': 58008, 'name': 'logd', 'cmdline': ['/usr/libexec/logd']}
+        ]
 
-        mock_getoutput = MagicMock(return_value=ps_output)
-
-        with patch('subprocess.getoutput', mock_getoutput):
-            result = sandbox_common.find_pids(self.core_run_dir, self.agent_run_dir)
-            self.assertEqual([], result)
+        result = sandbox_common.calculate_pids(self.core_run_dir, self.agent_run_dir, ps)
+        self.assertEqual([], result)
 
 
 class TestResolveConductRRolesByInstance(CliTestCase):

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ install_requires = [
     'requests>=2.6.0',
     'requests-toolbelt>=0.7.0',
     'argcomplete>=0.8.1',
+    'psutil>=5.0.1, <6.0',
     'pyhocon==0.2.1',
     'arrow>=0.6.0',
     'colorama>=0.3.7',


### PR DESCRIPTION
This PR reworks `sandbox ps` to use psutil instead of parsing `ps aux` output. This will allow it to work on non-UNIX environments, e.g. Windows.