### PR TITLE
Progress bar for terminals only

### DIFF
--- a/conductr_cli/logging_setup.py
+++ b/conductr_cli/logging_setup.py
@@ -77,13 +77,14 @@ def progress(self, message, *args, **kwargs):
     log.info('Hey')
     ```
     """
-    flush_required = kwargs.pop('flush')
+    if sys.stdout.isatty():
+        flush_required = kwargs.pop('flush')
 
-    line_end = '\r'
-    if flush_required:
-        line_end = '\n'
+        line_end = '\r'
+        if flush_required:
+            line_end = '\n'
 
-    self.log(LOG_LEVEL_PROGRESS, '{}{}'.format(message, line_end), *args, **kwargs)
+        self.log(LOG_LEVEL_PROGRESS, '{}{}'.format(message, line_end), *args, **kwargs)
 
 
 def is_verbose_enabled(self):

--- a/conductr_cli/test/test_bundle_deploy.py
+++ b/conductr_cli/test/test_bundle_deploy.py
@@ -175,6 +175,7 @@ class TestWaitForDeployment(CliTestCase):
         ])
 
         stdout = MagicMock()
+        is_tty_mock = MagicMock(return_value=True)
 
         deployment_id = 'a101449418187d92c789d1adc240b6d6'
         resolved_version = {
@@ -197,7 +198,8 @@ class TestWaitForDeployment(CliTestCase):
         with patch('conductr_cli.conduct_url.url', url_mock), \
                 patch('conductr_cli.conduct_url.conductr_host', conductr_host_mock), \
                 patch('conductr_cli.bundle_deploy.get_deployment_state', get_deployment_state_mock), \
-                patch('conductr_cli.sse_client.get_events', get_events_mock):
+                patch('conductr_cli.sse_client.get_events', get_events_mock), \
+                patch('sys.stdout.isatty', is_tty_mock):
             logging_setup.configure_logging(args, stdout)
             bundle_deploy.wait_for_deployment_complete(deployment_id, resolved_version, args)
 
@@ -302,6 +304,7 @@ class TestWaitForDeployment(CliTestCase):
         ])
 
         stdout = MagicMock()
+        is_tty_mock = MagicMock(return_value=True)
 
         deployment_id = 'a101449418187d92c789d1adc240b6d6'
         resolved_version = {
@@ -324,7 +327,8 @@ class TestWaitForDeployment(CliTestCase):
         with patch('conductr_cli.conduct_url.url', url_mock), \
                 patch('conductr_cli.conduct_url.conductr_host', conductr_host_mock), \
                 patch('conductr_cli.bundle_deploy.get_deployment_state', get_deployment_state_mock), \
-                patch('conductr_cli.sse_client.get_events', get_events_mock):
+                patch('conductr_cli.sse_client.get_events', get_events_mock), \
+                patch('sys.stdout.isatty', is_tty_mock):
             logging_setup.configure_logging(args, stdout)
             bundle_deploy.wait_for_deployment_complete(deployment_id, resolved_version, args)
 
@@ -539,6 +543,7 @@ class TestWaitForDeployment(CliTestCase):
         ])
 
         stdout = MagicMock()
+        is_tty_mock = MagicMock(return_value=True)
 
         deployment_id = 'a101449418187d92c789d1adc240b6d6'
         resolved_version = {
@@ -561,7 +566,8 @@ class TestWaitForDeployment(CliTestCase):
         with patch('conductr_cli.conduct_url.url', url_mock), \
                 patch('conductr_cli.conduct_url.conductr_host', conductr_host_mock), \
                 patch('conductr_cli.bundle_deploy.get_deployment_state', get_deployment_state_mock), \
-                patch('conductr_cli.sse_client.get_events', get_events_mock):
+                patch('conductr_cli.sse_client.get_events', get_events_mock), \
+                patch('sys.stdout.isatty', is_tty_mock):
             logging_setup.configure_logging(args, stdout)
             bundle_deploy.wait_for_deployment_complete(deployment_id, resolved_version, args)
 
@@ -673,6 +679,7 @@ class TestWaitForDeployment(CliTestCase):
         ])
 
         stdout = MagicMock()
+        is_tty_mock = MagicMock(return_value=True)
 
         deployment_id = 'a101449418187d92c789d1adc240b6d6'
         resolved_version = {
@@ -695,7 +702,8 @@ class TestWaitForDeployment(CliTestCase):
         with patch('conductr_cli.conduct_url.url', url_mock), \
                 patch('conductr_cli.conduct_url.conductr_host', conductr_host_mock), \
                 patch('conductr_cli.bundle_deploy.get_deployment_state', get_deployment_state_mock), \
-                patch('conductr_cli.sse_client.get_events', get_events_mock):
+                patch('conductr_cli.sse_client.get_events', get_events_mock), \
+                patch('sys.stdout.isatty', is_tty_mock):
             logging_setup.configure_logging(args, stdout)
             self.assertRaises(ContinuousDeliveryError, bundle_deploy.wait_for_deployment_complete, deployment_id,
                               resolved_version, args)

--- a/conductr_cli/test/test_bundle_installation.py
+++ b/conductr_cli/test/test_bundle_installation.py
@@ -272,6 +272,7 @@ class TestWaitForInstallation(CliTestCase):
         ])
 
         stdout = MagicMock()
+        is_tty_mock = MagicMock(return_value=True)
 
         bundle_id = 'a101449418187d92c789d1adc240b6d6'
         dcos_mode = False
@@ -284,7 +285,8 @@ class TestWaitForInstallation(CliTestCase):
         with patch('conductr_cli.conduct_url.url', url_mock), \
                 patch('conductr_cli.conduct_url.conductr_host', conductr_host_mock), \
                 patch('conductr_cli.bundle_installation.count_installations', count_installations_mock), \
-                patch('conductr_cli.sse_client.get_events', get_events_mock):
+                patch('conductr_cli.sse_client.get_events', get_events_mock), \
+                patch('sys.stdout.isatty', is_tty_mock):
             logging_setup.configure_logging(args, stdout)
             bundle_installation.wait_for_installation(bundle_id, args)
 
@@ -331,6 +333,7 @@ class TestWaitForInstallation(CliTestCase):
         ])
 
         stdout = MagicMock()
+        is_tty_mock = MagicMock(return_value=True)
 
         bundle_id = 'a101449418187d92c789d1adc240b6d6'
         dcos_mode = True
@@ -343,7 +346,8 @@ class TestWaitForInstallation(CliTestCase):
         with patch('conductr_cli.conduct_url.url', url_mock), \
                 patch('conductr_cli.conduct_url.conductr_host', conductr_host_mock), \
                 patch('conductr_cli.bundle_installation.count_installations', count_installations_mock), \
-                patch('conductr_cli.sse_client.get_events', get_events_mock):
+                patch('conductr_cli.sse_client.get_events', get_events_mock), \
+                patch('sys.stdout.isatty', is_tty_mock):
             logging_setup.configure_logging(args, stdout)
             bundle_installation.wait_for_installation(bundle_id, args)
 
@@ -390,6 +394,7 @@ class TestWaitForInstallation(CliTestCase):
         ])
 
         stdout = MagicMock()
+        is_tty_mock = MagicMock(return_value=True)
 
         bundle_id = 'a101449418187d92c789d1adc240b6d6'
         dcos_mode = True
@@ -402,7 +407,8 @@ class TestWaitForInstallation(CliTestCase):
         with patch('conductr_cli.conduct_url.url', url_mock), \
                 patch('conductr_cli.conduct_url.conductr_host', conductr_host_mock), \
                 patch('conductr_cli.bundle_installation.count_installations', count_installations_mock), \
-                patch('conductr_cli.sse_client.get_events', get_events_mock):
+                patch('conductr_cli.sse_client.get_events', get_events_mock), \
+                patch('sys.stdout.isatty', is_tty_mock):
             logging_setup.configure_logging(args, stdout)
             self.assertRaises(WaitTimeoutError, bundle_installation.wait_for_installation, bundle_id, args)
 
@@ -515,6 +521,7 @@ class TestWaitForInstallation(CliTestCase):
         ])
 
         stdout = MagicMock()
+        is_tty_mock = MagicMock(return_value=True)
 
         bundle_id = 'a101449418187d92c789d1adc240b6d6'
         dcos_mode = True
@@ -527,7 +534,8 @@ class TestWaitForInstallation(CliTestCase):
         with patch('conductr_cli.conduct_url.url', url_mock), \
                 patch('conductr_cli.bundle_installation.count_installations', count_installations_mock), \
                 patch('conductr_cli.conduct_url.conductr_host', conductr_host_mock), \
-                patch('conductr_cli.sse_client.get_events', get_events_mock):
+                patch('conductr_cli.sse_client.get_events', get_events_mock), \
+                patch('sys.stdout.isatty', is_tty_mock):
             logging_setup.configure_logging(args, stdout)
             self.assertRaises(WaitTimeoutError, bundle_installation.wait_for_installation, bundle_id, args)
 
@@ -698,6 +706,7 @@ class TestWaitForUninstallation(CliTestCase):
         ])
 
         stdout = MagicMock()
+        is_tty_mock = MagicMock(return_value=True)
 
         bundle_id = 'a101449418187d92c789d1adc240b6d6'
         dcos_mode = True
@@ -710,7 +719,8 @@ class TestWaitForUninstallation(CliTestCase):
         with patch('conductr_cli.conduct_url.url', url_mock), \
                 patch('conductr_cli.bundle_installation.count_installations', count_installations_mock), \
                 patch('conductr_cli.conduct_url.conductr_host', conductr_host_mock), \
-                patch('conductr_cli.sse_client.get_events', get_events_mock):
+                patch('conductr_cli.sse_client.get_events', get_events_mock), \
+                patch('sys.stdout.isatty', is_tty_mock):
             logging_setup.configure_logging(args, stdout)
             self.assertRaises(WaitTimeoutError, bundle_installation.wait_for_uninstallation, bundle_id, args)
 

--- a/conductr_cli/test/test_bundle_scale.py
+++ b/conductr_cli/test/test_bundle_scale.py
@@ -323,6 +323,7 @@ class TestWaitForScale(CliTestCase):
         ])
 
         stdout = MagicMock()
+        is_tty_mock = MagicMock(return_value=True)
 
         bundle_id = 'a101449418187d92c789d1adc240b6d6'
         dcos_mode = False
@@ -336,7 +337,8 @@ class TestWaitForScale(CliTestCase):
         with patch('conductr_cli.conduct_url.url', url_mock), \
                 patch('conductr_cli.conduct_url.conductr_host', conductr_host_mock), \
                 patch('conductr_cli.bundle_scale.get_scale', get_scale_mock), \
-                patch('conductr_cli.sse_client.get_events', get_events_mock):
+                patch('conductr_cli.sse_client.get_events', get_events_mock), \
+                patch('sys.stdout.isatty', is_tty_mock):
             logging_setup.configure_logging(args, stdout)
             bundle_scale.wait_for_scale(bundle_id, 3, args)
 
@@ -396,6 +398,7 @@ class TestWaitForScale(CliTestCase):
         ])
 
         stdout = MagicMock()
+        is_tty_mock = MagicMock(return_value=True)
 
         bundle_id = 'a101449418187d92c789d1adc240b6d6'
         dcos_mode = False
@@ -408,7 +411,8 @@ class TestWaitForScale(CliTestCase):
         with patch('conductr_cli.conduct_url.url', url_mock), \
                 patch('conductr_cli.conduct_url.conductr_host', conductr_host_mock), \
                 patch('conductr_cli.bundle_scale.get_scale', get_scale_mock), \
-                patch('conductr_cli.sse_client.get_events', get_events_mock):
+                patch('conductr_cli.sse_client.get_events', get_events_mock), \
+                patch('sys.stdout.isatty', is_tty_mock):
             logging_setup.configure_logging(args, stdout)
             bundle_scale.wait_for_scale(bundle_id, 3, args)
 
@@ -470,6 +474,7 @@ class TestWaitForScale(CliTestCase):
         ])
 
         stdout = MagicMock()
+        is_tty_mock = MagicMock(return_value=True)
 
         bundle_id = 'a101449418187d92c789d1adc240b6d6'
         dcos_mode = False
@@ -482,7 +487,8 @@ class TestWaitForScale(CliTestCase):
         with patch('conductr_cli.conduct_url.url', url_mock), \
                 patch('conductr_cli.conduct_url.conductr_host', conductr_host_mock), \
                 patch('conductr_cli.bundle_scale.get_scale', get_scale_mock), \
-                patch('conductr_cli.sse_client.get_events', get_events_mock):
+                patch('conductr_cli.sse_client.get_events', get_events_mock), \
+                patch('sys.stdout.isatty', is_tty_mock):
             logging_setup.configure_logging(args, stdout)
             self.assertRaises(WaitTimeoutError, bundle_scale.wait_for_scale, bundle_id, 3, args)
 
@@ -599,6 +605,7 @@ class TestWaitForScale(CliTestCase):
         ])
 
         stdout = MagicMock()
+        is_tty_mock = MagicMock(return_value=True)
 
         bundle_id = 'a101449418187d92c789d1adc240b6d6'
         dcos_mode = False
@@ -611,7 +618,8 @@ class TestWaitForScale(CliTestCase):
         with patch('conductr_cli.conduct_url.url', url_mock), \
                 patch('conductr_cli.conduct_url.conductr_host', conductr_host_mock), \
                 patch('conductr_cli.bundle_scale.get_scale', get_scale_mock), \
-                patch('conductr_cli.sse_client.get_events', get_events_mock):
+                patch('conductr_cli.sse_client.get_events', get_events_mock), \
+                patch('sys.stdout.isatty', is_tty_mock):
             logging_setup.configure_logging(args, stdout)
             self.assertRaises(WaitTimeoutError, bundle_scale.wait_for_scale, bundle_id, 3, args)
 

--- a/conductr_cli/test/test_logging_setup.py
+++ b/conductr_cli/test/test_logging_setup.py
@@ -1,22 +1,24 @@
 from conductr_cli.test.cli_test_case import CliTestCase, as_error, as_warn, strip_margin
 from conductr_cli import logging_setup
-from unittest.mock import MagicMock
+from unittest.mock import patch, MagicMock
 import logging
 
 
 class TestRootLogger(CliTestCase):
     def test_should_display_error_only(self):
         stdout = MagicMock()
+        is_tty_mock = MagicMock(return_value=True)
         stderr = MagicMock()
         logging_setup.configure_logging(MagicMock(), stdout, stderr)
 
-        log = logging.getLogger()
-        log.debug('this is debug')
-        log.verbose('this is verbose')
-        log.info('this is info')
-        log.quiet('this is quiet')
-        log.warning('this is warning')
-        log.error('this is error')
+        with patch('sys.stdout.isatty', is_tty_mock):
+            log = logging.getLogger()
+            log.debug('this is debug')
+            log.verbose('this is verbose')
+            log.info('this is info')
+            log.quiet('this is quiet')
+            log.warning('this is warning')
+            log.error('this is error')
 
         self.assertFalse(log.is_debug_enabled())
         self.assertFalse(log.is_verbose_enabled())
@@ -31,18 +33,20 @@ class TestRootLogger(CliTestCase):
 class TestConductrCliLogger(CliTestCase):
     def test_default_settings(self):
         stdout = MagicMock()
+        is_tty_mock = MagicMock(return_value=True)
         stderr = MagicMock()
         logging_setup.configure_logging(MagicMock(), stdout, stderr)
 
-        log = logging.getLogger('conductr_cli')
-        log.debug('this is debug')
-        log.verbose('this is verbose')
-        log.info('this is info')
-        log.progress('this is progress', flush=True)
-        log.quiet('this is quiet')
-        log.warning('this is warning')
-        log.error('this is error')
-        log.screen('this is screen')
+        with patch('sys.stdout.isatty', is_tty_mock):
+            log = logging.getLogger('conductr_cli')
+            log.debug('this is debug')
+            log.verbose('this is verbose')
+            log.info('this is info')
+            log.progress('this is progress', flush=True)
+            log.quiet('this is quiet')
+            log.warning('this is warning')
+            log.error('this is error')
+            log.screen('this is screen')
 
         self.assertFalse(log.is_debug_enabled())
         self.assertFalse(log.is_verbose_enabled())
@@ -61,18 +65,20 @@ class TestConductrCliLogger(CliTestCase):
 
     def test_verbose_settings(self):
         stdout = MagicMock()
+        is_tty_mock = MagicMock(return_value=True)
         stderr = MagicMock()
         logging_setup.configure_logging(MagicMock(**{'verbose': True}), stdout, stderr)
 
-        log = logging.getLogger('conductr_cli')
-        log.debug('this is debug')
-        log.verbose('this is verbose')
-        log.info('this is info')
-        log.progress('this is progress', flush=True)
-        log.quiet('this is quiet')
-        log.warning('this is warning')
-        log.error('this is error')
-        log.screen('this is screen')
+        with patch('sys.stdout.isatty', is_tty_mock):
+            log = logging.getLogger('conductr_cli')
+            log.debug('this is debug')
+            log.verbose('this is verbose')
+            log.info('this is info')
+            log.progress('this is progress', flush=True)
+            log.quiet('this is quiet')
+            log.warning('this is warning')
+            log.error('this is error')
+            log.screen('this is screen')
 
         self.assertFalse(log.is_debug_enabled())
         self.assertTrue(log.is_verbose_enabled())
@@ -92,18 +98,20 @@ class TestConductrCliLogger(CliTestCase):
 
     def test_quiet_settings(self):
         stdout = MagicMock()
+        is_tty_mock = MagicMock(return_value=True)
         stderr = MagicMock()
         logging_setup.configure_logging(MagicMock(**{'quiet': True}), stdout, stderr)
 
-        log = logging.getLogger('conductr_cli')
-        log.debug('this is debug')
-        log.verbose('this is verbose')
-        log.info('this is info')
-        log.progress('this is progress', flush=True)
-        log.quiet('this is quiet')
-        log.warning('this is warning')
-        log.error('this is error')
-        log.screen('this is screen')
+        with patch('sys.stdout.isatty', is_tty_mock):
+            log = logging.getLogger('conductr_cli')
+            log.debug('this is debug')
+            log.verbose('this is verbose')
+            log.info('this is info')
+            log.progress('this is progress', flush=True)
+            log.quiet('this is quiet')
+            log.warning('this is warning')
+            log.error('this is error')
+            log.screen('this is screen')
 
         self.assertFalse(log.is_debug_enabled())
         self.assertFalse(log.is_verbose_enabled())
@@ -120,13 +128,15 @@ class TestConductrCliLogger(CliTestCase):
 
     def test_progress_terminal_replace_characters(self):
         stdout = MagicMock()
+        is_tty_mock = MagicMock(return_value=True)
         stderr = MagicMock()
         logging_setup.configure_logging(MagicMock(), stdout, stderr)
 
-        log = logging.getLogger('conductr_cli')
-        log.progress('1', flush=False)
-        log.progress('**', flush=False)
-        log.progress('XYZ', flush=True)
+        with patch('sys.stdout.isatty', is_tty_mock):
+            log = logging.getLogger('conductr_cli')
+            log.progress('1', flush=False)
+            log.progress('**', flush=False)
+            log.progress('XYZ', flush=True)
 
         char_output = [c for c in self.output(stdout)]
         self.assertEqual(['1', '\r',

--- a/conductr_cli/test/test_sandbox_run.py
+++ b/conductr_cli/test/test_sandbox_run.py
@@ -271,6 +271,7 @@ class TestSandboxRunCommand(CliTestCase):
 class TestWaitForStart(CliTestCase):
     def test_wait_for_start(self):
         stdout = MagicMock()
+        is_tty_mock = MagicMock(return_value=True)
         mock_get_env = MagicMock(return_value=1)
 
         members_url = '/members'
@@ -281,7 +282,8 @@ class TestWaitForStart(CliTestCase):
         with \
                 patch('os.getenv', mock_get_env), \
                 patch('conductr_cli.conduct_url.url', mock_url), \
-                patch('conductr_cli.conduct_request.get', mock_http_get):
+                patch('conductr_cli.conduct_request.get', mock_http_get), \
+                patch('sys.stdout.isatty', is_tty_mock):
             args = MagicMock(**{
                 'no_wait': False
             })
@@ -313,6 +315,7 @@ class TestWaitForStart(CliTestCase):
 
     def test_wait_for_start_timeout(self):
         stdout = MagicMock()
+        is_tty_mock = MagicMock(return_value=True)
         mock_get_env = MagicMock(return_value=1)
 
         members_url = '/members'
@@ -323,7 +326,8 @@ class TestWaitForStart(CliTestCase):
         with \
                 patch('os.getenv', mock_get_env), \
                 patch('conductr_cli.conduct_url.url', mock_url), \
-                patch('conductr_cli.conduct_request.get', mock_http_get):
+                patch('conductr_cli.conduct_request.get', mock_http_get), \
+                patch('sys.stdout.isatty', is_tty_mock):
             args = MagicMock(**{
                 'no_wait': False
             })


### PR DESCRIPTION
Prior to this commit the progress bar output would pollute log files thus causing problems for destinations such as Travis CI builds. This commit now only outputs the progress bar when a terminal is being used; assumed by a human that is.

When running from a terminal:

```
Loading bundle configuration from cache typesafe/bundle-configuration/conductr-haproxy-dev-mode
Bintray credentials loaded from /Users/huntc/.lightbend/commercial.credentials
Retrieving from cache /Users/huntc/.conductr/cache/configuration/conductr-haproxy-dev-mode-v2-898a6faaf07e2342460e9cea76d7f74fd6fbca8b04d6742e7bc080f2b18e508f.zip
Loading bundle to ConductR..
[#################################################] 100%
Bundle b9fd79d2cb54784a4422d5a471d04a16-898a6faaf07e2342460e9cea76d7f74f is installed
```

...and when the output is directed to a file:

```
Loading bundle configuration from cache typesafe/bundle-configuration/conductr-haproxy-dev-mode
Bintray credentials loaded from /Users/huntc/.lightbend/commercial.credentials
Retrieving from cache /Users/huntc/.conductr/cache/configuration/conductr-haproxy-dev-mode-v2-898a6faaf07e2342460e9cea76d7f74fd6fbca8b04d6742e7bc080f2b18e508f.zip
Loading bundle to ConductR..
Bundle b9fd79d2cb54784a4422d5a471d04a16-898a6faaf07e2342460e9cea76d7f74f is installed
```