### PR TITLE
ReadMe update for building sandbox native command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -270,7 +270,7 @@ To build native packages follow the form:
 
     pyinstaller --onefile conductr_cli/conduct.py
     pyinstaller --onefile conductr_cli/shazar.py
-    pyinstaller --onefile conductr_cli/sandbox.py
+    pyinstaller --hidden-import psutil --onefile conductr_cli/sandbox.py
     
 This will result in standalone images for your current environment being created in a `dist` folder.
 


### PR DESCRIPTION
Ensure `psutil` is included when building sandbox native executable through `--hidden-import psutil` option.

If this option is not specified, `psutil` will not be included, causing error when sandbox native executable is invoked.