### PR TITLE
Introduces `add_default_features` and `--no-default-features`

### DIFF
--- a/conductr_cli/sandbox_main.py
+++ b/conductr_cli/sandbox_main.py
@@ -162,6 +162,11 @@ def build_parser():
                             help='Features to be enabled\n'
                                  'Available features: ' + ', '.join(feature_names),
                             metavar='')
+    run_parser.add_argument('--no-default-features',
+                            help='Disables default features (currently proxying and lite-logging)',
+                            dest='no_default_features',
+                            default=False,
+                            action='store_true')
     run_parser.add_argument('--no-wait',
                             help='Disables waiting for ConductR to be started in the sandbox',
                             default=False,

--- a/conductr_cli/sandbox_run.py
+++ b/conductr_cli/sandbox_run.py
@@ -32,7 +32,7 @@ def run(args):
     """`sandbox run` command"""
     write_run_command()
     is_conductr_v1 = major_version(args.image_version) == 1
-    features = sandbox_features.collect_features(args.features, args.image_version, args.offline_mode)
+    features = sandbox_features.collect_features(args.features, args.no_default_features, args.image_version, args.offline_mode)
     sandbox = sandbox_run_docker if is_conductr_v1 else sandbox_run_jvm
 
     run_result = sandbox.run(args, features)

--- a/conductr_cli/test/test_sandbox_features.py
+++ b/conductr_cli/test/test_sandbox_features.py
@@ -9,31 +9,39 @@ from conductr_cli.test.data.test_constants import LATEST_CONDUCTR_VERSION
 
 class TestFeatures(TestCase):
     def test_collect_features(self):
+        # default features enabled works
         self.assertEqual([LiteLoggingFeature],
-                         [type(f) for f in collect_features([], LATEST_CONDUCTR_VERSION, False)])
+                         [type(f) for f in collect_features([], False, LATEST_CONDUCTR_VERSION, False)])
+
+        # defeault features disabled works
+        self.assertEqual([],
+                         [type(f) for f in collect_features([], True, LATEST_CONDUCTR_VERSION, False)])
 
         self.assertEqual([LiteLoggingFeature, VisualizationFeature],
-                         [type(f) for f in collect_features([['visualization']], LATEST_CONDUCTR_VERSION, False)])
+                         [type(f) for f in collect_features([['visualization']], False, LATEST_CONDUCTR_VERSION, False)])
 
         self.assertEqual([LoggingFeature],
-                         [type(f) for f in collect_features([['logging']], LATEST_CONDUCTR_VERSION, False)])
+                         [type(f) for f in collect_features([['logging']], False, LATEST_CONDUCTR_VERSION, False)])
 
-        # enable dependencies
+        self.assertEqual([LoggingFeature],
+                         [type(f) for f in collect_features([['logging']], True, LATEST_CONDUCTR_VERSION, False)])
+
+    # enable dependencies
         self.assertEqual([LoggingFeature, MonitoringFeature],
-                         [type(f) for f in collect_features([['monitoring']], LATEST_CONDUCTR_VERSION, False)])
+                         [type(f) for f in collect_features([['monitoring']], False, LATEST_CONDUCTR_VERSION, False)])
 
         # allow explicit listing of dependencies
         self.assertEqual([LoggingFeature, MonitoringFeature],
-                         [type(f) for f in collect_features([['logging'], ['monitoring']], LATEST_CONDUCTR_VERSION, False)])
+                         [type(f) for f in collect_features([['logging'], ['monitoring']], False, LATEST_CONDUCTR_VERSION, False)])
 
         # topological ordering for dependencies
         self.assertEqual([LoggingFeature, MonitoringFeature],
-                         [type(f) for f in collect_features([['monitoring'], ['logging']], LATEST_CONDUCTR_VERSION, False)])
+                         [type(f) for f in collect_features([['monitoring'], ['logging']], False, LATEST_CONDUCTR_VERSION, False)])
 
         # topological ordering and ignore duplicates
         self.assertEqual([LoggingFeature, MonitoringFeature, VisualizationFeature],
                          [type(f) for f in collect_features([['monitoring'], ['visualization'], ['logging'], ['monitoring']],
-                                                            LATEST_CONDUCTR_VERSION, False)])
+                                                            False, LATEST_CONDUCTR_VERSION, False)])
 
     def test_select_bintray_uri(self):
         self.assertEqual('cinnamon-grafana', select_bintray_uri('cinnamon-grafana')['name'])


### PR DESCRIPTION
Introduces `add_default_features` which enables lite-logging if logging isn't explicitly enabled. It can be expanded in the future to include other default features, such as proxying. Also includes a `--no-default-features` flag to not include any features by default.

A follow-up PR will be based on this one and refactor haproxy to be part of a proxying feature that is part of this default feature set. To limit the scope of the PR, this change isn't included here.

The use-case here is allowing a user to start the sandbox without any features enabled by simply specifying `sandbox run <version> --no-default-features`