### PR TITLE
Update Conduct Deploy to match CD Service

### DIFF
--- a/conductr_cli/bundle_deploy.py
+++ b/conductr_cli/bundle_deploy.py
@@ -19,7 +19,7 @@ def generate_hmac_signature(secret_key, text):
     return base64.b64encode(signature).decode(STRING_ENCODING)
 
 
-def get_deployment_state(deployment_id, args):
+def get_deployment_events(deployment_id, args):
     deployment_state_url = conduct_url.url('deployments/{}'.format(deployment_id), args)
     response = conduct_request.get(args.dcos_mode, conduct_url.conductr_host(args), deployment_state_url,
                                    auth=args.conductr_auth, verify=args.server_verification_file)
@@ -38,14 +38,22 @@ def wait_for_deployment_complete(deployment_id, resolved_version, args):
     def display_bundle_id(bundle_id):
         return bundle_id if args.long_ids else bundle_utils.short_id(bundle_id)
 
-    def is_completed_with_success(deployment_state):
-        return deployment_state['eventType'] == "deploymentSuccess"
+    def is_completed_with_success(deployment_events):
+        for event in deployment_events:
+            if event['eventType'] == 'deploymentSuccess':
+                return True
 
-    def is_completed_with_failure(deployment_state):
-        return deployment_state['eventType'] == "deploymentFailure"
+        return False
 
-    def log_message(deployment_state):
-        event_type = deployment_state['eventType']
+    def is_completed_with_failure(deployment_events):
+        for event in deployment_events:
+            if event['eventType'] == 'deploymentFailure':
+                return True
+
+        return False
+
+    def display_deployment_event(deployment_event):
+        event_type = deployment_event['eventType']
         if event_type == 'deploymentStarted':
             return 'Deployment started'
 
@@ -53,15 +61,15 @@ def wait_for_deployment_complete(deployment_id, resolved_version, args):
             return 'Downloading bundle'
 
         elif event_type == 'configDownload':
-            compatible_bundle_id = display_bundle_id(deployment_state['compatibleBundleId'])
+            compatible_bundle_id = display_bundle_id(deployment_event['compatibleBundleId'])
             return 'Downloading config from bundle {}'.format(compatible_bundle_id)
 
         elif event_type == 'load':
-            return 'Loading bundle with config' if 'configFileName' in deployment_state else 'Loading bundle'
+            return 'Loading bundle with config' if 'configFileName' in deployment_event else 'Loading bundle'
 
         elif event_type == 'deploy':
-            bundle_old = deployment_state['bundleOld']
-            bundle_new = deployment_state['bundleNew']
+            bundle_old = deployment_event['bundleOld']
+            bundle_new = deployment_event['bundleNew']
             deploy_progress = 'Deploying - {} old instance vs {} new instance'.format(bundle_old['scale'],
                                                                                       bundle_new['scale'])
             return deploy_progress
@@ -70,10 +78,17 @@ def wait_for_deployment_complete(deployment_id, resolved_version, args):
             return 'Success'
 
         elif event_type == 'deploymentFailure':
-            return 'Failure: {}'.format(deployment_state['failure'])
+            return 'Failure: {}'.format(deployment_event['failure'])
 
         else:
-            return 'Unknown deployment state {}'.format(deployment_state)
+            return 'Unknown deployment state {}'.format(deployment_event)
+
+    def get_event_sequence(deployment_event):
+        return deployment_event['deploymentSequence']
+
+    def log_message(deployment_events):
+        latest_event = sorted(deployment_events, key=get_event_sequence)[-1]
+        return display_deployment_event(latest_event)
 
     package_name = resolved_version['package_name']
     compatibility_version = resolved_version['compatibility_version']
@@ -82,21 +97,21 @@ def wait_for_deployment_complete(deployment_id, resolved_version, args):
 
     log.info('Deploying {}'.format(bundle_shorthand))
 
-    deployment_state = get_deployment_state(deployment_id, args)
+    deployment_events = get_deployment_events(deployment_id, args)
 
-    if deployment_state and is_completed_with_success(deployment_state):
-        log.info(log_message(deployment_state))
+    if deployment_events and is_completed_with_success(deployment_events):
+        log.info(log_message(deployment_events))
         return
-    elif deployment_state and is_completed_with_failure(deployment_state):
+    elif deployment_events and is_completed_with_failure(deployment_events):
         raise ContinuousDeliveryError('Unable to deploy {} - {}'.format(bundle_shorthand,
-                                                                        log_message(deployment_state)))
+                                                                        log_message(deployment_events)))
     else:
         sse_heartbeat_count_after_event = 0
 
         deployment_events_url = conduct_url.url('deployments/events', args)
         sse_events = sse_client.get_events(args.dcos_mode, conduct_url.conductr_host(args), deployment_events_url,
                                            auth=args.conductr_auth, verify=args.server_verification_file)
-        last_deployment_state = None
+        last_events = None
         last_log_message = None
         for event in sse_events:
             sse_heartbeat_count_after_event += 1
@@ -110,32 +125,32 @@ def wait_for_deployment_complete(deployment_id, resolved_version, args):
                 if event.event:
                     sse_heartbeat_count_after_event = 0
 
-                deployment_state = get_deployment_state(deployment_id, args)
+                deployment_events = get_deployment_events(deployment_id, args)
 
-                if is_completed_with_success(deployment_state):
+                if is_completed_with_success(deployment_events):
                     # Reprint previous message with flush to go to next line
                     if last_log_message:
                         log.progress(last_log_message, flush=True)
 
-                    log.info(log_message(deployment_state))
+                    log.info(log_message(deployment_events))
                     return
 
-                elif is_completed_with_failure(deployment_state):
+                elif is_completed_with_failure(deployment_events):
                     # Reprint previous message with flush to go to next line
                     if last_log_message:
                         log.progress(last_log_message, flush=True)
 
                     raise ContinuousDeliveryError('Unable to deploy {} - {}'.format(bundle_shorthand,
-                                                                                    log_message(deployment_state)))
+                                                                                    log_message(deployment_events)))
                 else:
-                    if deployment_state != last_deployment_state:
-                        last_deployment_state = deployment_state
+                    if deployment_events != last_events:
+                        last_events = deployment_events
 
                         # Reprint previous message with flush to go to next line
                         if last_log_message:
                             log.progress(last_log_message, flush=True)
 
-                        last_log_message = log_message(deployment_state)
+                        last_log_message = log_message(deployment_events)
                         log.progress(last_log_message, flush=False)
                     else:
                         last_log_message = '{}.'.format(last_log_message)


### PR DESCRIPTION
CD Service HTTP /deployments/:deploymentId will now return a list of deployment events instead of single event.