### PR TITLE
Correct offline mode help description

### DIFF
--- a/conductr_cli/conduct_main.py
+++ b/conductr_cli/conduct_main.py
@@ -235,8 +235,8 @@ def build_parser(dcos_mode):
                              action='store_true',
                              help='Enables offline mode to resolve bundles only locally '
                                   'either by file uri or from the cache directory. '
-                                  'Defaults to environment variable CONDUCTR_OFFLINE_MODE. '
-                                  'If not set the default is False.')
+                                  'True if CONDUCTR_OFFLINE_MODE environment variable is set. '
+                                  'False if --offline flag not specified and environment variable not set.')
     add_default_arguments(load_parser, dcos_mode)
     add_bundle_resolve_cache_dir(load_parser)
     add_configuration_resolve_cache_dir(load_parser)

--- a/conductr_cli/sandbox_main.py
+++ b/conductr_cli/sandbox_main.py
@@ -86,8 +86,8 @@ def build_parser():
                             action='store_true',
                             help='Enables offline mode to resolve bundles only locally '
                                  'either by file uri or from the cache directory. '
-                                 'Defaults to environment variable CONDUCTR_OFFLINE_MODE. '
-                                 'If not set the default is False.')
+                                 'True if CONDUCTR_OFFLINE_MODE environment variable is set. '
+                                 'False if --offline flag not specified and environment variable not set.')
     run_parser.add_argument('-p', '--port',
                             dest='ports',
                             action='append',


### PR DESCRIPTION
The help description of the `—offline` flag was could be misinterpreted.

Now it is clear that ones the `CONDUCTR_OFFLINE_MODE` environment variable is set, the value is true - no matter what the value of the env is.

So all of the following lines would set the offline mode to true:

```
export CONDUCTR_OFFLINE_MODE
export CONDUCTR_OFFLINE_MODE=True
export CONDUCTR_OFFLINE_MODE=true
export CONDUCTR_OFFLINE_MODE=something
export CONDUCTR_OFFLINE_MODE=false
```