### PR TITLE
Update python versions in instruction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -203,13 +203,15 @@ After pyenv has been installed, add python 3.4. On macOS use:
 
   CFLAGS="-I$(brew --prefix openssl)/include" \
   LDFLAGS="-L$(brew --prefix openssl)/lib" \
-  pyenv install -v 3.4.3
+  pyenv install -v 3.4.5
+  pyenv install -v 3.5.2
 
 For others OS this is easier:
 
 .. code:: bash
 
-  pyenv install -v 3.4.3
+  pyenv install -v 3.4.5
+  pyenv install -v 3.5.2
 
 Make sure to install the ``tox`` module for multi-environment testing:
 
@@ -222,7 +224,7 @@ Afterwards, install the necessary dependencies for each environment and to set t
 .. code:: bash
 
   pip3 install .
-  pyenv local system 3.4.3
+  pyenv local system 3.4.5 3.5.2
 
 Running
 ^^^^^^^


### PR DESCRIPTION
The tests are running in Python 3.4.x and 3.5.x: https://github.com/typesafehub/conductr-cli/blob/master/tox.ini#L2

The README instructions are updated accordingly so that the developer need to install Python 3.4.5 and 3.5.2 via pyenv.