### PR TITLE
Implements proxying feature that runs haproxy

### DIFF
--- a/conductr_cli/constants.py
+++ b/conductr_cli/constants.py
@@ -34,3 +34,7 @@ DEFAULT_SANDBOX_PROXY_CONTAINER_NAME = os.getenv('CONDUCTR_SANDBOX_PROXY_CONTAIN
 DEFAULT_ERROR_LOG_FILE = os.path.abspath(os.getenv('CONDUCTR_CLI_ERROR_LOG',
                                                    '{}/errors.log'.format(DEFAULT_CLI_SETTINGS_DIR)))
 DEFAULT_WAIT_TIMEOUT = 60  # seconds
+
+FEATURE_PROVIDE_PROXYING = 'proxying'
+
+FEATURE_PROVIDE_LOGGING = 'logging'

--- a/conductr_cli/sandbox_features.py
+++ b/conductr_cli/sandbox_features.py
@@ -15,16 +15,93 @@ Feature attributes:
 """
 
 import conductr_cli
-from conductr_cli import docker
+from conductr_cli import docker, sandbox_proxy
+from conductr_cli.constants import FEATURE_PROVIDE_LOGGING, FEATURE_PROVIDE_PROXYING
 from conductr_cli.sandbox_common import major_version
 from conductr_cli.screen_utils import h1
 import logging
+
+
+class FeatureStartResult:
+    def __init__(self, started, bundle_results):
+        self.started = started
+        self.bundle_results = bundle_results
 
 
 class BundleStartResult:
     def __init__(self, name, port):
         self.name = name
         self.port = port
+
+
+class ProxyingFeature:
+    """Proxying feature.
+
+    On start, the proxying features will be run.
+    """
+
+    name = 'proxying'
+    ports = []
+    dependencies = []
+    provides = [FEATURE_PROVIDE_PROXYING]
+
+    def __init__(self, version_args, image_version, offline_mode):
+        self.version_args = version_args
+        self.image_version = image_version
+        self.offline_mode = offline_mode
+        self.host = None
+        self.proxy_bind_addr = None
+        self.bundle_http_port = None
+        self.proxy_ports = None
+
+    def conductr_post_start(self, args, run_result):
+        self.host = run_result.host
+        self.proxy_bind_addr = run_result.core_addrs[0]
+        self.bundle_http_port = args.bundle_http_port
+        self.proxy_ports = sorted(args.ports)
+
+    @staticmethod
+    def conductr_args():
+        return []
+
+    def conductr_feature_envs(self):
+        return []
+
+    def conductr_roles(self):
+        if major_version(self.image_version) == 1:
+            return []
+        else:
+            return ['haproxy']
+
+    def start(self):
+        if major_version(self.image_version) == 1 or None in [self.host, self.proxy_bind_addr, self.bundle_http_port,
+                                                              self.proxy_ports]:
+            return FeatureStartResult(False, [])
+        else:
+            log = logging.getLogger(__name__)
+            log.info(h1('Starting proxying feature'))
+
+            started = sandbox_proxy.start_proxy(proxy_bind_addr=self.proxy_bind_addr,
+                                                bundle_http_port=self.bundle_http_port,
+                                                proxy_ports=self.proxy_ports,
+                                                all_feature_ports=all_feature_ports())
+
+            if started:
+                log.info('HAProxy has been started')
+                log.info('Your Bundles are by default accessible on:')
+                log.info('  {}:{}'.format(self.host, self.bundle_http_port))
+            else:
+                log.info('HAProxy has not been started')
+                log.info('To enable proxying ensure Docker is running and restart the sandbox')
+
+            return FeatureStartResult(started, [])
+
+    @staticmethod
+    def stop():
+        if sandbox_proxy.get_running_haproxy():
+            return sandbox_proxy.stop_proxy()
+        else:
+            return True
 
 
 class VisualizationFeature:
@@ -40,11 +117,15 @@ class VisualizationFeature:
     name = 'visualization'
     ports = [9999]
     dependencies = []
+    provides = []
 
     def __init__(self, version_args, image_version, offline_mode):
         self.version_args = version_args
         self.image_version = image_version
         self.offline_mode = offline_mode
+
+    def conductr_post_start(self, args, run_result):
+        return
 
     def conductr_feature_envs(self):
         if major_version(self.image_version) == 1:
@@ -62,7 +143,7 @@ class VisualizationFeature:
 
     def start(self):
         if major_version(self.image_version) == 1:
-            return []
+            return FeatureStartResult(False, [])
         else:
             log = logging.getLogger(__name__)
             log.info(h1('Starting visualization feature'))
@@ -71,8 +152,13 @@ class VisualizationFeature:
             load_command = ['load', visualizer['bundle'], '--disable-instructions'] + \
                 parse_offline_mode_arg(self.offline_mode)
             conductr_cli.conduct_main.run(load_command, configure_logging=False)
-            conductr_cli.conduct_main.run(['run', visualizer['name'], '--disable-instructions'], configure_logging=False)
-            return [BundleStartResult('visualizer', self.ports[0])]
+            conductr_cli.conduct_main.run(['run', visualizer['name'], '--disable-instructions'],
+                                          configure_logging=False)
+            return FeatureStartResult(True, [BundleStartResult('visualizer', self.ports[0])])
+
+    @staticmethod
+    def stop():
+        return True
 
 
 class LoggingFeature:
@@ -88,11 +174,15 @@ class LoggingFeature:
     name = 'logging'
     ports = [5601, 9200]
     dependencies = []
+    provides = [FEATURE_PROVIDE_LOGGING]
 
     def __init__(self, version_args, image_version, offline_mode):
         self.version_args = version_args
         self.image_version = image_version
         self.offline_mode = offline_mode
+
+    def conductr_post_start(self, args, run_result):
+        return
 
     def conductr_feature_envs(self):
         if major_version(self.image_version) == 1:
@@ -114,7 +204,7 @@ class LoggingFeature:
 
     def start(self):
         if major_version(self.image_version) == 1:
-            return []
+            return FeatureStartResult(False, [])
         else:
             log = logging.getLogger(__name__)
             log.info(h1('Starting logging feature based on elasticsearch and kibana'))
@@ -126,15 +216,23 @@ class LoggingFeature:
             elasticsearch_load_command = ['load', elasticsearch['bundle'], '--disable-instructions'] + \
                 parse_offline_mode_arg(self.offline_mode)
             conductr_cli.conduct_main.run(elasticsearch_load_command, configure_logging=False)
-            conductr_cli.conduct_main.run(['run', elasticsearch['name'], '--disable-instructions'], configure_logging=False)
+            conductr_cli.conduct_main.run(['run', elasticsearch['name'], '--disable-instructions'],
+                                          configure_logging=False)
             kibana = select_bintray_uri('conductr-kibana', self.version_args)
             log.info('Deploying bundle %s..' % kibana['bundle'])
             kibana_load_command = ['load', kibana['bundle'], '--disable-instructions'] + \
                 parse_offline_mode_arg(self.offline_mode)
             conductr_cli.conduct_main.run(kibana_load_command, configure_logging=False)
-            conductr_cli.conduct_main.run(['run', kibana['name'], '--disable-instructions', '--wait-timeout', '600'], configure_logging=False)
-            return [BundleStartResult('conductr-kibana', self.ports[0]),
-                    BundleStartResult('conductr-elasticsearch', self.ports[1])]
+            conductr_cli.conduct_main.run(['run', kibana['name'], '--disable-instructions', '--wait-timeout', '600'],
+                                          configure_logging=False)
+            return FeatureStartResult(True, [
+                BundleStartResult('conductr-kibana', self.ports[0]),
+                BundleStartResult('conductr-elasticsearch', self.ports[1])
+            ])
+
+    @staticmethod
+    def stop():
+        return True
 
 
 class LiteLoggingFeature:
@@ -146,11 +244,15 @@ class LiteLoggingFeature:
     name = 'lite-logging'
     ports = []
     dependencies = []
+    provides = [FEATURE_PROVIDE_LOGGING]
 
     def __init__(self, version_args, image_version, offline_mode):
         self.version_args = version_args
         self.image_version = image_version
         self.offline_mode = offline_mode
+
+    def conductr_post_start(self, args, run_result):
+        return
 
     @staticmethod
     def conductr_feature_envs():
@@ -170,7 +272,7 @@ class LiteLoggingFeature:
 
     def start(self):
         if major_version(self.image_version) == 1:
-            return []
+            return FeatureStartResult(False, [])
         else:
             log = logging.getLogger(__name__)
             log.info(h1('Starting logging feature based on eslite'))
@@ -180,7 +282,11 @@ class LiteLoggingFeature:
                 parse_offline_mode_arg(self.offline_mode)
             conductr_cli.conduct_main.run(load_command, configure_logging=False)
             conductr_cli.conduct_main.run(['run', eslite['name'], '--disable-instructions'], configure_logging=False)
-            return []
+            return FeatureStartResult(True, [])
+
+    @staticmethod
+    def stop():
+        return True
 
 
 class MonitoringFeature:
@@ -202,11 +308,15 @@ class MonitoringFeature:
     conductr_args = []
     conductr_roles = []
     dependencies = [LoggingFeature.name]
+    provides = []
 
     def __init__(self, version_args, image_version, offline_mode):
         self.version_args = version_args
         self.image_version = image_version
         self.offline_mode = offline_mode
+
+    def conductr_post_start(self, args, run_result):
+        return
 
     @staticmethod
     def conductr_feature_envs():
@@ -232,13 +342,39 @@ class MonitoringFeature:
             parse_offline_mode_arg(self.offline_mode)
         conductr_cli.conduct_main.run(load_command, configure_logging=False)
         conductr_cli.conduct_main.run(['run', grafana['name'], '--disable-instructions', '--wait-timeout', '600'], configure_logging=False)
-        return [BundleStartResult(grafana['name'], self.ports[0])]
+        return FeatureStartResult(True, [BundleStartResult(grafana['name'], self.ports[0])])
+
+    @staticmethod
+    def stop():
+        return True
 
 
-feature_classes = [VisualizationFeature, LoggingFeature, LiteLoggingFeature, MonitoringFeature]
+feature_classes = [ProxyingFeature, VisualizationFeature, LoggingFeature, LiteLoggingFeature, MonitoringFeature]
 
 feature_names = [feature.name for feature in feature_classes]
 feature_lookup = {feature.name: feature for feature in feature_classes}
+
+
+def calculate_features(features):
+    """Given a list of feature names, calculates all features that are to be started in dependency order.
+
+    Returns:
+        list of str: All features (by name) to be started in dependency order
+    """
+
+    visited = set()
+    calculated_names = []
+
+    def visit(feature_names):
+        for feature_name in feature_names:
+            if feature_name not in visited:
+                visited.add(feature_name)
+                visit(feature_lookup[feature_name].dependencies)
+                calculated_names.append(feature_name)
+
+    visit(features)
+
+    return calculated_names
 
 
 def collect_features(feature_args, no_default_features, image_version, offline_mode):
@@ -261,32 +397,69 @@ def collect_features(feature_args, no_default_features, image_version, offline_m
     feature_names = [name for name, *args in feature_args]
     feature_args = {name: args for name, *args in feature_args}
 
-    visited = set()
     features = []
 
-    def visit(feature_names):
-        for feature_name in feature_names:
-            if feature_name not in visited:
-                visited.add(feature_name)
-                args = feature_args[feature_name] if feature_name in feature_args else []
-                feature = feature_lookup[feature_name](args, image_version, offline_mode)
-                visit(feature.dependencies)
-                features.append(feature)
+    all_feature_names = calculate_features(feature_names)
+
+    for feature_name in all_feature_names:
+        args = feature_args[feature_name] if feature_name in feature_args else []
+        feature = feature_lookup[feature_name](args, image_version, offline_mode)
+        features.append(feature)
 
     def add_default_features(features):
+        def add_proxying(features):
+            features.insert(0, feature_lookup[ProxyingFeature.name]([], image_version, offline_mode))
+
         def add_logging_lite(features):
             names = [feature.name for feature in features]
             if LoggingFeature.name not in names:
                 features.insert(0, feature_lookup[LiteLoggingFeature.name]([], image_version, offline_mode))
 
         add_logging_lite(features)
-
-    visit(feature_names)
+        add_proxying(features)
 
     if not no_default_features:
         add_default_features(features)
 
     return features
+
+
+def feature_conflicts(names):
+    """Calculates all feature conflicts (according to provides)
+
+    Args:
+        names: list of str
+
+    Returns:
+        dictionary with key equals provide, value equals list of conflicting names
+        e.g. { 'logging': ['logging-lite', 'logging'] }
+    """
+
+    conflicts = {}
+
+    for n in calculate_features(names):
+        f = feature_lookup[n]
+
+        for p in f.provides:
+            if p in conflicts:
+                conflicts[p].append(f.name)
+            else:
+                conflicts[p] = [f.name]
+
+    for p in list(conflicts):
+        if len(conflicts[p]) < 2:
+            del conflicts[p]
+
+    return conflicts
+
+
+def stop_features():
+    feature_success = True
+
+    for f in feature_classes:
+        feature_success = f.stop() and feature_success
+
+    return feature_success
 
 
 def select_bintray_uri(name, version_args=[], bundle_repo=''):

--- a/conductr_cli/sandbox_main.py
+++ b/conductr_cli/sandbox_main.py
@@ -4,7 +4,7 @@ import ipaddress
 import re
 import sys
 from conductr_cli.sandbox_common import CONDUCTR_DEV_IMAGE, major_version
-from conductr_cli.sandbox_features import feature_names
+from conductr_cli.sandbox_features import feature_conflicts, feature_names
 from conductr_cli.constants import DEFAULT_SANDBOX_ADDR_RANGE, DEFAULT_SANDBOX_IMAGE_DIR, DEFAULT_SANDBOX_TMP_DIR, \
     DEFAULT_OFFLINE_MODE
 from conductr_cli import sandbox_run, sandbox_restart, sandbox_stop, sandbox_common, sandbox_logs, sandbox_ps, \
@@ -286,6 +286,17 @@ def run(_args=[], configure_logging=True):
                 parser.exit('Invalid features: %s (choose from %s)' %
                             (', '.join("'%s'" % f for f in invalid_features),
                              ', '.join("'%s'" % f for f in feature_names)))
+
+            conflicting_features = feature_conflicts([name for name, *args in args.features])
+
+            if len(conflicting_features) > 0:
+                messages = []
+
+                for p, fs in conflicting_features.items():
+                    messages.append("'{0}' provided by ({1})".format(p, ', '.join(map(lambda e: "'" + e + "'", fs))))
+
+                parser.exit('Conflicting features: {0}'.format(', '.join(messages)))
+
         # Docker VM validation
         args.vm_type = docker.vm_type()
         if vars(args).get('func').__name__ == 'run' and major_version(args.image_version) == 1:

--- a/conductr_cli/sandbox_proxy.py
+++ b/conductr_cli/sandbox_proxy.py
@@ -1,4 +1,4 @@
-from conductr_cli import conduct_main, docker, terminal, sandbox_features
+from conductr_cli import conduct_main, docker, terminal
 from conductr_cli.constants import DEFAULT_SANDBOX_PROXY_DIR, DEFAULT_SANDBOX_PROXY_CONTAINER_NAME
 from conductr_cli.exceptions import DockerValidationError, NOT_FOUND_ERROR
 from conductr_cli.screen_utils import h1
@@ -31,11 +31,11 @@ DEFAULT_HAPROXY_CFG_ENTRIES = 'defaults\n' \
                               ''
 
 
-def start_proxy(proxy_bind_addr, bundle_http_port, proxy_ports):
+def start_proxy(proxy_bind_addr, bundle_http_port, proxy_ports, all_feature_ports):
     if is_docker_present():
         setup_haproxy_dirs()
         stop_proxy()
-        start_docker_instance(proxy_bind_addr, bundle_http_port, proxy_ports)
+        start_docker_instance(proxy_bind_addr, bundle_http_port, proxy_ports, all_feature_ports)
         start_conductr_haproxy()
         return True
     else:
@@ -82,7 +82,7 @@ def get_running_haproxy():
     return terminal.docker_ps(ps_filter='name={}'.format(DEFAULT_SANDBOX_PROXY_CONTAINER_NAME))
 
 
-def start_docker_instance(proxy_bind_addr, bundle_http_port, proxy_ports):
+def start_docker_instance(proxy_bind_addr, bundle_http_port, proxy_ports, all_feature_ports):
     log = logging.getLogger(__name__)
     log.info(h1('Starting HAProxy'))
 
@@ -93,7 +93,7 @@ def start_docker_instance(proxy_bind_addr, bundle_http_port, proxy_ports):
 
     all_proxy_ports = [bundle_http_port]
     all_proxy_ports.extend(DEFAULT_PROXY_PORTS)
-    all_proxy_ports.extend(sandbox_features.all_feature_ports())
+    all_proxy_ports.extend(all_feature_ports)
     all_proxy_ports.extend(proxy_ports)
     all_proxy_ports = sorted(set(all_proxy_ports))
 

--- a/conductr_cli/sandbox_run_docker.py
+++ b/conductr_cli/sandbox_run_docker.py
@@ -29,7 +29,7 @@ def run(args, features):
     return SandboxRunResult(container_names, host.DOCKER_IP)
 
 
-def log_run_attempt(args, run_result, feature_results, is_conductr_started, is_proxy_started, wait_timeout):
+def log_run_attempt(args, run_result, feature_results, is_conductr_started, feature_provided, wait_timeout):
     container_names = run_result.container_names
     if not args.no_wait:
         log = logging.getLogger(__name__)

--- a/conductr_cli/sandbox_stop.py
+++ b/conductr_cli/sandbox_stop.py
@@ -1,9 +1,15 @@
-from conductr_cli import sandbox_proxy, sandbox_stop_docker, sandbox_stop_jvm
+from conductr_cli import sandbox_features, sandbox_stop_docker, sandbox_stop_jvm
+
+
+def feature():
+    return sandbox_features.feature_classes
 
 
 def stop(args):
     """`sandbox stop` command"""
-    is_proxy_success = sandbox_proxy.stop_proxy()
+
+    is_feature_success = sandbox_features.stop_features()
     is_docker_success = sandbox_stop_docker.stop(args)
     is_jvm_success = sandbox_stop_jvm.stop(args)
-    return is_proxy_success and is_docker_success and is_jvm_success
+
+    return is_feature_success and is_docker_success and is_jvm_success

--- a/conductr_cli/test/test_sandbox_proxy.py
+++ b/conductr_cli/test/test_sandbox_proxy.py
@@ -25,12 +25,12 @@ class TestStartProxy(CliTestCase):
                 patch('conductr_cli.sandbox_proxy.start_docker_instance', mock_start_docker_instance), \
                 patch('conductr_cli.sandbox_proxy.start_conductr_haproxy', mock_start_conductr_haproxy):
             logging_setup.configure_logging(args, stdout)
-            sandbox_proxy.start_proxy(ipaddress.ip_address('192.168.1.1'), 9000, [3003])
+            sandbox_proxy.start_proxy(ipaddress.ip_address('192.168.1.1'), 9000, [3003], [9999, 9200])
 
         mock_is_docker_present.assert_called_once_with()
         mock_setup_haproxy_dirs.assert_called_once_with()
         mock_stop_proxy.assert_called_once_with()
-        mock_start_docker_instance.assert_called_once_with(ipaddress.ip_address('192.168.1.1'), 9000, [3003])
+        mock_start_docker_instance.assert_called_once_with(ipaddress.ip_address('192.168.1.1'), 9000, [3003], [9999, 9200])
         mock_start_conductr_haproxy.assert_called_once_with()
 
         self.assertEqual('', self.output(stdout))
@@ -52,7 +52,7 @@ class TestStartProxy(CliTestCase):
                 patch('conductr_cli.sandbox_proxy.start_docker_instance', mock_start_docker_instance), \
                 patch('conductr_cli.sandbox_proxy.start_conductr_haproxy', mock_start_conductr_haproxy):
             logging_setup.configure_logging(args, stdout)
-            sandbox_proxy.start_proxy(ipaddress.ip_address('192.168.1.1'), 9000, [3003])
+            sandbox_proxy.start_proxy(ipaddress.ip_address('192.168.1.1'), 9000, [3003], [9999, 9200])
 
         mock_is_docker_present.assert_called_once_with()
         mock_setup_haproxy_dirs.assert_not_called()
@@ -217,20 +217,17 @@ class TestStartDockerInstance(CliTestCase):
         mock_docker_images = MagicMock(return_value='sandbox-haproxy-container-id')
         mock_docker_pull = MagicMock()
         mock_docker_run = MagicMock()
-        mock_all_feature_ports = MagicMock(return_value=[19001])
 
         args = MagicMock(**{})
 
         with patch('conductr_cli.terminal.docker_images', mock_docker_images), \
                 patch('conductr_cli.terminal.docker_pull', mock_docker_pull), \
-                patch('conductr_cli.terminal.docker_run', mock_docker_run), \
-                patch('conductr_cli.sandbox_features.all_feature_ports', mock_all_feature_ports):
+                patch('conductr_cli.terminal.docker_run', mock_docker_run):
             logging_setup.configure_logging(args, stdout)
-            sandbox_proxy.start_docker_instance(ipaddress.ip_address('192.168.1.1'), 9000, [3003])
+            sandbox_proxy.start_docker_instance(ipaddress.ip_address('192.168.1.1'), 9000, [3003], [19001])
 
         mock_docker_images.assert_called_once_with('haproxy:1.5')
         mock_docker_pull.assert_not_called()
-        mock_all_feature_ports.assert_called_once_with()
         mock_docker_run.assert_called_once_with(
             ['-d',
              '--name', 'sandbox-haproxy',
@@ -257,20 +254,17 @@ class TestStartDockerInstance(CliTestCase):
         mock_docker_images = MagicMock(return_value='sandbox-haproxy-container-id')
         mock_docker_pull = MagicMock()
         mock_docker_run = MagicMock()
-        mock_all_feature_ports = MagicMock(return_value=[19001, 3000])
 
         args = MagicMock(**{})
 
         with patch('conductr_cli.terminal.docker_images', mock_docker_images), \
                 patch('conductr_cli.terminal.docker_pull', mock_docker_pull), \
-                patch('conductr_cli.terminal.docker_run', mock_docker_run), \
-                patch('conductr_cli.sandbox_features.all_feature_ports', mock_all_feature_ports):
+                patch('conductr_cli.terminal.docker_run', mock_docker_run):
             logging_setup.configure_logging(args, stdout)
-            sandbox_proxy.start_docker_instance(ipaddress.ip_address('192.168.1.1'), 9000, [3003, 3000])
+            sandbox_proxy.start_docker_instance(ipaddress.ip_address('192.168.1.1'), 9000, [3003, 3000], [19001, 3000])
 
         mock_docker_images.assert_called_once_with('haproxy:1.5')
         mock_docker_pull.assert_not_called()
-        mock_all_feature_ports.assert_called_once_with()
         mock_docker_run.assert_called_once_with(
             ['-d',
              '--name', 'sandbox-haproxy',
@@ -298,16 +292,14 @@ class TestStartDockerInstance(CliTestCase):
         mock_docker_images = MagicMock(return_value=None)
         mock_docker_pull = MagicMock()
         mock_docker_run = MagicMock()
-        mock_all_feature_ports = MagicMock(return_value=[19001])
 
         args = MagicMock(**{})
 
         with patch('conductr_cli.terminal.docker_images', mock_docker_images), \
                 patch('conductr_cli.terminal.docker_pull', mock_docker_pull), \
-                patch('conductr_cli.terminal.docker_run', mock_docker_run), \
-                patch('conductr_cli.sandbox_features.all_feature_ports', mock_all_feature_ports):
+                patch('conductr_cli.terminal.docker_run', mock_docker_run):
             logging_setup.configure_logging(args, stdout)
-            sandbox_proxy.start_docker_instance(ipaddress.ip_address('192.168.1.1'), 9000, [3003])
+            sandbox_proxy.start_docker_instance(ipaddress.ip_address('192.168.1.1'), 9000, [3003], [19001])
 
         mock_docker_images.assert_called_once_with('haproxy:1.5')
         mock_docker_pull.assert_called_once_with('haproxy:1.5')

--- a/conductr_cli/test/test_sandbox_run_docker.py
+++ b/conductr_cli/test/test_sandbox_run_docker.py
@@ -1,5 +1,6 @@
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin, as_error
 from conductr_cli import sandbox_run_docker, logging_setup
+from conductr_cli.constants import FEATURE_PROVIDE_PROXYING
 from conductr_cli.docker import DockerVmType
 from conductr_cli.exceptions import InstanceCountError
 from conductr_cli.sandbox_common import CONDUCTR_DEV_IMAGE
@@ -47,7 +48,7 @@ class TestRun(CliTestCase):
                 patch('conductr_cli.terminal.docker_ps', return_value=''), \
                 patch('conductr_cli.terminal.docker_inspect', return_value='10.10.10.10'), \
                 patch('conductr_cli.terminal.docker_run', return_value='') as mock_docker_run, \
-                patch('conductr_cli.sandbox_proxy.stop_proxy') as mock_stop_proxy, \
+                patch('conductr_cli.sandbox_features.stop_features') as mock_stop_proxy, \
                 patch('conductr_cli.sandbox_common.resolve_running_docker_containers', return_value=[]):
             logging_setup.configure_logging(MagicMock(**self.default_args), stdout)
             sandbox_run_docker.run(input_args, features)
@@ -76,7 +77,7 @@ class TestRun(CliTestCase):
                 patch('conductr_cli.terminal.docker_ps', return_value=''), \
                 patch('conductr_cli.terminal.docker_inspect', return_value='10.10.10.10'), \
                 patch('conductr_cli.terminal.docker_run', return_value='') as mock_docker_run, \
-                patch('conductr_cli.sandbox_proxy.stop_proxy') as mock_stop_proxy, \
+                patch('conductr_cli.sandbox_features.stop_features') as mock_stop_proxy, \
                 patch('conductr_cli.sandbox_common.resolve_running_docker_containers', return_value=[]):
             args = self.default_args.copy()
             args.update({'nr_of_instances': nr_of_instances})
@@ -144,7 +145,7 @@ class TestRun(CliTestCase):
                 patch('conductr_cli.terminal.docker_ps', return_value=''), \
                 patch('conductr_cli.terminal.docker_inspect', return_value='10.10.10.10'), \
                 patch('conductr_cli.terminal.docker_run', return_value='') as mock_docker_run, \
-                patch('conductr_cli.sandbox_proxy.stop_proxy') as mock_stop_proxy, \
+                patch('conductr_cli.sandbox_features.stop_features') as mock_stop_proxy, \
                 patch('conductr_cli.sandbox_common.resolve_running_docker_containers', return_value=[]):
             args = self.default_args.copy()
             args.update({
@@ -193,7 +194,7 @@ class TestRun(CliTestCase):
                 patch('conductr_cli.terminal.docker_ps', return_value=''), \
                 patch('conductr_cli.terminal.docker_inspect', return_value='10.10.10.10'), \
                 patch('conductr_cli.terminal.docker_run', return_value='') as mock_docker_run, \
-                patch('conductr_cli.sandbox_proxy.stop_proxy') as mock_stop_proxy, \
+                patch('conductr_cli.sandbox_features.stop_features') as mock_stop_proxy, \
                 patch('conductr_cli.sandbox_common.resolve_running_docker_containers', return_value=[]):
             args = self.default_args.copy()
             args.update({
@@ -260,7 +261,7 @@ class TestRun(CliTestCase):
                 patch('conductr_cli.terminal.docker_inspect', return_value='10.10.10.10'), \
                 patch('conductr_cli.terminal.docker_run', return_value=''), \
                 patch('conductr_cli.sandbox_common.resolve_running_docker_containers', return_value=running_containers), \
-                patch('conductr_cli.sandbox_proxy.stop_proxy') as mock_stop_proxy, \
+                patch('conductr_cli.sandbox_features.stop_features') as mock_stop_proxy, \
                 patch('conductr_cli.terminal.docker_rm') as mock_docker_rm:
             logging_setup.configure_logging(input_args, stdout)
             sandbox_run_docker.run(input_args, features)
@@ -294,7 +295,7 @@ class TestRun(CliTestCase):
                 patch('conductr_cli.terminal.docker_ps', return_value=''), \
                 patch('conductr_cli.terminal.docker_inspect', return_value='10.10.10.10'), \
                 patch('conductr_cli.terminal.docker_run', return_value='') as mock_docker_run, \
-                patch('conductr_cli.sandbox_proxy.stop_proxy') as mock_stop_proxy, \
+                patch('conductr_cli.sandbox_features.stop_features') as mock_stop_proxy, \
                 patch('conductr_cli.sandbox_common.resolve_running_docker_containers', return_value=[]), \
                 patch('os.getenv', side_effect=run_env) as mock_get_env:
             logging_setup.configure_logging(input_args, stdout)
@@ -346,7 +347,7 @@ class TestLogRunAttempt(CliTestCase):
             run_result=self.run_result,
             feature_results=self.feature_results,
             is_conductr_started=True,
-            is_proxy_started=True,
+            feature_provided=[FEATURE_PROVIDE_PROXYING],
             wait_timeout=self.wait_timeout
         )
 
@@ -373,7 +374,7 @@ class TestLogRunAttempt(CliTestCase):
             run_result=sandbox_run_docker.SandboxRunResult(['cond-0'], self.hostname),
             feature_results=self.feature_results,
             is_conductr_started=True,
-            is_proxy_started=True,
+            feature_provided=[FEATURE_PROVIDE_PROXYING],
             wait_timeout=self.wait_timeout
         )
 
@@ -401,7 +402,7 @@ class TestLogRunAttempt(CliTestCase):
             run_result=self.run_result,
             feature_results=self.feature_results,
             is_conductr_started=False,
-            is_proxy_started=False,
+            feature_provided=[],
             wait_timeout=self.wait_timeout
         )
 
@@ -428,7 +429,7 @@ class TestLogRunAttempt(CliTestCase):
             run_result=self.run_result,
             feature_results=self.feature_results,
             is_conductr_started=True,
-            is_proxy_started=True,
+            feature_provided=[FEATURE_PROVIDE_PROXYING],
             wait_timeout=self.wait_timeout
         )
 

--- a/conductr_cli/test/test_sandbox_run_jvm.py
+++ b/conductr_cli/test/test_sandbox_run_jvm.py
@@ -1,5 +1,6 @@
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
 from conductr_cli import logging_setup, sandbox_run_jvm, sandbox_features
+from conductr_cli.constants import FEATURE_PROVIDE_PROXYING
 from conductr_cli.exceptions import BindAddressNotFound, InstanceCountError, BintrayUnreachableError, \
     SandboxImageNotFoundError, SandboxImageNotAvailableOfflineError, SandboxUnsupportedOsError, \
     SandboxUnsupportedOsArchError, JavaCallError, JavaUnsupportedVendorError, JavaUnsupportedVersionError, \
@@ -983,7 +984,7 @@ class TestLogRunAttempt(CliTestCase):
                 run_result=self.run_result,
                 feature_results=self.feature_results,
                 is_conductr_started=True,
-                is_proxy_started=True,
+                feature_provided=[FEATURE_PROVIDE_PROXYING],
                 wait_timeout=self.wait_timeout
             )
 
@@ -1000,12 +1001,6 @@ class TestLogRunAttempt(CliTestCase):
                                           |  agent instances on 192.168.1.1, 192.168.1.2, 192.168.1.3
                                           |ConductR service locator has been started on:
                                           |  192.168.1.1:9008
-                                          ||- - - - - - - - - - - - - - - - - - - - - - - - |
-                                          || Proxy                                          |
-                                          ||- - - - - - - - - - - - - - - - - - - - - - - - |
-                                          |HAProxy has been started
-                                          |Your Bundles are by default accessible on:
-                                          |  192.168.1.1:9000
                                           ||- - - - - - - - - - - - - - - - - - - - - - - - |
                                           || Features                                       |
                                           ||- - - - - - - - - - - - - - - - - - - - - - - - |
@@ -1042,7 +1037,7 @@ class TestLogRunAttempt(CliTestCase):
                 run_result=run_result,
                 feature_results=self.feature_results,
                 is_conductr_started=True,
-                is_proxy_started=True,
+                feature_provided=[FEATURE_PROVIDE_PROXYING],
                 wait_timeout=self.wait_timeout
             )
 
@@ -1057,12 +1052,6 @@ class TestLogRunAttempt(CliTestCase):
                                           |  agent instance on 192.168.1.1
                                           |ConductR service locator has been started on:
                                           |  192.168.1.1:9008
-                                          ||- - - - - - - - - - - - - - - - - - - - - - - - |
-                                          || Proxy                                          |
-                                          ||- - - - - - - - - - - - - - - - - - - - - - - - |
-                                          |HAProxy has been started
-                                          |Your Bundles are by default accessible on:
-                                          |  192.168.1.1:9000
                                           ||- - - - - - - - - - - - - - - - - - - - - - - - |
                                           || Features                                       |
                                           ||- - - - - - - - - - - - - - - - - - - - - - - - |
@@ -1079,7 +1068,6 @@ class TestLogRunAttempt(CliTestCase):
         self.assertEqual(expected_stdout, self.output(stdout))
 
     def test_log_output_no_proxy(self):
-
         run_mock = MagicMock()
         stdout = MagicMock()
         input_args = MagicMock(**{
@@ -1093,7 +1081,7 @@ class TestLogRunAttempt(CliTestCase):
                 run_result=self.run_result,
                 feature_results=self.feature_results,
                 is_conductr_started=True,
-                is_proxy_started=False,
+                feature_provided=[],
                 wait_timeout=self.wait_timeout
             )
 
@@ -1108,11 +1096,6 @@ class TestLogRunAttempt(CliTestCase):
                                           |  agent instances on 192.168.1.1, 192.168.1.2, 192.168.1.3
                                           |ConductR service locator has been started on:
                                           |  192.168.1.1:9008
-                                          ||- - - - - - - - - - - - - - - - - - - - - - - - |
-                                          || Proxy                                          |
-                                          ||- - - - - - - - - - - - - - - - - - - - - - - - |
-                                          |HAProxy has not been started
-                                          |To enable proxying ensure Docker is running and restart the sandbox
                                           ||- - - - - - - - - - - - - - - - - - - - - - - - |
                                           || Features                                       |
                                           ||- - - - - - - - - - - - - - - - - - - - - - - - |
@@ -1142,7 +1125,7 @@ class TestLogRunAttempt(CliTestCase):
                 run_result=self.run_result,
                 feature_results=self.feature_results,
                 is_conductr_started=True,
-                is_proxy_started=True,
+                feature_provided=[FEATURE_PROVIDE_PROXYING],
                 wait_timeout=self.wait_timeout
             )
 

--- a/conductr_cli/test/test_sandbox_stop.py
+++ b/conductr_cli/test/test_sandbox_stop.py
@@ -12,61 +12,61 @@ class TestSandboxStopCommand(CliTestCase):
     }
 
     def test_success(self):
-        mock_sandbox_stop_proxy = MagicMock(return_value=True)
+        mock_sandbox_stop_features = MagicMock(return_value=True)
         mock_sandbox_stop_docker = MagicMock(return_value=True)
         mock_sandbox_stop_jvm = MagicMock(return_value=True)
 
         input_args = MagicMock(**self.default_args)
         with patch('conductr_cli.sandbox_stop_docker.stop', mock_sandbox_stop_docker), \
                 patch('conductr_cli.sandbox_stop_jvm.stop', mock_sandbox_stop_jvm), \
-                patch('conductr_cli.sandbox_proxy.stop_proxy', mock_sandbox_stop_proxy):
+                patch('conductr_cli.sandbox_features.stop_features', mock_sandbox_stop_features):
             self.assertTrue(sandbox_stop.stop(input_args))
 
-        mock_sandbox_stop_proxy.assert_called_once_with()
+        mock_sandbox_stop_features.assert_called_once_with()
         mock_sandbox_stop_docker.assert_called_once_with(input_args)
         mock_sandbox_stop_jvm.assert_called_once_with(input_args)
 
     def test_stop_proxy_error(self):
-        mock_sandbox_stop_proxy = MagicMock(return_value=False)
+        mock_sandbox_stop_features = MagicMock(return_value=False)
         mock_sandbox_stop_docker = MagicMock(return_value=False)
         mock_sandbox_stop_jvm = MagicMock(return_value=True)
 
         input_args = MagicMock(**self.default_args)
         with patch('conductr_cli.sandbox_stop_docker.stop', mock_sandbox_stop_docker), \
                 patch('conductr_cli.sandbox_stop_jvm.stop', mock_sandbox_stop_jvm), \
-                patch('conductr_cli.sandbox_proxy.stop_proxy', mock_sandbox_stop_proxy):
+                patch('conductr_cli.sandbox_features.stop_features', mock_sandbox_stop_features):
             self.assertFalse(sandbox_stop.stop(input_args))
 
-        mock_sandbox_stop_proxy.assert_called_once_with()
+        mock_sandbox_stop_features.assert_called_once_with()
         mock_sandbox_stop_docker.assert_called_once_with(input_args)
         mock_sandbox_stop_jvm.assert_called_once_with(input_args)
 
     def test_stop_docker_error(self):
-        mock_sandbox_stop_proxy = MagicMock(return_value=True)
+        mock_sandbox_stop_features = MagicMock(return_value=True)
         mock_sandbox_stop_docker = MagicMock(return_value=False)
         mock_sandbox_stop_jvm = MagicMock(return_value=True)
 
         input_args = MagicMock(**self.default_args)
         with patch('conductr_cli.sandbox_stop_docker.stop', mock_sandbox_stop_docker), \
                 patch('conductr_cli.sandbox_stop_jvm.stop', mock_sandbox_stop_jvm), \
-                patch('conductr_cli.sandbox_proxy.stop_proxy', mock_sandbox_stop_proxy):
+                patch('conductr_cli.sandbox_features.stop_features', mock_sandbox_stop_features):
             self.assertFalse(sandbox_stop.stop(input_args))
 
-        mock_sandbox_stop_proxy.assert_called_once_with()
+        mock_sandbox_stop_features.assert_called_once_with()
         mock_sandbox_stop_docker.assert_called_once_with(input_args)
         mock_sandbox_stop_jvm.assert_called_once_with(input_args)
 
     def test_stop_jvm_error(self):
-        mock_sandbox_stop_proxy = MagicMock(return_value=True)
+        mock_sandbox_stop_features = MagicMock(return_value=True)
         mock_sandbox_stop_docker = MagicMock(return_value=True)
         mock_sandbox_stop_jvm = MagicMock(return_value=False)
 
         input_args = MagicMock(**self.default_args)
         with patch('conductr_cli.sandbox_stop_docker.stop', mock_sandbox_stop_docker), \
                 patch('conductr_cli.sandbox_stop_jvm.stop', mock_sandbox_stop_jvm), \
-                patch('conductr_cli.sandbox_proxy.stop_proxy', mock_sandbox_stop_proxy):
+                patch('conductr_cli.sandbox_features.stop_features', mock_sandbox_stop_features):
             self.assertFalse(sandbox_stop.stop(input_args))
 
-        mock_sandbox_stop_proxy.assert_called_once_with()
+        mock_sandbox_stop_features.assert_called_once_with()
         mock_sandbox_stop_docker.assert_called_once_with(input_args)
         mock_sandbox_stop_jvm.assert_called_once_with(input_args)


### PR DESCRIPTION
Implements proxying feature that runs haproxy. This is part of the default set of features that can be disabled with `--no-default-features`. Features now have a `stop` method that will be called when `sandbox` stop is run, and proxying takes advantage of that.