### PR TITLE
Handle Docker validation error during sandbox run

### DIFF
--- a/conductr_cli/sandbox_main.py
+++ b/conductr_cli/sandbox_main.py
@@ -5,7 +5,8 @@ import re
 from conductr_cli.sandbox_common import CONDUCTR_DEV_IMAGE, major_version
 from conductr_cli.sandbox_features import feature_names
 from conductr_cli.constants import DEFAULT_SANDBOX_ADDR_RANGE, DEFAULT_SANDBOX_IMAGE_DIR, DEFAULT_OFFLINE_MODE
-from conductr_cli import sandbox_run, sandbox_stop, sandbox_common, sandbox_logs, sandbox_ps, logging_setup, docker, version
+from conductr_cli import sandbox_run, sandbox_stop, sandbox_common, sandbox_logs, sandbox_ps, logging_setup, docker, \
+    version, validation
 from conductr_cli.sandbox_run_jvm import NR_OF_INSTANCE_EXPRESSION
 
 
@@ -184,6 +185,7 @@ def add_image_dir(sub_parser):
                             help='Default directory where sandbox images is stored.')
 
 
+@validation.handle_docker_validation_error
 def run():
     # Parse arguments
     parser = build_parser()


### PR DESCRIPTION
Docker exception during the `sandbox run` command were not handled which resulted in throwing the exception to the user:

```
$ sandbox run 1.1.12
Error: Encountered unexpected error.
Error: Reason: DockerValidationError ['Docker is installed but not running.', 'Please start Docker with one of the Docker flavors based on your OS:', '  Linux:   Docker service', '  MacOS:   Docker for Mac', 'A successful Docker startup can be verified with: docker info']
Error: Further information of the error can be found in the error log file: /Users/mj/.conductr/errors.log
```

This PR fixes the handling so that only the appropiate error message is displayed:

```
$ sandbox run 1.1.12
Error: Docker is installed but not running.
Error: Please start Docker with one of the Docker flavors based on your OS:
Error:   Linux:   Docker service
Error:   MacOS:   Docker for Mac
Error: A successful Docker startup can be verified with: docker info
```