### PR TITLE
relax check for determining core/agent processes

### DIFF
--- a/conductr_cli/sandbox_common.py
+++ b/conductr_cli/sandbox_common.py
@@ -56,7 +56,7 @@ def calculate_pids(core_run_dir, agent_run_dir, ps):
             return default
 
         if process['name'] and process['name'] == 'java' and \
-                process['cmdline'] and any('com.typesafe.conductr.ConductR' == e for e in process['cmdline']) and \
+                process['cmdline'] and any('-Dconductr.ip=' in e for e in process['cmdline']) and \
                 any(core_run_dir in e for e in process['cmdline']):
             pids_info.append({
                 'type': 'core',
@@ -65,7 +65,7 @@ def calculate_pids(core_run_dir, agent_run_dir, ps):
             })
         elif process['name'] and process['name'] == 'java' and \
                 process['cmdline'] and \
-                any('com.typesafe.conductr.agent.ConductRAgent' == e for e in process['cmdline']) and \
+                any('-Dconductr.agent.ip=' in e for e in process['cmdline']) and \
                 any(agent_run_dir in e for e in process['cmdline']):
             pids_info.append({
                 'type': 'agent',


### PR DESCRIPTION
This PR relaxes the check for determining that a process is a core or agent one launched by the sandbox. In CI, the process entry is incredibly long and the classname, being the last argument, is being truncated.

This simply changes the check to look for the presence of `-Dconductr.ip=` (core node) or `-Dconductr.agent.ip=` (agent node). This ought to be sufficient - the Sandbox always launches nodes with these arguments.