### PR TITLE
Fix for cleaning up the old cache

### DIFF
--- a/conductr_cli/conduct_load.py
+++ b/conductr_cli/conduct_load.py
@@ -257,10 +257,9 @@ def cleanup_old_cache_location():
     Removes files under `~/.cache` directory.
     Nowadays, the files are cached under `/.cache/bundle` and `/.cache/configuration`.
     """
-    with os.scandir(DEFAULT_RESOLVE_CACHE_DIR) as it:
-        for entry in it:
-            if entry.is_file():
-                os.remove(entry)
+    for entry in os.scandir(DEFAULT_RESOLVE_CACHE_DIR):
+        if entry.is_file():
+            os.remove(entry.path)
 
 
 def cleanup_old_bundles(cache_dir, bundle_file_name, excluded):


### PR DESCRIPTION
Prior to this commit `with` was being used in order to process the result of `os.scandir`. `with` operates on objects and thus errors given that `os.scandir` returns an iterator. This commit fixes that problem.