### PR TITLE
Implement `sandbox logs` for collecting logs from agent and core processes

### DIFF
--- a/conductr_cli/sandbox_logs.py
+++ b/conductr_cli/sandbox_logs.py
@@ -1,26 +1,113 @@
+import fcntl
 import os
+import sys
+import time
 
-
-def logs_args(args):
-    core_log = os.path.abspath('{}/core/logs/conductr.log'.format(args.image_dir))
-    agent_log = os.path.abspath('{}/agent/logs/conductr-agent.log'.format(args.image_dir))
-
-    tail_args = ['/usr/bin/env', 'tail', '-q']
-
-    if args.follow:
-        tail_args.append('-f')
-        tail_args.append('--follow=name')
-        tail_args.append('--retry')
-
-    if args.lines:
-        tail_args.append('-n')
-        tail_args.append(str(args.lines))
-
-    tail_args.append(core_log)
-    tail_args.append(agent_log)
-
-    return tail_args
+READ_SIZE_KB = 8
+FOLLOW_SLEEP_SECONDS = 0.25
 
 
 def logs(args):
-    os.execv('/usr/bin/env', logs_args(args))
+    return tail(log_files(args), args.follow, sys.stdout, READ_SIZE_KB, FOLLOW_SLEEP_SECONDS)
+
+
+def log_files(args):
+    core_log = os.path.abspath('{}/core/logs/conductr.log'.format(args.image_dir))
+    agent_log = os.path.abspath('{}/agent/logs/conductr-agent.log'.format(args.image_dir))
+
+    return [core_log, agent_log]
+
+
+def tail(paths, follow, print_file, read_size_kb, follow_sleep_seconds):
+    """
+    Reads an array of paths, line-by-line, and sends their contents
+    to `print_file`. If `follow` is enabled, emulates UNIX `tail -F`
+    (follow-by-name) behavior.
+
+    :param paths: array filesystem paths
+    :param follow: boolean whether to follow or not (analogous to tail -F)
+    :param print_file: supplied to print() - must have write(string) method
+    :param read_size_kb: buffer size for read operations
+    :param follow_sleep_seconds: time to wait between polling
+    """
+
+    def empty_file(path):
+        return {'path': p, 'file': False, 'size': 0, 'buffer': ''}
+
+    # opens a path and sets non-blocking flags on it
+    def do_open(path):
+        try:
+            file = open(p, 'r')
+            fd = file.fileno()
+            flag = fcntl.fcntl(fd, fcntl.F_GETFL)
+            fcntl.fcntl(fd, fcntl.F_SETFL, flag | os.O_NONBLOCK)
+
+            return {'path': path, 'file': file, 'size': os.path.getsize(path), 'buffer': ''}
+        except:
+            return empty_file(path)
+
+    def do_read(files):
+        done = True
+
+        for i, f in enumerate(files):
+            try:
+                if not f['file'] or os.path.getsize(f['path']) < f['size']:
+                    f = do_open(f['path'])
+
+                if f['file']:
+                    data = f['file'].read(read_size_kb * 1024)
+
+                    if len(data) > 0:
+                        f['buffer'] += data
+                        done = False
+
+                files[i] = f
+            except:
+                files[i] = empty_file(f['path'])
+
+        return done, files
+
+    def do_output(files):
+        for f in files:
+            if len(f['buffer']) > 0:
+                ends_on_line = f['buffer'][-1] == '\n'
+
+                lines = f['buffer'].splitlines()
+                num_lines = len(lines)
+
+                for i, line in enumerate(lines):
+                    if ends_on_line or i < num_lines - 1:
+                        print(line, file=print_file)
+                        print(line)
+
+                if ends_on_line:
+                    f['buffer'] = ''
+                else:
+                    f['buffer'] = lines[-1]
+
+    # we pass through the entire log files one by one (i.e. not interleaved).
+    # once completed, if following is enabled, interleave files as data is appended
+
+    files = []
+
+    for p in paths:
+        f = do_open(p)
+
+        full_done = False
+
+        while not full_done:
+            full_done, fs = do_read([f])
+
+            f = fs[0]
+
+            do_output([f])
+
+        files.append(f)
+
+    if follow:
+        while True:
+            _, files = do_read(files)
+
+            do_output(files)
+
+            time.sleep(follow_sleep_seconds)

--- a/conductr_cli/sandbox_logs.py
+++ b/conductr_cli/sandbox_logs.py
@@ -1,5 +1,6 @@
 import os
 
+
 def logs_args(args):
     core_log = os.path.abspath('{}/core/logs/conductr.log'.format(args.image_dir))
     agent_log = os.path.abspath('{}/agent/logs/conductr-agent.log'.format(args.image_dir))
@@ -19,6 +20,7 @@ def logs_args(args):
     tail_args.append(agent_log)
 
     return tail_args
+
 
 def logs(args):
     os.execv('/usr/bin/env', logs_args(args))

--- a/conductr_cli/sandbox_logs.py
+++ b/conductr_cli/sandbox_logs.py
@@ -1,0 +1,24 @@
+import os
+
+def logs_args(args):
+    core_log = os.path.abspath('{}/core/logs/conductr.log'.format(args.image_dir))
+    agent_log = os.path.abspath('{}/agent/logs/conductr-agent.log'.format(args.image_dir))
+
+    tail_args = ['/usr/bin/env', 'tail', '-q']
+
+    if args.follow:
+        tail_args.append('-f')
+        tail_args.append('--follow=name')
+        tail_args.append('--retry')
+
+    if args.lines:
+        tail_args.append('-n')
+        tail_args.append(str(args.lines))
+
+    tail_args.append(core_log)
+    tail_args.append(agent_log)
+
+    return tail_args
+
+def logs(args):
+    os.execv('/usr/bin/env', logs_args(args))

--- a/conductr_cli/sandbox_main.py
+++ b/conductr_cli/sandbox_main.py
@@ -158,11 +158,6 @@ def build_parser():
                              default=False,
                              dest='follow',
                              action='store_true')
-    logs_parser.add_argument('-n', '--lines',
-                             help='Output the last NUM lines (default 10)',
-                             default=10,
-                             type=int,
-                             dest='lines')
     logs_parser.set_defaults(func=sandbox_logs.logs)
 
     return parser

--- a/conductr_cli/sandbox_main.py
+++ b/conductr_cli/sandbox_main.py
@@ -5,7 +5,7 @@ import re
 from conductr_cli.sandbox_common import CONDUCTR_DEV_IMAGE, major_version
 from conductr_cli.sandbox_features import feature_names
 from conductr_cli.constants import DEFAULT_SANDBOX_ADDR_RANGE, DEFAULT_SANDBOX_IMAGE_DIR, DEFAULT_OFFLINE_MODE
-from conductr_cli import sandbox_run, sandbox_stop, sandbox_common, sandbox_ps, logging_setup, docker, version
+from conductr_cli import sandbox_run, sandbox_stop, sandbox_common, sandbox_logs, sandbox_ps, logging_setup, docker, version
 from conductr_cli.sandbox_run_jvm import NR_OF_INSTANCE_EXPRESSION
 
 
@@ -61,9 +61,7 @@ def build_parser():
                             default='info',
                             help='Log level of ConductR.\n'
                                  'Defaults to `info`.\n'
-                                 'You can observe ConductRs logging via the `docker logs` command. \n'
-                                 'For example `docker logs -f cond-0` will follow the logs of the first '
-                                 'ConductR container.\n'
+                                 'ConductR logs can be inspected via the `sandbox logs` command.\n'
                                  'Available log levels: ' + ', '.join(log_levels),
                             choices=log_levels,
                             metavar='')
@@ -149,6 +147,23 @@ def build_parser():
                            dest='is_quiet',
                            action='store_true')
     ps_parser.set_defaults(func=sandbox_ps.ps)
+
+    # Sub-parser for `logs` sub-command
+    logs_parser = subparsers.add_parser('logs',
+                                        help='Fetches the logs of ConductR core and agent processes')
+    add_image_dir(logs_parser)
+    add_default_arguments(logs_parser)
+    logs_parser.add_argument('-f', '--follow',
+                             help='Output appended as the log files grow',
+                             default=False,
+                             dest='follow',
+                             action='store_true')
+    logs_parser.add_argument('-n', '--lines',
+                             help='Output the last NUM lines (default 10)',
+                             default=10,
+                             type=int,
+                             dest='lines')
+    logs_parser.set_defaults(func=sandbox_logs.logs)
 
     return parser
 

--- a/conductr_cli/test/test_sandbox_logs.py
+++ b/conductr_cli/test/test_sandbox_logs.py
@@ -2,6 +2,7 @@ from conductr_cli.test.cli_test_case import CliTestCase
 from conductr_cli import sandbox_logs
 from unittest.mock import MagicMock
 
+
 class TestSandboxLogs(CliTestCase):
     def test_tail_args_built(self):
         self.assertEqual(
@@ -13,7 +14,6 @@ class TestSandboxLogs(CliTestCase):
                 'lines': 15
             }))
         )
-
 
         self.assertEqual(
             ['/usr/bin/env', 'tail', '-q', '-f', '--follow=name', '--retry', '-n', '35', '/some/image/dir/core/logs/conductr.log', '/some/image/dir/agent/logs/conductr-agent.log'],

--- a/conductr_cli/test/test_sandbox_logs.py
+++ b/conductr_cli/test/test_sandbox_logs.py
@@ -2,25 +2,35 @@ from conductr_cli.test.cli_test_case import CliTestCase
 from conductr_cli import sandbox_logs
 from unittest.mock import MagicMock
 
+import io
+import tempfile
+
 
 class TestSandboxLogs(CliTestCase):
-    def test_tail_args_built(self):
+    def test_log_files_is_correct(self):
         self.assertEqual(
-            ['/usr/bin/env', 'tail', '-q', '-n', '15', '/image/dir/core/logs/conductr.log', '/image/dir/agent/logs/conductr-agent.log'],
+            ['/image/dir/core/logs/conductr.log', '/image/dir/agent/logs/conductr-agent.log'],
 
-            sandbox_logs.logs_args(MagicMock(**{
-                'image_dir': '/image/dir',
-                'follow': False,
-                'lines': 15
-            }))
+            sandbox_logs.log_files(MagicMock(**{'image_dir': '/image/dir'}))
         )
 
-        self.assertEqual(
-            ['/usr/bin/env', 'tail', '-q', '-f', '--follow=name', '--retry', '-n', '35', '/some/image/dir/core/logs/conductr.log', '/some/image/dir/agent/logs/conductr-agent.log'],
+    def test_tail_reads_files(self):
+        one_fd, one_path = tempfile.mkstemp()
+        two_fd, two_path = tempfile.mkstemp()
 
-            sandbox_logs.logs_args(MagicMock(**{
-                'image_dir': '/some/image/dir',
-                'follow': True,
-                'lines': 35
-            }))
+        one_file = open(one_path, 'w')
+        two_file = open(two_path, 'w')
+
+        output = io.StringIO()
+
+        one_file.write("line 1\nline 2\nline 3\n")
+        one_file.close()
+        two_file.write("line a\nline b\nline c\n")
+        two_file.close()
+
+        sandbox_logs.tail([one_path, two_path], False, output, 8, 0.25)
+
+        self.assertEqual(
+            "line 1\nline 2\nline 3\nline a\nline b\nline c\n",
+            output.getvalue()
         )

--- a/conductr_cli/test/test_sandbox_logs.py
+++ b/conductr_cli/test/test_sandbox_logs.py
@@ -1,0 +1,26 @@
+from conductr_cli.test.cli_test_case import CliTestCase
+from conductr_cli import sandbox_logs
+from unittest.mock import MagicMock
+
+class TestSandboxLogs(CliTestCase):
+    def test_tail_args_built(self):
+        self.assertEqual(
+            ['/usr/bin/env', 'tail', '-q', '-n', '15', '/image/dir/core/logs/conductr.log', '/image/dir/agent/logs/conductr-agent.log'],
+
+            sandbox_logs.logs_args(MagicMock(**{
+                'image_dir': '/image/dir',
+                'follow': False,
+                'lines': 15
+            }))
+        )
+
+
+        self.assertEqual(
+            ['/usr/bin/env', 'tail', '-q', '-f', '--follow=name', '--retry', '-n', '35', '/some/image/dir/core/logs/conductr.log', '/some/image/dir/agent/logs/conductr-agent.log'],
+
+            sandbox_logs.logs_args(MagicMock(**{
+                'image_dir': '/some/image/dir',
+                'follow': True,
+                'lines': 35
+            }))
+        )


### PR DESCRIPTION
This PR introduces a `sandbox logs` command that prints logs from the agent and core processes to stdout. It also contains a `-f` option to optionally follow these logs, in a fashion similar to `tail -F`.

Other open source libraries for implementing this functionality in Python were of questionable quality, hence the home-grown implementation. Notably, they should be able to deal with file deletion and file truncation, of which none appeared to do correctly.