### PR TITLE
Delete files under old cache directory

### DIFF
--- a/conductr_cli/constants.py
+++ b/conductr_cli/constants.py
@@ -9,11 +9,12 @@ DEFAULT_BASE_PATH = os.getenv('CONDUCTR_BASE_PATH', '/')
 DEFAULT_API_VERSION = os.getenv('CONDUCTR_API_VERSION', '2')
 DEFAULT_DCOS_SERVICE = os.getenv('CONDUCTR_DCOS_SERVICE', 'conductr')
 DEFAULT_CLI_SETTINGS_DIR = os.getenv('CONDUCTR_CLI_SETTINGS_DIR', '{}/.conductr'.format(os.path.expanduser('~')))
+DEFAULT_RESOLVE_CACHE_DIR = '{}/cache'.format(DEFAULT_CLI_SETTINGS_DIR)
 DEFAULT_BUNDLE_RESOLVE_CACHE_DIR = os.getenv('CONDUCTR_BUNDLE_RESOLVE_CACHE_DIR',
-                                             '{}/cache/bundle'.format(DEFAULT_CLI_SETTINGS_DIR))
+                                             '{}/bundle'.format(DEFAULT_RESOLVE_CACHE_DIR))
 DEFAULT_CONFIGURATION_RESOLVE_CACHE_DIR = os.getenv('CONDUCTR_CONFIGURATION_RESOLVE_CACHE_DIR',
-                                                    '{}/cache/configuration'
-                                                    .format(DEFAULT_CLI_SETTINGS_DIR))
+                                                    '{}/configuration'
+                                                    .format(DEFAULT_RESOLVE_CACHE_DIR))
 DEFAULT_CUSTOM_SETTINGS_FILE = os.getenv('CONDUCTR_CUSTOM_SETTINGS_FILE',
                                          '{}/settings.conf'.format(DEFAULT_CLI_SETTINGS_DIR))
 DEFAULT_CUSTOM_PLUGINS_DIR = os.getenv('CONDUCTR_CUSTOM_PLUGINS_DIR',

--- a/conductr_cli/test/conduct_load_test_base.py
+++ b/conductr_cli/test/conduct_load_test_base.py
@@ -62,11 +62,13 @@ class ConductLoadTestBase(CliTestCase):
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
         wait_for_installation_mock = MagicMock()
+        cleanup_old_cache_location_mock = MagicMock()
         cleanup_old_bundles_mock = MagicMock()
 
         input_args = MagicMock(**self.default_args)
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
+                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
                 patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
@@ -101,10 +103,12 @@ class ConductLoadTestBase(CliTestCase):
         open_mock = MagicMock(return_value=1)
         wait_for_installation_mock = MagicMock()
         cleanup_old_bundles_mock = MagicMock()
+        cleanup_old_cache_location_mock = MagicMock()
 
         input_args = MagicMock(**self.default_args)
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
+                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
                 patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('dcos.http.post', http_method), \
                 patch('builtins.open', open_mock), \
@@ -135,6 +139,7 @@ class ConductLoadTestBase(CliTestCase):
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
         wait_for_installation_mock = MagicMock()
+        cleanup_old_cache_location_mock = MagicMock()
         cleanup_old_bundles_mock = MagicMock()
 
         args = self.default_args.copy()
@@ -143,6 +148,7 @@ class ConductLoadTestBase(CliTestCase):
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
+                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
                 patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
@@ -173,6 +179,7 @@ class ConductLoadTestBase(CliTestCase):
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
         wait_for_installation_mock = MagicMock()
+        cleanup_old_cache_location_mock = MagicMock()
         cleanup_old_bundles_mock = MagicMock()
 
         args = self.default_args.copy()
@@ -181,6 +188,7 @@ class ConductLoadTestBase(CliTestCase):
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
+                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
                 patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
@@ -211,6 +219,7 @@ class ConductLoadTestBase(CliTestCase):
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
         wait_for_installation_mock = MagicMock()
+        cleanup_old_cache_location_mock = MagicMock()
         cleanup_old_bundles_mock = MagicMock()
 
         args = self.default_args.copy()
@@ -219,6 +228,7 @@ class ConductLoadTestBase(CliTestCase):
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
+                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
                 patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
@@ -249,6 +259,7 @@ class ConductLoadTestBase(CliTestCase):
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
         wait_for_installation_mock = MagicMock()
+        cleanup_old_cache_location_mock = MagicMock()
         cleanup_old_bundles_mock = MagicMock()
 
         cli_parameters = ' --ip 127.0.1.1 --port 9006'
@@ -258,6 +269,7 @@ class ConductLoadTestBase(CliTestCase):
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
+                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
                 patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
@@ -290,6 +302,7 @@ class ConductLoadTestBase(CliTestCase):
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
         wait_for_installation_mock = MagicMock()
+        cleanup_old_cache_location_mock = MagicMock()
         cleanup_old_bundles_mock = MagicMock()
 
         cli_parameters = ' --host 127.0.1.1 --port 9006'
@@ -299,6 +312,7 @@ class ConductLoadTestBase(CliTestCase):
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
+                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
                 patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
@@ -336,11 +350,13 @@ class ConductLoadTestBase(CliTestCase):
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
         wait_for_installation_mock = MagicMock()
+        cleanup_old_cache_location_mock = MagicMock()
         cleanup_old_bundles_mock = MagicMock()
 
         input_args = MagicMock(**args)
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
+                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
                 patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
@@ -370,6 +386,7 @@ class ConductLoadTestBase(CliTestCase):
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
+        cleanup_old_cache_location_mock = MagicMock()
         cleanup_old_bundles_mock = MagicMock()
 
         args = self.default_args.copy()
@@ -378,6 +395,7 @@ class ConductLoadTestBase(CliTestCase):
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
+                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
                 patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock):
@@ -405,6 +423,7 @@ class ConductLoadTestBase(CliTestCase):
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
+        cleanup_old_cache_location_mock = MagicMock()
         cleanup_old_bundles_mock = MagicMock()
         wait_for_installation_mock = MagicMock()
 
@@ -414,6 +433,7 @@ class ConductLoadTestBase(CliTestCase):
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
+                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
                 patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
@@ -443,10 +463,12 @@ class ConductLoadTestBase(CliTestCase):
         stdout = MagicMock()
         stderr = MagicMock()
         open_mock = MagicMock(return_value=1)
+        cleanup_old_cache_location_mock = MagicMock()
 
         input_args = MagicMock(**self.default_args)
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
+                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock):
             logging_setup.configure_logging(input_args, stdout, stderr)
@@ -475,10 +497,12 @@ class ConductLoadTestBase(CliTestCase):
         stdout = MagicMock()
         stderr = MagicMock()
         open_mock = MagicMock(return_value=1)
+        cleanup_old_cache_location_mock = MagicMock()
 
         input_args = MagicMock(**self.default_args)
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
+                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock):
             logging_setup.configure_logging(input_args, stdout, stderr)
@@ -503,6 +527,7 @@ class ConductLoadTestBase(CliTestCase):
         resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, self.bundle_file))
         create_multipart_mock = MagicMock(return_value=self.multipart_mock)
         http_method = self.raise_read_timeout_error('test reason', self.default_url)
+        cleanup_old_cache_location_mock = MagicMock()
         stdout = MagicMock()
         stderr = MagicMock()
         open_mock = MagicMock(return_value=1)
@@ -510,6 +535,7 @@ class ConductLoadTestBase(CliTestCase):
         input_args = MagicMock(**self.default_args)
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
+                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock):
             logging_setup.configure_logging(input_args, stdout, stderr)
@@ -537,8 +563,10 @@ class ConductLoadTestBase(CliTestCase):
         resolve_bundle_mock = MagicMock(side_effect=BundleResolutionError('some message'))
         stdout = MagicMock()
         stderr = MagicMock()
+        cleanup_old_cache_location_mock = MagicMock()
 
-        with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
+        with patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
+                patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
             args = self.default_args.copy()
             args.update({'bundle': 'no_such.bundle'})
             logging_setup.configure_logging(MagicMock(**args), stdout, stderr)
@@ -558,9 +586,11 @@ class ConductLoadTestBase(CliTestCase):
         resolve_bundle_configuration_mock = MagicMock(side_effect=BundleResolutionError('some message'))
         stdout = MagicMock()
         stderr = MagicMock()
+        cleanup_old_cache_location_mock = MagicMock()
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
-                patch('conductr_cli.resolver.resolve_bundle_configuration', resolve_bundle_configuration_mock):
+                patch('conductr_cli.resolver.resolve_bundle_configuration', resolve_bundle_configuration_mock), \
+                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock):
             args = self.default_args.copy()
             args.update({'configuration': 'no_such.conf'})
             logging_setup.configure_logging(MagicMock(**args), stdout, stderr)
@@ -581,8 +611,10 @@ class ConductLoadTestBase(CliTestCase):
         resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, self.bundle_file))
         stderr = MagicMock()
         open_mock = MagicMock(side_effect=BadZipFile('test bad zip error'))
+        cleanup_old_cache_location_mock = MagicMock()
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
+                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
                 patch('builtins.open', open_mock):
             logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
             result = conduct_load.load(MagicMock(**self.default_args))
@@ -601,8 +633,10 @@ class ConductLoadTestBase(CliTestCase):
         add_info_mock = MagicMock()
         resolve_bundle_mock = MagicMock(side_effect=HTTPError('url', 'code', 'message', 'headers', add_info_mock))
         stderr = MagicMock()
+        cleanup_old_cache_location_mock = MagicMock()
 
-        with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
+        with patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
+                patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
             logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
             result = conduct_load.load(MagicMock(**self.default_args))
             self.assertFalse(result)
@@ -618,8 +652,10 @@ class ConductLoadTestBase(CliTestCase):
     def base_test_failure_no_file_url_error(self):
         resolve_bundle_mock = MagicMock(side_effect=URLError('reason', None))
         stderr = MagicMock()
+        cleanup_old_cache_location_mock = MagicMock()
 
-        with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
+        with patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
+                patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
             logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
             result = conduct_load.load(MagicMock(**self.default_args))
             self.assertFalse(result)
@@ -638,6 +674,7 @@ class ConductLoadTestBase(CliTestCase):
         http_method = self.respond_with(200, self.default_response)
         stderr = MagicMock()
         open_mock = MagicMock(return_value=1)
+        cleanup_old_cache_location_mock = MagicMock()
         wait_for_installation_mock = MagicMock(side_effect=WaitTimeoutError('test timeout'))
 
         input_args = MagicMock(**self.default_args)
@@ -645,6 +682,7 @@ class ConductLoadTestBase(CliTestCase):
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
+                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
             logging_setup.configure_logging(input_args, err_output=stderr)
             result = conduct_load.load(input_args)

--- a/conductr_cli/test/test_conduct_load_v1.py
+++ b/conductr_cli/test/test_conduct_load_v1.py
@@ -107,6 +107,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
+        cleanup_old_cache_location_mock = MagicMock()
         wait_for_installation_mock = MagicMock()
 
         args = self.default_args.copy()
@@ -118,6 +119,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
+                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_load.load(input_args)
@@ -176,7 +178,9 @@ class TestConductLoadCommand(ConductLoadTestBase):
                             |""").format(self.memory, self.disk_space, ', '.join(self.roles)))
 
         resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, bundle_file))
-        with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
+        cleanup_old_cache_location_mock = MagicMock()
+        with patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
+                patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
             args = self.default_args.copy()
             args.update({'bundle': bundle_file})
             logging_setup.configure_logging(MagicMock(**args), err_output=stderr)
@@ -204,7 +208,9 @@ class TestConductLoadCommand(ConductLoadTestBase):
                             |""").format(self.nr_of_cpus, self.disk_space, ', '.join(self.roles)))
 
         resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, bundle_file))
-        with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
+        cleanup_old_cache_location_mock = MagicMock()
+        with patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
+                patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
             args = self.default_args.copy()
             args.update({'bundle': bundle_file})
             logging_setup.configure_logging(MagicMock(**args), err_output=stderr)
@@ -232,7 +238,9 @@ class TestConductLoadCommand(ConductLoadTestBase):
                             |""").format(self.nr_of_cpus, self.memory, ', '.join(self.roles)))
 
         resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, bundle_file))
-        with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
+        cleanup_old_cache_location_mock = MagicMock()
+        with patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
+                patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
             args = self.default_args.copy()
             args.update({'bundle': bundle_file})
             logging_setup.configure_logging(MagicMock(**args), err_output=stderr)
@@ -260,7 +268,9 @@ class TestConductLoadCommand(ConductLoadTestBase):
                             |""").format(self.nr_of_cpus, self.memory, self.disk_space))
 
         resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, bundle_file))
-        with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
+        cleanup_old_cache_location_mock = MagicMock()
+        with patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
+                patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
             args = self.default_args.copy()
             args.update({'bundle': bundle_file})
             logging_setup.configure_logging(MagicMock(**args), err_output=stderr)
@@ -289,7 +299,9 @@ class TestConductLoadCommand(ConductLoadTestBase):
                             |""").format(self.nr_of_cpus, self.memory, self.disk_space, '-'.join(self.roles)))
 
         resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, bundle_file))
-        with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
+        cleanup_old_cache_location_mock = MagicMock()
+        with patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
+                patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
             args = self.default_args.copy()
             args.update({'bundle': bundle_file})
             logging_setup.configure_logging(MagicMock(**args), err_output=stderr)

--- a/conductr_cli/test/test_conduct_load_v2.py
+++ b/conductr_cli/test/test_conduct_load_v2.py
@@ -158,6 +158,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
+        cleanup_old_cache_location_mock = MagicMock()
         wait_for_installation_mock = MagicMock()
 
         args = self.default_args.copy()
@@ -171,6 +172,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
+                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_load.load(input_args)
@@ -234,6 +236,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
+        cleanup_old_cache_location_mock = MagicMock()
         wait_for_installation_mock = MagicMock()
 
         args = self.default_args.copy()
@@ -247,6 +250,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
+                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_load.load(input_args)
@@ -350,9 +354,11 @@ class TestConductLoadCommand(ConductLoadTestBase):
     def test_failure_no_bundle_conf(self):
         resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, self.bundle_file))
         conf_mock = MagicMock(return_value=None)
+        cleanup_old_cache_location_mock = MagicMock()
         stderr = MagicMock()
 
-        with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
+        with patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
+                patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.bundle_utils.conf', conf_mock):
             args = self.default_args.copy()
             logging_setup.configure_logging(MagicMock(**args), err_output=stderr)


### PR DESCRIPTION
Each `conduct load` call will delete the files under the `~/.cache` directory. It will **not** delete directories under `~/.cache`, e.g. `~/.cache/bundle`.

This is necessary to delete the bundle and bundle configuration files from the previous ~/.cache` location.

Corresponding PRs are https://github.com/typesafehub/conductr-cli/pull/298 and https://github.com/typesafehub/conductr-cli/pull/299.