### PR TITLE
Fixing docker error handling

### DIFF
--- a/conductr_cli/docker.py
+++ b/conductr_cli/docker.py
@@ -2,7 +2,7 @@ import os.path
 import re
 import logging
 from conductr_cli import terminal
-from conductr_cli.exceptions import DockerValidationError
+from conductr_cli.exceptions import DockerValidationError, NOT_FOUND_ERROR
 from subprocess import CalledProcessError
 
 DEFAULT_DOCKER_RAM_SIZE = 1.9
@@ -60,7 +60,7 @@ def validate_docker_vm(vm_type):
                 if not has_sufficient_cpu:
                     log.warning('Docker has an insufficient no. of CPUs {} - please increase to a minimum of {} CPUs'
                                 .format(existing_cpu, DEFAULT_DOCKER_CPU_COUNT))
-        except (AttributeError, CalledProcessError):
+        except (AttributeError, CalledProcessError, NOT_FOUND_ERROR):
             raise DockerValidationError([
                 'Docker is installed but not running.',
                 'Please start Docker with one of the Docker flavors based on your OS:',

--- a/conductr_cli/sandbox_proxy.py
+++ b/conductr_cli/sandbox_proxy.py
@@ -1,6 +1,6 @@
 from conductr_cli import conduct_main, docker, terminal
 from conductr_cli.constants import DEFAULT_SANDBOX_PROXY_DIR, DEFAULT_SANDBOX_PROXY_CONTAINER_NAME
-from conductr_cli.exceptions import DockerValidationError
+from conductr_cli.exceptions import DockerValidationError, NOT_FOUND_ERROR
 from conductr_cli.screen_utils import h1
 from subprocess import CalledProcessError
 import logging
@@ -55,7 +55,7 @@ def stop_proxy():
             log.info('HAProxy has been successfully stopped')
 
         return True
-    except (AttributeError, CalledProcessError):
+    except (AttributeError, CalledProcessError, NOT_FOUND_ERROR):
         # Fail silently as these errors will be raised if Docker is not installed or Docker environment is not
         # configured properly.
         return False

--- a/conductr_cli/sandbox_stop_docker.py
+++ b/conductr_cli/sandbox_stop_docker.py
@@ -1,20 +1,26 @@
 from conductr_cli import sandbox_common, terminal
 from conductr_cli.screen_utils import h1
+from conductr_cli.exceptions import NOT_FOUND_ERROR
 from subprocess import CalledProcessError
 import logging
 
 
 def stop(args):
     log = logging.getLogger(__name__)
-    running_containers = sandbox_common.resolve_running_docker_containers()
+    try:
+        running_containers = sandbox_common.resolve_running_docker_containers()
+    except (AttributeError, CalledProcessError, NOT_FOUND_ERROR):
+        # return True because Docker is not installed and therefore no containers need to be stopped.
+        return True
+
     if running_containers:
         log.info(h1('Stopping ConductR'))
         try:
             terminal.docker_rm(running_containers)
             log.info('ConductR has been successfully stopped')
             return True
-        except (AttributeError, CalledProcessError):
-            log.error('ConductR containers could not be stopped pid 58002 could not be stopped')
+        except (AttributeError, CalledProcessError, NOT_FOUND_ERROR):
+            log.error('ConductR containers could not be stopped')
             log.error('Please stop the Docker containers manually')
             return False
     else:

--- a/conductr_cli/test/test_sandbox_stop_docker.py
+++ b/conductr_cli/test/test_sandbox_stop_docker.py
@@ -45,7 +45,7 @@ class TestStop(CliTestCase):
                                          ||------------------------------------------------|
                                          |"""), self.output(stdout))
         self.assertEqual(
-            as_error(strip_margin("""|Error: ConductR containers could not be stopped pid 58002 could not be stopped
+            as_error(strip_margin("""|Error: ConductR containers could not be stopped
                                      |Error: Please stop the Docker containers manually
                                      |""")), self.output(stderr))
         mock_docker_rm.assert_called_once_with(containers)


### PR DESCRIPTION
The `sandbox run` command with ConductR 2.0.0  was failing with an exception if Docker was not installed. Docker is not required by Docker so it should not fail:

```
2017-02-01 18:41:14,908: Failure running the following command:
['sandbox', 'run', '2.0.0', '-n', '3', '--feature', 'visuali
zation']
Traceback (most recent call last):
File "conductr_cli/main_handler.py", line 14, in run
File "conductr_cli/sandbox.py", line 6, in main_method
File "conductr_cli/validation.py", line 407, in handler
File "conductr_cli/sandbox_main.py", line 224, in run
File "conductr_cli/validation.py", line 38, in handler
File "conductr_cli/validation.py", line 54, in handler
File "conductr_cli/validation.py", line 219, in handler
File "conductr_cli/validation.py", line 238, in handler
File "conductr_cli/validation.py", line 255, in handler
File "conductr_cli/validation.py", line 274, in handler
File "conductr_cli/validation.py", line 292, in handler
File "conductr_cli/validation.py", line 309, in handler
File "conductr_cli/validation.py", line 346, in handler
File "conductr_cli/validation.py", line 327, in handler
File "conductr_cli/validation.py", line 373, in handler
File "conductr_cli/validation.py", line 407, in handler
File "conductr_cli/sandbox_run.py", line 35, in run
File "conductr_cli/sandbox_run_jvm.py", line 64, in run
File "conductr_cli/sandbox_stop.py", line 6, in stop
File "conductr_cli/sandbox_proxy.py", line 50, in stop_proxy
File "conductr_cli/sandbox_proxy.py", line 83, in get_running_haproxy
File "conductr_cli/terminal.py", line 19, in docker_ps
File "subprocess.py", line 607, in check_output
File "subprocess.py", line 859, in __init__
File "subprocess.py", line 1457, in _execute_child
FileNotFoundError: [Errno 2] No such file or directory: 'docker'
```

The reason for the exception was that the `docker` command could not been found and therefore a `FileNotFoundError` was thrown. This error was not handled in the Docker validation.

This is PR is fixing this.