### PR TITLE
Conduct Deploy: modify digest to SHA-256

### DIFF
--- a/conductr_cli/bundle_deploy.py
+++ b/conductr_cli/bundle_deploy.py
@@ -8,7 +8,7 @@ import logging
 import base64
 
 STRING_ENCODING = 'UTF-8'
-HMAC_DIGEST_MOD = 'MD5'
+HMAC_DIGEST_MOD = 'SHA256'
 
 
 def generate_hmac_signature(secret_key, text):

--- a/conductr_cli/resolver.py
+++ b/conductr_cli/resolver.py
@@ -43,8 +43,8 @@ def resolve_bundle_configuration(custom_settings, cache_dir, uri, offline_mode=F
     raise BundleResolutionError('Unable to resolve bundle using {}'.format(uri))
 
 
-def resolve_bundle_version(custom_settings, uri):
-    all_resolvers = resolver_chain(custom_settings)
+def resolve_bundle_version(custom_settings, uri, offline_mode=False):
+    all_resolvers = resolver_chain(custom_settings, offline_mode)
 
     for resolver in all_resolvers:
         resolved_version = resolver.resolve_bundle_version(uri)
@@ -54,8 +54,8 @@ def resolve_bundle_version(custom_settings, uri):
     raise BundleResolutionError('Unable to resolve bundle using {}'.format(uri))
 
 
-def continuous_delivery_uri(custom_settings, resolved_version):
-    all_resolvers = resolver_chain(custom_settings)
+def continuous_delivery_uri(custom_settings, resolved_version, offline_mode=False):
+    all_resolvers = resolver_chain(custom_settings, offline_mode)
 
     for resolver in all_resolvers:
         uri = resolver.continuous_delivery_uri(resolved_version)

--- a/conductr_cli/test/test_bundle_deploy.py
+++ b/conductr_cli/test/test_bundle_deploy.py
@@ -11,7 +11,7 @@ import json
 class TestGenerateHmac(TestCase):
     def test_success(self):
         result = bundle_deploy.generate_hmac_signature('secret', 'reactive-maps-backend-summary')
-        self.assertEqual('GnNDrC0VQ0CN1qbWFgnvLw==', result)
+        self.assertEqual('2un791uBDf59/fHrIOWMqt0mhwEoH0yqkZXmz//4alQ=', result)
 
 
 class TestGetDeploymentStateIp(CliTestCase):


### PR DESCRIPTION
This is to match Bintray's webhook: https://bintray.com/docs/api/#_test_a_webhook