### PR TITLE
Use sys.exit instead of exit

### DIFF
--- a/conductr_cli/conduct_main.py
+++ b/conductr_cli/conduct_main.py
@@ -397,7 +397,7 @@ def run(_args=[], configure_logging=True):
     if not vars(args).get('func'):
         if vars(args).get('dcos_info'):
             print('Lightbend ConductR sub commands. Type \'dcos conduct\' to see more.')
-            exit(0)
+            sys.exit(0)
         else:
             parser.print_help()
     else:
@@ -457,7 +457,7 @@ def run(_args=[], configure_logging=True):
                 logging_setup.configure_logging(args)
                 log = logging.getLogger(__name__)
                 log.error('Ensure server SSL verification file exists: {}'.format(args.server_verification_file))
-                exit(1)
+                sys.exit(1)
 
             if not args.dcos_mode and args.scheme == 'https':
                 disable_urllib3_warnings()
@@ -467,4 +467,4 @@ def run(_args=[], configure_logging=True):
 
         is_completed_without_error = args.func(args)
         if not is_completed_without_error:
-            exit(1)
+            sys.exit(1)

--- a/conductr_cli/sandbox_main.py
+++ b/conductr_cli/sandbox_main.py
@@ -2,6 +2,7 @@ import argcomplete
 import argparse
 import ipaddress
 import re
+import sys
 from conductr_cli.sandbox_common import CONDUCTR_DEV_IMAGE, major_version
 from conductr_cli.sandbox_features import feature_names
 from conductr_cli.constants import DEFAULT_SANDBOX_ADDR_RANGE, DEFAULT_SANDBOX_IMAGE_DIR, DEFAULT_OFFLINE_MODE
@@ -222,7 +223,7 @@ def run():
 
         result = args.func(args)
         if not result:
-            exit(1)
+            sys.exit(1)
 
 
 def nr_of_instances(value):


### PR DESCRIPTION
This is due to PyInstaller's builtins not including the `sys.exit()`, causing the `exit` keyword not to be recognized:

https://github.com/pyinstaller/pyinstaller/issues/1687

I think for correctness' sake, we should be using `sys.exit()` as it's a more explicit way to invoke the exit.