### PR TITLE
Remove cleanup_old_cache_location() for now

### DIFF
--- a/conductr_cli/conduct_load.py
+++ b/conductr_cli/conduct_load.py
@@ -3,7 +3,7 @@ from pyhocon.exceptions import ConfigMissingException
 from conductr_cli import bundle_utils, conduct_request, conduct_url, screen_utils, validation
 from conductr_cli.exceptions import MalformedBundleError, InsecureFilePermissions
 from conductr_cli import resolver, bundle_installation
-from conductr_cli.constants import DEFAULT_RESOLVE_CACHE_DIR, DEFAULT_BUNDLE_RESOLVE_CACHE_DIR, \
+from conductr_cli.constants import DEFAULT_BUNDLE_RESOLVE_CACHE_DIR, \
     DEFAULT_CONFIGURATION_RESOLVE_CACHE_DIR
 from conductr_cli.conduct_url import conductr_host
 from functools import partial
@@ -33,7 +33,6 @@ KEEP_BUNDLE_VERSIONS = 1
 @validation.handle_insecure_file_permissions
 @validation.handle_bintray_credentials_error
 def load(args):
-    cleanup_old_cache_location()
     if args.api_version == '1':
         return load_v1(args)
     else:
@@ -250,16 +249,6 @@ def conduct_load_progress_monitor(log):
 
 def string_io(input_text):
     return io.StringIO(input_text)
-
-
-def cleanup_old_cache_location():
-    """
-    Removes files under `~/.cache` directory.
-    Nowadays, the files are cached under `/.cache/bundle` and `/.cache/configuration`.
-    """
-    for entry in os.scandir(DEFAULT_RESOLVE_CACHE_DIR):
-        if entry.is_file():
-            os.remove(entry.path)
 
 
 def cleanup_old_bundles(cache_dir, bundle_file_name, excluded):

--- a/conductr_cli/test/conduct_load_test_base.py
+++ b/conductr_cli/test/conduct_load_test_base.py
@@ -62,13 +62,11 @@ class ConductLoadTestBase(CliTestCase):
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
         wait_for_installation_mock = MagicMock()
-        cleanup_old_cache_location_mock = MagicMock()
         cleanup_old_bundles_mock = MagicMock()
 
         input_args = MagicMock(**self.default_args)
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
-                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
                 patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
@@ -103,12 +101,10 @@ class ConductLoadTestBase(CliTestCase):
         open_mock = MagicMock(return_value=1)
         wait_for_installation_mock = MagicMock()
         cleanup_old_bundles_mock = MagicMock()
-        cleanup_old_cache_location_mock = MagicMock()
 
         input_args = MagicMock(**self.default_args)
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
-                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
                 patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('dcos.http.post', http_method), \
                 patch('builtins.open', open_mock), \
@@ -139,7 +135,6 @@ class ConductLoadTestBase(CliTestCase):
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
         wait_for_installation_mock = MagicMock()
-        cleanup_old_cache_location_mock = MagicMock()
         cleanup_old_bundles_mock = MagicMock()
 
         args = self.default_args.copy()
@@ -148,7 +143,6 @@ class ConductLoadTestBase(CliTestCase):
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
-                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
                 patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
@@ -179,7 +173,6 @@ class ConductLoadTestBase(CliTestCase):
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
         wait_for_installation_mock = MagicMock()
-        cleanup_old_cache_location_mock = MagicMock()
         cleanup_old_bundles_mock = MagicMock()
 
         args = self.default_args.copy()
@@ -188,7 +181,6 @@ class ConductLoadTestBase(CliTestCase):
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
-                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
                 patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
@@ -219,7 +211,6 @@ class ConductLoadTestBase(CliTestCase):
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
         wait_for_installation_mock = MagicMock()
-        cleanup_old_cache_location_mock = MagicMock()
         cleanup_old_bundles_mock = MagicMock()
 
         args = self.default_args.copy()
@@ -228,7 +219,6 @@ class ConductLoadTestBase(CliTestCase):
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
-                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
                 patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
@@ -259,7 +249,6 @@ class ConductLoadTestBase(CliTestCase):
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
         wait_for_installation_mock = MagicMock()
-        cleanup_old_cache_location_mock = MagicMock()
         cleanup_old_bundles_mock = MagicMock()
 
         cli_parameters = ' --ip 127.0.1.1 --port 9006'
@@ -269,7 +258,6 @@ class ConductLoadTestBase(CliTestCase):
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
-                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
                 patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
@@ -302,7 +290,6 @@ class ConductLoadTestBase(CliTestCase):
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
         wait_for_installation_mock = MagicMock()
-        cleanup_old_cache_location_mock = MagicMock()
         cleanup_old_bundles_mock = MagicMock()
 
         cli_parameters = ' --host 127.0.1.1 --port 9006'
@@ -312,7 +299,6 @@ class ConductLoadTestBase(CliTestCase):
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
-                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
                 patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
@@ -350,13 +336,11 @@ class ConductLoadTestBase(CliTestCase):
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
         wait_for_installation_mock = MagicMock()
-        cleanup_old_cache_location_mock = MagicMock()
         cleanup_old_bundles_mock = MagicMock()
 
         input_args = MagicMock(**args)
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
-                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
                 patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
@@ -386,7 +370,6 @@ class ConductLoadTestBase(CliTestCase):
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
-        cleanup_old_cache_location_mock = MagicMock()
         cleanup_old_bundles_mock = MagicMock()
 
         args = self.default_args.copy()
@@ -395,7 +378,6 @@ class ConductLoadTestBase(CliTestCase):
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
-                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
                 patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock):
@@ -423,7 +405,6 @@ class ConductLoadTestBase(CliTestCase):
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
-        cleanup_old_cache_location_mock = MagicMock()
         cleanup_old_bundles_mock = MagicMock()
         wait_for_installation_mock = MagicMock()
 
@@ -433,7 +414,6 @@ class ConductLoadTestBase(CliTestCase):
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
-                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
                 patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
@@ -463,12 +443,10 @@ class ConductLoadTestBase(CliTestCase):
         stdout = MagicMock()
         stderr = MagicMock()
         open_mock = MagicMock(return_value=1)
-        cleanup_old_cache_location_mock = MagicMock()
 
         input_args = MagicMock(**self.default_args)
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
-                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock):
             logging_setup.configure_logging(input_args, stdout, stderr)
@@ -497,12 +475,10 @@ class ConductLoadTestBase(CliTestCase):
         stdout = MagicMock()
         stderr = MagicMock()
         open_mock = MagicMock(return_value=1)
-        cleanup_old_cache_location_mock = MagicMock()
 
         input_args = MagicMock(**self.default_args)
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
-                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock):
             logging_setup.configure_logging(input_args, stdout, stderr)
@@ -527,7 +503,6 @@ class ConductLoadTestBase(CliTestCase):
         resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, self.bundle_file))
         create_multipart_mock = MagicMock(return_value=self.multipart_mock)
         http_method = self.raise_read_timeout_error('test reason', self.default_url)
-        cleanup_old_cache_location_mock = MagicMock()
         stdout = MagicMock()
         stderr = MagicMock()
         open_mock = MagicMock(return_value=1)
@@ -535,7 +510,6 @@ class ConductLoadTestBase(CliTestCase):
         input_args = MagicMock(**self.default_args)
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
-                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock):
             logging_setup.configure_logging(input_args, stdout, stderr)
@@ -563,10 +537,8 @@ class ConductLoadTestBase(CliTestCase):
         resolve_bundle_mock = MagicMock(side_effect=BundleResolutionError('some message'))
         stdout = MagicMock()
         stderr = MagicMock()
-        cleanup_old_cache_location_mock = MagicMock()
 
-        with patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
-                patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
+        with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
             args = self.default_args.copy()
             args.update({'bundle': 'no_such.bundle'})
             logging_setup.configure_logging(MagicMock(**args), stdout, stderr)
@@ -586,11 +558,9 @@ class ConductLoadTestBase(CliTestCase):
         resolve_bundle_configuration_mock = MagicMock(side_effect=BundleResolutionError('some message'))
         stdout = MagicMock()
         stderr = MagicMock()
-        cleanup_old_cache_location_mock = MagicMock()
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
-                patch('conductr_cli.resolver.resolve_bundle_configuration', resolve_bundle_configuration_mock), \
-                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock):
+                patch('conductr_cli.resolver.resolve_bundle_configuration', resolve_bundle_configuration_mock):
             args = self.default_args.copy()
             args.update({'configuration': 'no_such.conf'})
             logging_setup.configure_logging(MagicMock(**args), stdout, stderr)
@@ -611,10 +581,8 @@ class ConductLoadTestBase(CliTestCase):
         resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, self.bundle_file))
         stderr = MagicMock()
         open_mock = MagicMock(side_effect=BadZipFile('test bad zip error'))
-        cleanup_old_cache_location_mock = MagicMock()
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
-                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
                 patch('builtins.open', open_mock):
             logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
             result = conduct_load.load(MagicMock(**self.default_args))
@@ -633,10 +601,8 @@ class ConductLoadTestBase(CliTestCase):
         add_info_mock = MagicMock()
         resolve_bundle_mock = MagicMock(side_effect=HTTPError('url', 'code', 'message', 'headers', add_info_mock))
         stderr = MagicMock()
-        cleanup_old_cache_location_mock = MagicMock()
 
-        with patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
-                patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
+        with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
             logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
             result = conduct_load.load(MagicMock(**self.default_args))
             self.assertFalse(result)
@@ -652,10 +618,8 @@ class ConductLoadTestBase(CliTestCase):
     def base_test_failure_no_file_url_error(self):
         resolve_bundle_mock = MagicMock(side_effect=URLError('reason', None))
         stderr = MagicMock()
-        cleanup_old_cache_location_mock = MagicMock()
 
-        with patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
-                patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
+        with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
             logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
             result = conduct_load.load(MagicMock(**self.default_args))
             self.assertFalse(result)
@@ -674,7 +638,6 @@ class ConductLoadTestBase(CliTestCase):
         http_method = self.respond_with(200, self.default_response)
         stderr = MagicMock()
         open_mock = MagicMock(return_value=1)
-        cleanup_old_cache_location_mock = MagicMock()
         wait_for_installation_mock = MagicMock(side_effect=WaitTimeoutError('test timeout'))
 
         input_args = MagicMock(**self.default_args)
@@ -682,7 +645,6 @@ class ConductLoadTestBase(CliTestCase):
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
-                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
             logging_setup.configure_logging(input_args, err_output=stderr)
             result = conduct_load.load(input_args)

--- a/conductr_cli/test/test_conduct_load_v1.py
+++ b/conductr_cli/test/test_conduct_load_v1.py
@@ -107,7 +107,6 @@ class TestConductLoadCommand(ConductLoadTestBase):
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
-        cleanup_old_cache_location_mock = MagicMock()
         wait_for_installation_mock = MagicMock()
 
         args = self.default_args.copy()
@@ -119,7 +118,6 @@ class TestConductLoadCommand(ConductLoadTestBase):
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
-                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_load.load(input_args)
@@ -178,9 +176,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
                             |""").format(self.memory, self.disk_space, ', '.join(self.roles)))
 
         resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, bundle_file))
-        cleanup_old_cache_location_mock = MagicMock()
-        with patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
-                patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
+        with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
             args = self.default_args.copy()
             args.update({'bundle': bundle_file})
             logging_setup.configure_logging(MagicMock(**args), err_output=stderr)
@@ -208,9 +204,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
                             |""").format(self.nr_of_cpus, self.disk_space, ', '.join(self.roles)))
 
         resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, bundle_file))
-        cleanup_old_cache_location_mock = MagicMock()
-        with patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
-                patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
+        with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
             args = self.default_args.copy()
             args.update({'bundle': bundle_file})
             logging_setup.configure_logging(MagicMock(**args), err_output=stderr)
@@ -238,9 +232,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
                             |""").format(self.nr_of_cpus, self.memory, ', '.join(self.roles)))
 
         resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, bundle_file))
-        cleanup_old_cache_location_mock = MagicMock()
-        with patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
-                patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
+        with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
             args = self.default_args.copy()
             args.update({'bundle': bundle_file})
             logging_setup.configure_logging(MagicMock(**args), err_output=stderr)
@@ -268,9 +260,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
                             |""").format(self.nr_of_cpus, self.memory, self.disk_space))
 
         resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, bundle_file))
-        cleanup_old_cache_location_mock = MagicMock()
-        with patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
-                patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
+        with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
             args = self.default_args.copy()
             args.update({'bundle': bundle_file})
             logging_setup.configure_logging(MagicMock(**args), err_output=stderr)
@@ -299,9 +289,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
                             |""").format(self.nr_of_cpus, self.memory, self.disk_space, '-'.join(self.roles)))
 
         resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, bundle_file))
-        cleanup_old_cache_location_mock = MagicMock()
-        with patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
-                patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
+        with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock):
             args = self.default_args.copy()
             args.update({'bundle': bundle_file})
             logging_setup.configure_logging(MagicMock(**args), err_output=stderr)

--- a/conductr_cli/test/test_conduct_load_v2.py
+++ b/conductr_cli/test/test_conduct_load_v2.py
@@ -158,7 +158,6 @@ class TestConductLoadCommand(ConductLoadTestBase):
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
-        cleanup_old_cache_location_mock = MagicMock()
         wait_for_installation_mock = MagicMock()
 
         args = self.default_args.copy()
@@ -172,7 +171,6 @@ class TestConductLoadCommand(ConductLoadTestBase):
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
-                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_load.load(input_args)
@@ -236,7 +234,6 @@ class TestConductLoadCommand(ConductLoadTestBase):
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
-        cleanup_old_cache_location_mock = MagicMock()
         wait_for_installation_mock = MagicMock()
 
         args = self.default_args.copy()
@@ -250,7 +247,6 @@ class TestConductLoadCommand(ConductLoadTestBase):
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
-                patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_load.load(input_args)
@@ -354,11 +350,9 @@ class TestConductLoadCommand(ConductLoadTestBase):
     def test_failure_no_bundle_conf(self):
         resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, self.bundle_file))
         conf_mock = MagicMock(return_value=None)
-        cleanup_old_cache_location_mock = MagicMock()
         stderr = MagicMock()
 
-        with patch('conductr_cli.conduct_load.cleanup_old_cache_location', cleanup_old_cache_location_mock), \
-                patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
+        with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.bundle_utils.conf', conf_mock):
             args = self.default_args.copy()
             logging_setup.configure_logging(MagicMock(**args), err_output=stderr)


### PR DESCRIPTION
This is removed as `os.scandir` throws exception if the directory doesn't exist, and it will also fail as it's not available in Python 3.4