### PR TITLE
Display date and time by default for Conduct Logs and Events

### DIFF
--- a/conductr_cli/conduct_main.py
+++ b/conductr_cli/conduct_main.py
@@ -156,6 +156,12 @@ def add_dcos_mode_args(sub_parser, dcos_mode):
         add_dcos_settings(sub_parser)
 
 
+def add_date_args(sub_parser):
+    sub_parser.add_argument('--utc',
+                            action='store_true',
+                            help='Convert the date/time of the events to UTC')
+
+
 def add_default_arguments(sub_parser, dcos_mode):
     add_dcos_mode_args(sub_parser, dcos_mode)
     add_verbose(sub_parser)
@@ -274,12 +280,7 @@ def build_parser(dcos_mode):
                                type=int,
                                default=10,
                                help='The number of events to fetch, defaults to 10')
-    events_parser.add_argument('--date',
-                               action='store_true',
-                               help='Display the date of the events')
-    events_parser.add_argument('--utc',
-                               action='store_true',
-                               help='Convert the date/time of the events to UTC')
+    add_date_args(events_parser)
     events_parser.add_argument('bundle',
                                help='The ID or name of the bundle')
     events_parser.set_defaults(func=conduct_events.events)
@@ -292,12 +293,7 @@ def build_parser(dcos_mode):
                              type=int,
                              default=10,
                              help='The number of logs to fetch, defaults to 10')
-    logs_parser.add_argument('--date',
-                             action='store_true',
-                             help='Display the date of the log')
-    logs_parser.add_argument('--utc',
-                             action='store_true',
-                             help='Convert the date/time of the log to UTC')
+    add_date_args(logs_parser)
     logs_parser.add_argument('bundle',
                              help='The ID or name of the bundle')
     logs_parser.set_defaults(func=conduct_logs.logs)

--- a/conductr_cli/test/test_conduct_events.py
+++ b/conductr_cli/test/test_conduct_events.py
@@ -22,7 +22,6 @@ class TestConductEventsCommand(CliTestCase):
         'api_version': '1',
         'bundle': bundle_id,
         'lines': 1,
-        'date': True,
         'utc': True,
         'conductr_auth': conductr_auth,
         'server_verification_file': server_verification_file
@@ -50,6 +49,7 @@ class TestConductEventsCommand(CliTestCase):
             self.output(stdout))
 
     def test_multiple_events(self):
+        self.maxDiff = None
         http_method = self.respond_with(text="""[
             {
                 "timestamp":"2015-08-24T01:16:22.327Z",
@@ -75,9 +75,9 @@ class TestConductEventsCommand(CliTestCase):
         http_method.assert_called_with(self.default_url, auth=self.conductr_auth, verify=self.server_verification_file,
                                        timeout=DEFAULT_HTTP_TIMEOUT, headers={'Host': '127.0.0.1'})
         self.assertEqual(
-            strip_margin("""|TIME                  EVENT                                       DESC
-                            |2015-08-24T01:16:22Z  conductr.loadScheduler.loadBundleRequested  Load bundle requested: requestId=cba938cd-860e-41a4-9cbe-2c677feaca20, bundleName=visualizer
-                            |2015-08-24T01:16:25Z  conductr.loadExecutor.bundleWritten         Bundle written: requestId=cba938cd-860e-41a4-9cbe-2c677feaca20, bundleName=visualizer
+            strip_margin("""|TIME                      EVENT                                       DESC
+                            |Mon 2015-08-24T01:16:22Z  conductr.loadScheduler.loadBundleRequested  Load bundle requested: requestId=cba938cd-860e-41a4-9cbe-2c677feaca20, bundleName=visualizer
+                            |Mon 2015-08-24T01:16:25Z  conductr.loadExecutor.bundleWritten         Bundle written: requestId=cba938cd-860e-41a4-9cbe-2c677feaca20, bundleName=visualizer
                             |"""),
             self.output(stdout))
 

--- a/conductr_cli/test/test_conduct_logging.py
+++ b/conductr_cli/test/test_conduct_logging.py
@@ -7,34 +7,13 @@ import arrow
 class TestConductLogsCommand(TestCase):
     def test_format_date_timestamp_utc(self):
         timestamp = '2015-08-24T01:16:22.327Z'
-        args = MagicMock()
-        args.date = True
-        args.utc = True
+        args = MagicMock(**{'utc': True})
         result = validation.format_timestamp(timestamp, args)
-        self.assertEqual('2015-08-24T01:16:22Z', result)
-
-    def test_format_timestamp_utc(self):
-        timestamp = '2015-08-24T01:16:22.327Z'
-        args = MagicMock()
-        args.date = False
-        args.utc = True
-        result = validation.format_timestamp(timestamp, args)
-        self.assertEqual('01:16:22Z', result)
+        self.assertEqual('Mon 2015-08-24T01:16:22Z', result)
 
     def test_format_date_timestamp(self):
         timestamp = '2015-08-24T01:16:22.327Z'
-        args = MagicMock()
-        args.date = True
-        args.utc = False
+        args = MagicMock(**{'utc': False})
         result = validation.format_timestamp(timestamp, args)
-        expected_result = arrow.get(timestamp).to('local').datetime.strftime('%c')
-        self.assertEqual(expected_result, result)
-
-    def test_format_timestamp(self):
-        timestamp = '2015-08-24T01:16:22.327Z'
-        args = MagicMock()
-        args.date = False
-        args.utc = False
-        result = validation.format_timestamp(timestamp, args)
-        expected_result = arrow.get(timestamp).to('local').datetime.strftime('%X')
+        expected_result = arrow.get(timestamp).to('local').strftime('%a %Y-%m-%dT%H:%M:%S%z')
         self.assertEqual(expected_result, result)

--- a/conductr_cli/test/test_conduct_logs.py
+++ b/conductr_cli/test/test_conduct_logs.py
@@ -22,7 +22,6 @@ class TestConductLogsCommand(CliTestCase):
         'api_version': '1',
         'bundle': bundle_id,
         'lines': 1,
-        'date': True,
         'utc': True,
         'conductr_auth': conductr_auth,
         'server_verification_file': server_verification_file
@@ -50,6 +49,7 @@ class TestConductLogsCommand(CliTestCase):
             self.output(stdout))
 
     def test_multiple_events(self):
+        self.maxDiff = None
         http_method = self.respond_with(text="""[
             {
                 "timestamp":"2015-08-24T01:16:22.327Z",
@@ -75,9 +75,9 @@ class TestConductLogsCommand(CliTestCase):
         http_method.assert_called_with(self.default_url, auth=self.conductr_auth, verify=self.server_verification_file,
                                        timeout=DEFAULT_HTTP_TIMEOUT, headers={'Host': '127.0.0.1'})
         self.assertEqual(
-            strip_margin("""|TIME                  HOST        LOG
-                            |2015-08-24T01:16:22Z  10.0.1.232  [WARN] [04/21/2015 12:54:30.079] [doc-renderer-cluster-1-akka.remote.default-remote-dispatcher-22] Association with remote system has failed.
-                            |2015-08-24T01:16:25Z  10.0.1.232  [WARN] [04/21/2015 12:54:36.079] [doc-renderer-cluster-1-akka.remote.default-remote-dispatcher-26] Association with remote system has failed.
+            strip_margin("""|TIME                      HOST        LOG
+                            |Mon 2015-08-24T01:16:22Z  10.0.1.232  [WARN] [04/21/2015 12:54:30.079] [doc-renderer-cluster-1-akka.remote.default-remote-dispatcher-22] Association with remote system has failed.
+                            |Mon 2015-08-24T01:16:25Z  10.0.1.232  [WARN] [04/21/2015 12:54:36.079] [doc-renderer-cluster-1-akka.remote.default-remote-dispatcher-26] Association with remote system has failed.
                             |"""),
             self.output(stdout))
 

--- a/conductr_cli/validation.py
+++ b/conductr_cli/validation.py
@@ -420,15 +420,9 @@ def handle_docker_validation_error(func):
 
 def format_timestamp(timestamp, args):
     date = arrow.get(timestamp)
-
-    if args.date and args.utc:
-        return date.to('UTC').strftime('%Y-%m-%dT%H:%M:%SZ')
-    elif args.date:
-        return date.to('local').strftime('%c')
-    elif args.utc:
-        return date.to('UTC').strftime('%H:%M:%SZ')
-    else:
-        return date.to('local').strftime('%X')
+    date_display = date.to('UTC') if args.utc else date.to('local')
+    date_format = '%a %Y-%m-%dT%H:%M:%SZ' if args.utc else '%a %Y-%m-%dT%H:%M:%S%z'
+    return date_display.strftime(date_format)
 
 
 def get_logger_for_func(func):


### PR DESCRIPTION
Remove `--date` option for Conduct Logs and Events.