### PR TITLE
None check for ps keys

### DIFF
--- a/conductr_cli/sandbox_common.py
+++ b/conductr_cli/sandbox_common.py
@@ -55,13 +55,18 @@ def calculate_pids(core_run_dir, agent_run_dir, ps):
 
             return default
 
-        if process['name'] == 'java' and any('com.typesafe.conductr.ConductR' == e for e in process['cmdline']) and any(core_run_dir in e for e in process['cmdline']):
+        if process['name'] and process['name'] == 'java' and \
+                process['cmdline'] and any('com.typesafe.conductr.ConductR' == e for e in process['cmdline']) and \
+                any(core_run_dir in e for e in process['cmdline']):
             pids_info.append({
                 'type': 'core',
                 'id': int(process['pid']),
                 'ip': extract_param('-Dconductr.ip=(\S+)', '')
             })
-        elif process['name'] == 'java' and any('com.typesafe.conductr.agent.ConductRAgent' == e for e in process['cmdline']) and any(agent_run_dir in e for e in process['cmdline']):
+        elif process['name'] and process['name'] == 'java' and \
+                process['cmdline'] and \
+                any('com.typesafe.conductr.agent.ConductRAgent' == e for e in process['cmdline']) and \
+                any(agent_run_dir in e for e in process['cmdline']):
             pids_info.append({
                 'type': 'agent',
                 'id': int(process['pid']),


### PR DESCRIPTION
The `psutil` library is used to get the running processes. It is possible that certain keys such as `cmdline` or `name` can be empty.

We now perform a None check of these keys.

Fixes https://github.com/typesafehub/conductr-cli/issues/308.