### PR TITLE
Implements `conduct members` and `conduct agents` sub-commands.

### DIFF
--- a/conductr_cli/conduct_agents.py
+++ b/conductr_cli/conduct_agents.py
@@ -36,7 +36,7 @@ def agents(args):
             data.append({
                 'address': entry['address'],
                 'roles': ','.join(entry['roles']),
-                'observed': ','.join(map(lambda e: e['node']['uid'], entry['observedBy']))
+                'observed': ','.join(map(lambda e: e['node']['address'], entry['observedBy']))
             })
 
     padding = 2

--- a/conductr_cli/conduct_agents.py
+++ b/conductr_cli/conduct_agents.py
@@ -1,0 +1,72 @@
+from conductr_cli import validation, conduct_request, conduct_url, screen_utils
+from conductr_cli.conduct_url import conductr_host
+import json
+import logging
+from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
+
+
+def calculate_row(entry):
+    return {
+        'address': entry['address'],
+        'roles': ','.join(entry['roles'])
+    }
+
+
+def calculate_rows(args, raw_data):
+    data = [
+        {
+            'address': 'ADDRESS',
+            'roles': 'ROLES'
+        }
+    ]
+
+    for entry in raw_data:
+        if include_entry(args, entry):
+            data.append(calculate_row(entry))
+
+    return data
+
+
+def format_rows(rows):
+    padding = 2
+    column_widths = dict(screen_utils.calc_column_widths(rows), **{'padding': ' ' * padding})
+
+    formatted = []
+
+    for row in rows:
+        formatted.append('''\
+{address: <{address_width}}{padding}\
+{roles: >{roles_width}}{padding}'''.format(**dict(row, **column_widths)).rstrip())
+
+    return formatted
+
+
+def include_entry(args, entry):
+    return args.role is None or args.role in entry['roles']
+
+
+@validation.handle_connection_error
+@validation.handle_http_error
+def agents(args):
+    """`conduct agents` command"""
+
+    log = logging.getLogger(__name__)
+
+    request_url = conduct_url.url('agents', args)
+    response = conduct_request.get(args.dcos_mode, conductr_host(args), request_url, auth=args.conductr_auth,
+                                   verify=args.server_verification_file, timeout=DEFAULT_HTTP_TIMEOUT)
+
+    validation.raise_for_status_inc_3xx(response)
+
+    if log.is_verbose_enabled():
+        log.verbose(validation.pretty_json(response.text))
+
+    raw_data = json.loads(response.text)
+
+    rows = calculate_rows(args, raw_data)
+    formatted_rows = format_rows(rows)
+
+    for line in formatted_rows:
+        log.screen(line)
+
+    return True

--- a/conductr_cli/conduct_main.py
+++ b/conductr_cli/conduct_main.py
@@ -1,7 +1,7 @@
 import argcomplete
 import argparse
 from conductr_cli import \
-    conduct_deploy, conduct_info, conduct_load, conduct_run, conduct_service_names, \
+    conduct_agents, conduct_deploy, conduct_info, conduct_load, conduct_members, conduct_run, conduct_service_names, \
     conduct_stop, conduct_unload, version, conduct_logs, \
     conduct_events, conduct_acls, conduct_dcos, host, logging_setup, \
     conduct_url, custom_settings
@@ -359,6 +359,32 @@ def build_parser(dcos_mode):
     add_no_wait(deploy_parser)
     add_long_ids(deploy_parser)
     deploy_parser.set_defaults(func=conduct_deploy.deploy)
+
+    # Sub-parser for `members` sub-command
+    members_parser = subparsers.add_parser('members',
+                                           help='Display cluster member information',
+                                           formatter_class=argparse.RawTextHelpFormatter)
+
+    add_default_arguments(members_parser, dcos_mode)
+
+    members_parser.add_argument('--role',
+                                help='Show only agents with supplied role',
+                                default=None)
+
+    members_parser.set_defaults(func=conduct_members.members)
+
+    # Sub-parser for `agents` sub-command
+    agents_parser = subparsers.add_parser('agents',
+                                          help='Display agent information',
+                                          formatter_class=argparse.RawTextHelpFormatter)
+
+    add_default_arguments(agents_parser, dcos_mode)
+
+    agents_parser.add_argument('--role',
+                               help='Show only agents with supplied role',
+                               default=None)
+
+    agents_parser.set_defaults(func=conduct_agents.agents)
 
     return parser
 

--- a/conductr_cli/conduct_members.py
+++ b/conductr_cli/conduct_members.py
@@ -1,0 +1,86 @@
+from conductr_cli import validation, conduct_request, conduct_url, screen_utils
+from conductr_cli.conduct_url import conductr_host
+import json
+import logging
+from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
+
+
+def calculate_row(entry, reachable):
+    return {
+        'address': entry['node']['address'],
+        'uid': entry['node']['uid'],
+        'roles': ','.join(entry['roles']),
+        'status': entry['status'],
+        'reachable': 'Yes' if reachable else 'No'
+    }
+
+
+def calculate_rows(args, raw_data):
+    data = [
+        {
+            'address': 'ADDRESS',
+            'uid': 'UID',
+            'roles': 'ROLES',
+            'status': 'STATUS',
+            'reachable': 'REACHABLE'
+        }
+    ]
+
+    unreachable_nodes = []
+
+    for entry in raw_data['unreachable']:
+        unreachable_nodes.append(entry['node'])
+
+    for entry in raw_data['members']:
+        if include_entry(args, entry):
+            data.append(calculate_row(entry, entry['node'] not in unreachable_nodes))
+
+    return data
+
+
+def format_rows(rows):
+    padding = 2
+    column_widths = dict(screen_utils.calc_column_widths(rows), **{'padding': ' ' * padding})
+
+    formatted = []
+
+    for row in rows:
+        formatted.append('''\
+{address: <{address_width}}{padding}\
+{uid: <{uid_width}}{padding}\
+{roles: <{roles_width}}{padding}\
+{status: <{status_width}}{padding}\
+{reachable: >{reachable_width}}'''.format(**dict(row, **column_widths)).rstrip())
+
+    return formatted
+
+
+def include_entry(args, entry):
+    return args.role is None or args.role in entry['roles']
+
+
+@validation.handle_connection_error
+@validation.handle_http_error
+def members(args):
+    """`conduct members` command"""
+
+    log = logging.getLogger(__name__)
+
+    request_url = conduct_url.url('members', args)
+    response = conduct_request.get(args.dcos_mode, conductr_host(args), request_url, auth=args.conductr_auth,
+                                   verify=args.server_verification_file, timeout=DEFAULT_HTTP_TIMEOUT)
+
+    validation.raise_for_status_inc_3xx(response)
+
+    if log.is_verbose_enabled():
+        log.verbose(validation.pretty_json(response.text))
+
+    raw_data = json.loads(response.text)
+
+    rows = calculate_rows(args, raw_data)
+    formatted_rows = format_rows(rows)
+
+    for line in formatted_rows:
+        log.screen(line)
+
+    return True

--- a/conductr_cli/test/test_conduct_agents.py
+++ b/conductr_cli/test/test_conduct_agents.py
@@ -1,0 +1,71 @@
+import json
+
+from conductr_cli.test.cli_test_case import CliTestCase
+from conductr_cli import conduct_agents
+from unittest.mock import MagicMock
+
+
+class TestConductMembersCommand(CliTestCase):
+    conductr_auth = ('username', 'password')
+    server_verification_file = MagicMock(name='server_verification_file')
+
+    default_args = {
+        'dcos_mode': False,
+        'scheme': 'http',
+        'host': '127.0.0.1',
+        'port': 9005,
+        'base_path': '/',
+        'api_version': '1',
+        'verbose': False,
+        'quiet': False,
+        'long_ids': False,
+        'conductr_auth': conductr_auth,
+        'server_verification_file': server_verification_file,
+        'role': None
+    }
+
+    filtered_by_role_asdf_args = default_args.copy()
+    filtered_by_role_asdf_args.update({'role': 'asdf'})
+
+    filtered_by_role_replicator_args = default_args.copy()
+    filtered_by_role_replicator_args.update({'role': 'web'})
+
+    example_json = json.loads(
+        """
+            [
+                {
+                    "address": "akka.tcp://conductr-agent@127.0.0.1:2552/user/reaper/cluster-client#1363584093",
+                    "roles": [
+                        "web"
+                    ],
+                    "observedBy": [
+                        {
+                            "node": {
+                                "uid": "-2007039750",
+                                "address": "akka.tcp://conductr@127.0.0.1:9004"
+                            }
+                        }
+                    ]
+                }
+            ]
+        """
+    )
+
+    def test_calculate_rows(self):
+        example_rows = conduct_agents.calculate_rows(MagicMock(**self.default_args), self.example_json)
+
+        self.assertEqual(example_rows[1], {
+            'address': 'akka.tcp://conductr-agent@127.0.0.1:2552/user/reaper/cluster-client#1363584093',
+            'roles': 'web'
+        })
+
+    def test_include_entry(self):
+        self.assertFalse(conduct_agents.include_entry(MagicMock(**self.filtered_by_role_asdf_args), {
+            'address': 'akka.tcp://conductr-agent@127.0.0.1:2552/user/reaper/cluster-client#1363584093',
+            'roles': 'web'
+        }))
+
+        self.assertTrue(conduct_agents.include_entry(MagicMock(**self.filtered_by_role_replicator_args), {
+            'address': 'akka.tcp://conductr-agent@127.0.0.1:2552/user/reaper/cluster-client#1363584093',
+            'roles': 'web'
+        }))

--- a/conductr_cli/test/test_conduct_agents.py
+++ b/conductr_cli/test/test_conduct_agents.py
@@ -91,10 +91,10 @@ class TestConductAgentsCommand(CliTestCase):
                                        timeout=DEFAULT_HTTP_TIMEOUT, headers={'Host': '127.0.0.1'})
 
         self.assertEqual(
-            strip_margin("""|ADDRESS                                                                            ROLES     OBSERVED BY
-                            |akka.tcp://conductr-agent@192.168.10.1:2552/user/reaper/cluster-client#-596247188  web,data   1129598726
-                            |akka.tcp://conductr-agent@192.168.10.2:2552/user/reaper/cluster-client#-775189131  web        1129598726
-                            |akka.tcp://conductr-agent@192.168.10.3:2552/user/reaper/cluster-client#1858099110  web,data   1129598726
+            strip_margin("""|ADDRESS                                                                            ROLES                               OBSERVED BY
+                            |akka.tcp://conductr-agent@192.168.10.1:2552/user/reaper/cluster-client#-596247188  web,data  akka.tcp://conductr@192.168.10.2:9004
+                            |akka.tcp://conductr-agent@192.168.10.2:2552/user/reaper/cluster-client#-775189131  web       akka.tcp://conductr@192.168.10.2:9004
+                            |akka.tcp://conductr-agent@192.168.10.3:2552/user/reaper/cluster-client#1858099110  web,data  akka.tcp://conductr@192.168.10.2:9004
                             |"""),
             self.output(stdout))
 
@@ -139,10 +139,10 @@ class TestConductAgentsCommand(CliTestCase):
         http_method.assert_called_with(self.default_url, auth=self.conductr_auth, verify=self.server_verification_file,
                                        timeout=DEFAULT_HTTP_TIMEOUT, headers={'Host': '127.0.0.1'})
         self.assertEqual(
-            strip_margin("""|ADDRESS                                                                            ROLES     OBSERVED BY
-                            |akka.tcp://conductr-agent@192.168.10.1:2552/user/reaper/cluster-client#-596247188  web,data   1129598726
-                            |akka.tcp://conductr-agent@192.168.10.2:2552/user/reaper/cluster-client#-775189131  web        1129598726
-                            |akka.tcp://conductr-agent@192.168.10.3:2552/user/reaper/cluster-client#1858099110  web,data   1129598726
+            strip_margin("""|ADDRESS                                                                            ROLES                               OBSERVED BY
+                            |akka.tcp://conductr-agent@192.168.10.1:2552/user/reaper/cluster-client#-596247188  web,data  akka.tcp://conductr@192.168.10.2:9004
+                            |akka.tcp://conductr-agent@192.168.10.2:2552/user/reaper/cluster-client#-775189131  web       akka.tcp://conductr@192.168.10.2:9004
+                            |akka.tcp://conductr-agent@192.168.10.3:2552/user/reaper/cluster-client#1858099110  web,data  akka.tcp://conductr@192.168.10.2:9004
                             |"""),
             self.output(stdout))
 
@@ -165,8 +165,8 @@ class TestConductAgentsCommand(CliTestCase):
         http_method.assert_called_with(self.default_url, auth=self.conductr_auth, verify=self.server_verification_file,
                                        timeout=DEFAULT_HTTP_TIMEOUT, headers={'Host': '127.0.0.1'})
         self.assertEqual(
-            strip_margin("""|ADDRESS                                                                            ROLES     OBSERVED BY
-                            |akka.tcp://conductr-agent@192.168.10.1:2552/user/reaper/cluster-client#-596247188  web,data   1129598726
-                            |akka.tcp://conductr-agent@192.168.10.3:2552/user/reaper/cluster-client#1858099110  web,data   1129598726
+            strip_margin("""|ADDRESS                                                                            ROLES                               OBSERVED BY
+                            |akka.tcp://conductr-agent@192.168.10.1:2552/user/reaper/cluster-client#-596247188  web,data  akka.tcp://conductr@192.168.10.2:9004
+                            |akka.tcp://conductr-agent@192.168.10.3:2552/user/reaper/cluster-client#1858099110  web,data  akka.tcp://conductr@192.168.10.2:9004
                             |"""),
             self.output(stdout))

--- a/conductr_cli/test/test_conduct_members.py
+++ b/conductr_cli/test/test_conduct_members.py
@@ -1,0 +1,116 @@
+import json
+
+from conductr_cli.test.cli_test_case import CliTestCase
+from conductr_cli import conduct_members
+from unittest.mock import MagicMock
+
+
+class TestConductMembersCommand(CliTestCase):
+    conductr_auth = ('username', 'password')
+    server_verification_file = MagicMock(name='server_verification_file')
+
+    default_args = {
+        'dcos_mode': False,
+        'scheme': 'http',
+        'host': '127.0.0.1',
+        'port': 9005,
+        'base_path': '/',
+        'api_version': '1',
+        'verbose': False,
+        'quiet': False,
+        'long_ids': False,
+        'conductr_auth': conductr_auth,
+        'server_verification_file': server_verification_file,
+        'role': None
+    }
+
+    filtered_by_role_asdf_args = default_args.copy()
+    filtered_by_role_asdf_args.update({'role': 'asdf'})
+
+    filtered_by_role_replicator_args = default_args.copy()
+    filtered_by_role_replicator_args.update({'role': 'replicator'})
+
+    example_json = json.loads(
+        """
+            {
+                "selfNode": {
+                    "address": "akka.tcp://conductr@127.0.0.1:9004",
+                    "uid": -2007039750
+                },
+                "members": [
+                    {
+                        "node": {
+                            "address": "akka.tcp://conductr@127.0.0.1:9004",
+                            "uid": -2007039750
+                        },
+                        "status": "Up",
+                        "roles": [
+                            "replicator"
+                        ]
+                    },
+                    {
+                        "node": {
+                            "address": "akka.tcp://conductr@127.0.0.2:9004",
+                            "uid": 1902649436
+                        },
+                        "status": "Up",
+                        "roles": [
+                            "replicator"
+                        ]
+                    }
+                ],
+                "unreachable": [
+                    {
+                        "node": {
+                            "address": "akka.tcp://conductr@127.0.0.2:9004",
+                            "uid": 1902649436
+                        },
+                        "observedBy": [
+                            {
+                                "address": "akka.tcp://conductr@127.0.0.1:9004",
+                                "uid": -2007039750
+                            }
+                        ]
+                    }
+                ]
+            }
+        """
+    )
+
+    def test_calculate_rows(self):
+        example_rows = conduct_members.calculate_rows(MagicMock(**self.default_args), self.example_json)
+
+        self.assertEqual(example_rows[1], {
+            'address': 'akka.tcp://conductr@127.0.0.1:9004',
+            'uid': -2007039750,
+            'roles': 'replicator',
+            'status': 'Up',
+            'reachable': 'Yes'
+        })
+
+        self.assertEqual(example_rows[2], {
+            'address': 'akka.tcp://conductr@127.0.0.2:9004',
+            'uid': 1902649436,
+            'roles': 'replicator',
+            'status': 'Up',
+            'reachable': 'No'
+        })
+
+    def test_include_entry(self):
+        self.assertFalse(conduct_members.include_entry(MagicMock(**self.filtered_by_role_asdf_args), {
+            'node': {
+                'address': 'akka.tcp://conductr@127.0.0.1:9004',
+                'uid': -2007039750
+            },
+            'status': 'Up',
+            'roles': ['replicator']
+        }))
+
+        self.assertTrue(conduct_members.include_entry(MagicMock(**self.filtered_by_role_replicator_args), {
+            'node': {
+                'address': 'akka.tcp://conductr@127.0.0.1:9004',
+                'uid': -2007039750
+            },
+            'status': 'Up',
+            'roles': ['replicator']
+        }))


### PR DESCRIPTION
This PR implements `conduct members` and `conduct agents` to show member/agent information. It simply parses the output of the control protocol.

- Each shows relevant information in a nicely formatted table
- Each includes role argument to only show those with a supplied role

Example Output:

```
~/work/lightbend/conductr-cli#more-info $ conduct members
ADDRESS                             UID          ROLES       STATUS  REACHABLE
akka.tcp://conductr@127.0.0.1:9004  -2007039750  replicator  Up            Yes
akka.tcp://conductr@127.0.0.2:9004  284794675    replicator  Up            Yes
-> 0

~/work/lightbend/conductr-cli#more-info $ conduct agents
ADDRESS                                                                         ROLES
akka.tcp://conductr-agent@127.0.0.1:2552/user/reaper/cluster-client#1363584093    web
-> 0

~/work/lightbend/conductr-cli#more-info $ conduct members
ADDRESS                             UID          ROLES       STATUS  REACHABLE
akka.tcp://conductr@127.0.0.1:9004  -2007039750  replicator  Up            Yes
akka.tcp://conductr@127.0.0.2:9004  284794675    replicator  Up             No
-> 0
```