### PR TITLE
Separate cache dirs for bundle and configuration

### DIFF
--- a/conductr_cli/conduct_main.py
+++ b/conductr_cli/conduct_main.py
@@ -8,8 +8,8 @@ from conductr_cli import \
 from conductr_cli.constants import \
     DEFAULT_SCHEME, DEFAULT_PORT, DEFAULT_BASE_PATH, \
     DEFAULT_API_VERSION, DEFAULT_DCOS_SERVICE, DEFAULT_CLI_SETTINGS_DIR, \
-    DEFAULT_CUSTOM_SETTINGS_FILE, DEFAULT_CUSTOM_PLUGINS_DIR, \
-    DEFAULT_BUNDLE_RESOLVE_CACHE_DIR, DEFAULT_WAIT_TIMEOUT, DEFAULT_OFFLINE_MODE
+    DEFAULT_CUSTOM_SETTINGS_FILE, DEFAULT_CUSTOM_PLUGINS_DIR, DEFAULT_BUNDLE_RESOLVE_CACHE_DIR, \
+    DEFAULT_CONFIGURATION_RESOLVE_CACHE_DIR, DEFAULT_WAIT_TIMEOUT, DEFAULT_OFFLINE_MODE
 from dcos import config, constants
 
 from pathlib import Path
@@ -107,11 +107,19 @@ def add_custom_plugins_dir(sub_parser):
 
 
 def add_bundle_resolve_cache_dir(sub_parser):
-    sub_parser.add_argument('--resolve-cache-dir',
+    sub_parser.add_argument('--bundle-resolve-cache-dir',
                             help='Directory where resolved bundles are cached, defaults to {}'.format(
                                 DEFAULT_BUNDLE_RESOLVE_CACHE_DIR),
                             default=DEFAULT_BUNDLE_RESOLVE_CACHE_DIR,
-                            dest='resolve_cache_dir')
+                            dest='bundle_resolve_cache_dir')
+
+
+def add_configuration_resolve_cache_dir(sub_parser):
+    sub_parser.add_argument('--configuration-resolve-cache-dir',
+                            help='Directory where resolved bundle configurations are cached, defaults to {}'.format(
+                                DEFAULT_CONFIGURATION_RESOLVE_CACHE_DIR),
+                            default=DEFAULT_CONFIGURATION_RESOLVE_CACHE_DIR,
+                            dest='configuration_resolve_cache_dir')
 
 
 def add_disable_instructions(sub_parser):
@@ -231,6 +239,7 @@ def build_parser(dcos_mode):
                                   'If not set the default is False.')
     add_default_arguments(load_parser, dcos_mode)
     add_bundle_resolve_cache_dir(load_parser)
+    add_configuration_resolve_cache_dir(load_parser)
     add_wait_timeout(load_parser)
     add_no_wait(load_parser)
     load_parser.set_defaults(func=conduct_load.load)

--- a/conductr_cli/constants.py
+++ b/conductr_cli/constants.py
@@ -10,7 +10,10 @@ DEFAULT_API_VERSION = os.getenv('CONDUCTR_API_VERSION', '2')
 DEFAULT_DCOS_SERVICE = os.getenv('CONDUCTR_DCOS_SERVICE', 'conductr')
 DEFAULT_CLI_SETTINGS_DIR = os.getenv('CONDUCTR_CLI_SETTINGS_DIR', '{}/.conductr'.format(os.path.expanduser('~')))
 DEFAULT_BUNDLE_RESOLVE_CACHE_DIR = os.getenv('CONDUCTR_BUNDLE_RESOLVE_CACHE_DIR',
-                                             '{}/cache'.format(DEFAULT_CLI_SETTINGS_DIR))
+                                             '{}/cache/bundle'.format(DEFAULT_CLI_SETTINGS_DIR))
+DEFAULT_CONFIGURATION_RESOLVE_CACHE_DIR = os.getenv('CONDUCTR_CONFIGURATION_RESOLVE_CACHE_DIR',
+                                                    '{}/cache/configuration'
+                                                    .format(DEFAULT_CLI_SETTINGS_DIR))
 DEFAULT_CUSTOM_SETTINGS_FILE = os.getenv('CONDUCTR_CUSTOM_SETTINGS_FILE',
                                          '{}/settings.conf'.format(DEFAULT_CLI_SETTINGS_DIR))
 DEFAULT_CUSTOM_PLUGINS_DIR = os.getenv('CONDUCTR_CUSTOM_PLUGINS_DIR',

--- a/conductr_cli/test/conduct_load_test_base.py
+++ b/conductr_cli/test/conduct_load_test_base.py
@@ -569,7 +569,7 @@ class ConductLoadTestBase(CliTestCase):
 
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
                                                self.bundle_file, self.offline_mode)
-        resolve_bundle_configuration_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
+        resolve_bundle_configuration_mock.assert_called_with(self.custom_settings, self.configuration_resolve_cache_dir,
                                                              'no_such.conf', self.offline_mode)
 
         self.assertEqual(

--- a/conductr_cli/test/test_conduct_load_v1.py
+++ b/conductr_cli/test/test_conduct_load_v1.py
@@ -20,6 +20,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
         self.system = 'bundle'
         self.custom_settings = Mock()
         self.bundle_resolve_cache_dir = 'bundle-resolve-cache-dir'
+        self.configuration_resolve_cache_dir = 'configuration-resolve-cache-dir'
 
         self.tmpdir, self.bundle_file = create_temp_bundle(
             strip_margin("""|nrOfCpus   = {},
@@ -50,7 +51,8 @@ class TestConductLoadCommand(ConductLoadTestBase):
             'command': 'conduct',
             'cli_parameters': '',
             'custom_settings': self.custom_settings,
-            'resolve_cache_dir': self.bundle_resolve_cache_dir,
+            'bundle_resolve_cache_dir': self.bundle_resolve_cache_dir,
+            'configuration_resolve_cache_dir': self.configuration_resolve_cache_dir,
             'bundle': self.bundle_file,
             'configuration': None,
             'conductr_auth': self.conductr_auth,
@@ -128,7 +130,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
 
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
                                                self.bundle_file, self.offline_mode)
-        resolve_bundle_configuration_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
+        resolve_bundle_configuration_mock.assert_called_with(self.custom_settings, self.configuration_resolve_cache_dir,
                                                              config_file, self.offline_mode)
         expected_files = self.default_files + [('configuration', ('config.zip', 1))]
         expected_files[4] = ('bundleName', 'overlaid-name')

--- a/conductr_cli/test/test_conduct_load_v2.py
+++ b/conductr_cli/test/test_conduct_load_v2.py
@@ -20,6 +20,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
         self.compatibility_version = '2.0'
         self.custom_settings = Mock()
         self.bundle_resolve_cache_dir = 'bundle-resolve-cache-dir'
+        self.configuration_resolve_cache_dir = 'configuration-resolve-cache-dir'
 
         self.tmpdir, self.bundle_file = create_temp_bundle(
             strip_margin("""|nrOfCpus               = {}
@@ -55,7 +56,8 @@ class TestConductLoadCommand(ConductLoadTestBase):
             'command': 'conduct',
             'cli_parameters': '',
             'custom_settings': self.custom_settings,
-            'resolve_cache_dir': self.bundle_resolve_cache_dir,
+            'bundle_resolve_cache_dir': self.bundle_resolve_cache_dir,
+            'configuration_resolve_cache_dir': self.configuration_resolve_cache_dir,
             'bundle': self.bundle_file,
             'configuration': None,
             'conductr_auth': self.conductr_auth,
@@ -176,7 +178,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
 
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
                                                self.bundle_file, self.offline_mode)
-        resolve_bundle_configuration_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
+        resolve_bundle_configuration_mock.assert_called_with(self.custom_settings, self.configuration_resolve_cache_dir,
                                                              config_file, self.offline_mode)
         self.assertEqual(
             conf_mock.call_args_list,
@@ -252,7 +254,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
 
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
                                                self.bundle_file, self.offline_mode)
-        resolve_bundle_configuration_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
+        resolve_bundle_configuration_mock.assert_called_with(self.custom_settings, self.configuration_resolve_cache_dir,
                                                              config_file, self.offline_mode)
 
         self.assertEqual(

--- a/conductr_cli/test/test_conduct_main.py
+++ b/conductr_cli/test/test_conduct_main.py
@@ -72,7 +72,9 @@ class TestConduct(TestCase):
         self.assertEqual(args.port, 9005)
         self.assertEqual(args.api_version, '2')
         self.assertEqual(args.cli_settings_dir, '{}/.conductr'.format(os.path.expanduser('~')))
-        self.assertEqual(args.resolve_cache_dir, '{}/.conductr/cache'.format(os.path.expanduser('~')))
+        self.assertEqual(args.bundle_resolve_cache_dir, '{}/.conductr/cache/bundle'.format(os.path.expanduser('~')))
+        self.assertEqual(args.configuration_resolve_cache_dir,
+                         '{}/.conductr/cache/configuration'.format(os.path.expanduser('~')))
         self.assertEqual(args.verbose, False)
         self.assertEqual(args.long_ids, False)
         self.assertEqual(args.no_wait, False)
@@ -80,15 +82,37 @@ class TestConduct(TestCase):
         self.assertEqual(args.bundle, 'path-to-bundle')
         self.assertEqual(args.configuration, 'path-to-conf')
 
-    def test_parser_load_with_custom_resolve_cache_dir(self):
-        args = self.parser.parse_args('load --resolve-cache-dir /somewhere path-to-bundle path-to-conf'.split())
+    def test_parser_load_with_custom_bundle_resolve_cache_dir(self):
+        args = self.parser.parse_args('load --bundle-resolve-cache-dir /new-bundle-dir path-to-bundle path-to-conf'
+                                      .split())
 
         self.assertEqual(args.func.__name__, 'load')
         self.assertEqual(args.ip, None)
         self.assertEqual(args.port, 9005)
         self.assertEqual(args.api_version, '2')
         self.assertEqual(args.cli_settings_dir, '{}/.conductr'.format(os.path.expanduser('~')))
-        self.assertEqual(args.resolve_cache_dir, '/somewhere')
+        self.assertEqual(args.bundle_resolve_cache_dir, '/new-bundle-dir')
+        self.assertEqual(args.configuration_resolve_cache_dir,
+                         '{}/.conductr/cache/configuration'.format(os.path.expanduser('~')))
+        self.assertEqual(args.verbose, False)
+        self.assertEqual(args.long_ids, False)
+        self.assertEqual(args.no_wait, False)
+        self.assertEqual(args.wait_timeout, 60)
+        self.assertEqual(args.bundle, 'path-to-bundle')
+        self.assertEqual(args.configuration, 'path-to-conf')
+        self.assertFalse(args.quiet)
+
+    def test_parser_load_with_custom_configuration_resolve_cache_dir(self):
+        args = self.parser.parse_args('load --configuration-resolve-cache-dir /new-conf-dir path-to-bundle path-to-conf'
+                                      .split())
+
+        self.assertEqual(args.func.__name__, 'load')
+        self.assertEqual(args.ip, None)
+        self.assertEqual(args.port, 9005)
+        self.assertEqual(args.api_version, '2')
+        self.assertEqual(args.cli_settings_dir, '{}/.conductr'.format(os.path.expanduser('~')))
+        self.assertEqual(args.bundle_resolve_cache_dir, '{}/.conductr/cache/bundle'.format(os.path.expanduser('~')))
+        self.assertEqual(args.configuration_resolve_cache_dir, '/new-conf-dir')
         self.assertEqual(args.verbose, False)
         self.assertEqual(args.long_ids, False)
         self.assertEqual(args.no_wait, False)


### PR DESCRIPTION
The bundle and bundle configuration files are now cached in separate dirs:

- `.conductr/cache/bundle`
- `.conductr/cache/configuration`

This ensures that the offline resolver picks up the correct bundle and bundle configuration.

Fixes https://github.com/typesafehub/conductr-cli/issues/285.