### PR TITLE
JVM-based sandbox: expose all feature ports by default

### DIFF
--- a/conductr_cli/sandbox_features.py
+++ b/conductr_cli/sandbox_features.py
@@ -306,3 +306,11 @@ def parse_offline_mode_arg(offline_mode):
         return ['--offline']
     else:
         return []
+
+
+def all_feature_ports():
+    return sorted([
+        port
+        for f in feature_classes
+        for port in f.ports
+    ])

--- a/conductr_cli/sandbox_proxy.py
+++ b/conductr_cli/sandbox_proxy.py
@@ -1,4 +1,4 @@
-from conductr_cli import conduct_main, docker, terminal
+from conductr_cli import conduct_main, docker, terminal, sandbox_features
 from conductr_cli.constants import DEFAULT_SANDBOX_PROXY_DIR, DEFAULT_SANDBOX_PROXY_CONTAINER_NAME
 from conductr_cli.exceptions import DockerValidationError, NOT_FOUND_ERROR
 from conductr_cli.screen_utils import h1
@@ -94,6 +94,7 @@ def start_docker_instance(proxy_bind_addr, proxy_ports):
 
     all_proxy_ports = []
     all_proxy_ports.extend(DEFAULT_PROXY_PORTS)
+    all_proxy_ports.extend(sandbox_features.all_feature_ports())
     all_proxy_ports.extend(proxy_ports)
     all_proxy_ports = sorted(all_proxy_ports)
 

--- a/conductr_cli/sandbox_run.py
+++ b/conductr_cli/sandbox_run.py
@@ -35,19 +35,14 @@ def run(args):
     run_result = sandbox.run(args, features)
 
     is_conductr_started, wait_timeout = wait_for_start(args, run_result)
+
+    feature_results = []
+    print_proxy_output = False
     if is_conductr_started:
         if not is_conductr_v1:
-            feature_ports = []
-            for feature in features:
-                feature_ports.extend(feature.ports)
-
-            proxy_ports = sorted(args.ports + feature_ports)
             print_proxy_output = sandbox_proxy.start_proxy(proxy_bind_addr=run_result.core_addrs[0],
-                                                           proxy_ports=proxy_ports)
-        else:
-            print_proxy_output = False
+                                                           proxy_ports=sorted(args.ports))
 
-        feature_results = []
         for feature in features:
             result = feature.start()
             feature_results += result

--- a/conductr_cli/test/test_sandbox_proxy.py
+++ b/conductr_cli/test/test_sandbox_proxy.py
@@ -220,17 +220,20 @@ class TestStartDockerInstance(CliTestCase):
         mock_docker_images = MagicMock(return_value='sandbox-haproxy-container-id')
         mock_docker_pull = MagicMock()
         mock_docker_run = MagicMock()
+        mock_all_feature_ports = MagicMock(return_value=[19001])
 
         args = MagicMock(**{})
 
         with patch('conductr_cli.terminal.docker_images', mock_docker_images), \
                 patch('conductr_cli.terminal.docker_pull', mock_docker_pull), \
-                patch('conductr_cli.terminal.docker_run', mock_docker_run):
+                patch('conductr_cli.terminal.docker_run', mock_docker_run), \
+                patch('conductr_cli.sandbox_features.all_feature_ports', mock_all_feature_ports):
             logging_setup.configure_logging(args, stdout)
             sandbox_proxy.start_docker_instance(ipaddress.ip_address('192.168.1.1'), [3003])
 
         mock_docker_images.assert_called_once_with('haproxy:1.5')
         mock_docker_pull.assert_not_called()
+        mock_all_feature_ports.assert_called_once_with()
         mock_docker_run.assert_called_once_with(
             ['-d',
              '--name', 'sandbox-haproxy',
@@ -238,6 +241,7 @@ class TestStartDockerInstance(CliTestCase):
              '-p', '192.168.1.1:443:443',
              '-p', '192.168.1.1:3003:3003',
              '-p', '192.168.1.1:9000:9000',
+             '-p', '192.168.1.1:19001:19001',
              '-v', '{}:/usr/local/etc/haproxy:ro'.format(sandbox_proxy.HAPROXY_CFG_DIR)],
             'haproxy:1.5',
             positional_args=[]
@@ -246,7 +250,7 @@ class TestStartDockerInstance(CliTestCase):
         expected_output = strip_margin("""||------------------------------------------------|
                                           || Starting HAProxy                               |
                                           ||------------------------------------------------|
-                                          |Exposing the following ports [80, 443, 3003, 9000]
+                                          |Exposing the following ports [80, 443, 3003, 9000, 19001]
                                           |""")
         self.assertEqual(expected_output, self.output(stdout))
 
@@ -256,12 +260,14 @@ class TestStartDockerInstance(CliTestCase):
         mock_docker_images = MagicMock(return_value=None)
         mock_docker_pull = MagicMock()
         mock_docker_run = MagicMock()
+        mock_all_feature_ports = MagicMock(return_value=[19001])
 
         args = MagicMock(**{})
 
         with patch('conductr_cli.terminal.docker_images', mock_docker_images), \
                 patch('conductr_cli.terminal.docker_pull', mock_docker_pull), \
-                patch('conductr_cli.terminal.docker_run', mock_docker_run):
+                patch('conductr_cli.terminal.docker_run', mock_docker_run), \
+                patch('conductr_cli.sandbox_features.all_feature_ports', mock_all_feature_ports):
             logging_setup.configure_logging(args, stdout)
             sandbox_proxy.start_docker_instance(ipaddress.ip_address('192.168.1.1'), [3003])
 
@@ -274,6 +280,7 @@ class TestStartDockerInstance(CliTestCase):
              '-p', '192.168.1.1:443:443',
              '-p', '192.168.1.1:3003:3003',
              '-p', '192.168.1.1:9000:9000',
+             '-p', '192.168.1.1:19001:19001',
              '-v', '{}:/usr/local/etc/haproxy:ro'.format(sandbox_proxy.HAPROXY_CFG_DIR)],
             'haproxy:1.5',
             positional_args=[]
@@ -283,7 +290,7 @@ class TestStartDockerInstance(CliTestCase):
                                           || Starting HAProxy                               |
                                           ||------------------------------------------------|
                                           |Pulling docker image haproxy:1.5
-                                          |Exposing the following ports [80, 443, 3003, 9000]
+                                          |Exposing the following ports [80, 443, 3003, 9000, 19001]
                                           |""")
         self.assertEqual(expected_output, self.output(stdout))
 

--- a/conductr_cli/test/test_sandbox_run.py
+++ b/conductr_cli/test/test_sandbox_run.py
@@ -93,7 +93,7 @@ class TestSandboxRunCommand(CliTestCase):
         args = self.default_args.copy()
         args.update({
             'image_version': conductr_version,
-            'ports': [3553]
+            'ports': [5001, 3553]
         })
         input_args = MagicMock(**args)
         with \
@@ -109,7 +109,7 @@ class TestSandboxRunCommand(CliTestCase):
         mock_wait_for_conductr.assert_called_once_with(input_args, sandbox_run_result, 0,
                                                        DEFAULT_WAIT_RETRIES,
                                                        DEFAULT_WAIT_RETRY_INTERVAL)
-        mock_start_proxy.assert_called_once_with(proxy_bind_addr='192.168.1.1', proxy_ports=[3553, 10001])
+        mock_start_proxy.assert_called_once_with(proxy_bind_addr='192.168.1.1', proxy_ports=[3553, 5001])
 
         mock_log_run_attempt.assert_called_with(input_args, sandbox_run_result, bundle_start_result, True, True, 60)
 


### PR DESCRIPTION
This will allow user to load and run features with correct proxy settings when sandbox is already started.