### PR TITLE
Fixes a bug with setting up address aliases

### DIFF
--- a/conductr_cli/host.py
+++ b/conductr_cli/host.py
@@ -79,12 +79,23 @@ def is_listening(ip_addr, port):
     return result
 
 
-def addr_alias_setup_instructions(addrs, subnet_mask):
+def addr_alias_setup_instructions(addrs, ip_version):
     info_text = 'Whoops. Network address aliases are required ' \
                 'so that the sandbox can operate as a cluster of machines.' + \
                 '\n\nPlease run the following and then try your command again:'
 
     if_name = loopback_device_name()
+
+    # Note that the CIDR notation (e.g. /24) is for identifying the subnet to pick an address from.
+    # For actually setting up the alias, we want to mask out the entire network so the alias only
+    # responds to traffic for its own IP.
+
+    masks = {
+        4: "255.255.255.255",
+        6: "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"
+    }
+
+    subnet_mask = masks[ip_version]
 
     if is_linux():
         commands = ['sudo ifconfig {}:{} {} netmask {} up'.format(if_name, idx, addr.exploded, subnet_mask)

--- a/conductr_cli/sandbox_run_jvm.py
+++ b/conductr_cli/sandbox_run_jvm.py
@@ -440,7 +440,7 @@ def start_core_instances(core_extracted_dir, tmp_dir,
 
     Each instance is allocated an address to be bound based on the address range. For example:
     - Given 3 required core instances
-    - Given the address range input of 192.168.128.0/32
+    - Given the address range input of 192.168.128.0/24
     - The instances will be allocated these addresses: 192.168.128.1, 192.168.128.2, 192.168.128.3
 
     :param core_extracted_dir: the directory containing the files expanded from core's binary .tgz
@@ -512,7 +512,7 @@ def start_agent_instances(agent_extracted_dir, tmp_dir,
 
     Each instance is allocated an address to be bound based on the address range. For example:
     - Given 3 required agent instances
-    - Given the address range input of 192.168.128.0/32
+    - Given the address range input of 192.168.128.0/24
     - The instances will be allocated these addresses: 192.168.128.1, 192.168.128.2, 192.168.128.3
 
     :param agent_extracted_dir: the directory containing the files expanded from agent's binary .tgz

--- a/conductr_cli/sandbox_run_jvm.py
+++ b/conductr_cli/sandbox_run_jvm.py
@@ -249,9 +249,9 @@ def find_bind_addrs(nr_of_addrs, addr_range):
 
     These addresses requires setup using ifconfig as such (MacOS example):
 
-    sudo ifconfig lo0 alias 192.168.128.1 255.255.255.0
-    sudo ifconfig lo0 alias 192.168.128.2 255.255.255.0
-    sudo ifconfig lo0 alias 192.168.128.3 255.255.255.0
+    sudo ifconfig lo0 alias 192.168.128.1 255.255.255.255
+    sudo ifconfig lo0 alias 192.168.128.2 255.255.255.255
+    sudo ifconfig lo0 alias 192.168.128.3 255.255.255.255
 
     This command will check if 192.168.128.1, 192.168.128.2, and 192.168.128.3 can be bound. The check is done by
     binding a socket to each of these address using a test port.
@@ -277,7 +277,7 @@ def find_bind_addrs(nr_of_addrs, addr_range):
     if len(addrs_to_bind) < nr_of_addrs:
         nr_of_addr_setup = nr_of_addrs - len(addrs_to_bind)
         setup_instructions = host.addr_alias_setup_instructions(addrs_unavailable[0:nr_of_addr_setup],
-                                                                addr_range.netmask)
+                                                                addr_range.version)
         raise BindAddressNotFound(setup_instructions)
     else:
         return addrs_to_bind
@@ -440,7 +440,7 @@ def start_core_instances(core_extracted_dir, tmp_dir,
 
     Each instance is allocated an address to be bound based on the address range. For example:
     - Given 3 required core instances
-    - Given the address range input of 192.168.128.0/24
+    - Given the address range input of 192.168.128.0/32
     - The instances will be allocated these addresses: 192.168.128.1, 192.168.128.2, 192.168.128.3
 
     :param core_extracted_dir: the directory containing the files expanded from core's binary .tgz
@@ -512,7 +512,7 @@ def start_agent_instances(agent_extracted_dir, tmp_dir,
 
     Each instance is allocated an address to be bound based on the address range. For example:
     - Given 3 required agent instances
-    - Given the address range input of 192.168.128.0/24
+    - Given the address range input of 192.168.128.0/32
     - The instances will be allocated these addresses: 192.168.128.1, 192.168.128.2, 192.168.128.3
 
     :param agent_extracted_dir: the directory containing the files expanded from agent's binary .tgz

--- a/conductr_cli/test/test_host.py
+++ b/conductr_cli/test/test_host.py
@@ -230,15 +230,13 @@ class TestIsListening(TestCase):
 
 
 class TestAddrAliasSetupInstructions(TestCase):
-    addr_range_ipv4 = ipaddress.ip_network('192.168.1.0/24')
-    subnet_mask_ipv4 = addr_range_ipv4.netmask
+    addr_range_ipv4 = ipaddress.ip_network('192.168.1.0/32')
     addrs_ipv4 = [
         ipaddress.ip_address('192.168.1.1'),
         ipaddress.ip_address('192.168.1.2')
     ]
 
     addr_range_ipv6 = ipaddress.ip_network('0:0:0:0:0:ffff:c0a8:101/128')
-    subnet_mask_ipv6 = addr_range_ipv6.netmask
     addrs_ipv6 = [
         ipaddress.ip_address('0:0:0:0:0:ffff:c0a8:101'),
         ipaddress.ip_address('0:0:0:0:0:ffff:c0a8:102')
@@ -254,14 +252,14 @@ class TestAddrAliasSetupInstructions(TestCase):
         with patch('conductr_cli.host.loopback_device_name', mock_loopback_device_name), \
                 patch('conductr_cli.host.is_linux', mock_is_linux), \
                 patch('conductr_cli.host.is_macos', mock_is_macos):
-            result = host.addr_alias_setup_instructions(self.addrs_ipv4, self.subnet_mask_ipv4)
+            result = host.addr_alias_setup_instructions(self.addrs_ipv4, 4)
 
             expected_result = strip_margin("""|Whoops. Network address aliases are required so that the sandbox can operate as a cluster of machines.
                                               |
                                               |Please run the following and then try your command again:
                                               |
-                                              |sudo ifconfig ix0:0 192.168.1.1 netmask 255.255.255.0 up
-                                              |sudo ifconfig ix0:1 192.168.1.2 netmask 255.255.255.0 up
+                                              |sudo ifconfig ix0:0 192.168.1.1 netmask 255.255.255.255 up
+                                              |sudo ifconfig ix0:1 192.168.1.2 netmask 255.255.255.255 up
                                               |""")
             self.assertEqual(expected_result, result)
 
@@ -277,7 +275,7 @@ class TestAddrAliasSetupInstructions(TestCase):
         with patch('conductr_cli.host.loopback_device_name', mock_loopback_device_name), \
                 patch('conductr_cli.host.is_linux', mock_is_linux), \
                 patch('conductr_cli.host.is_macos', mock_is_macos):
-            result = host.addr_alias_setup_instructions(self.addrs_ipv6, self.subnet_mask_ipv6)
+            result = host.addr_alias_setup_instructions(self.addrs_ipv6, 6)
 
             expected_result = strip_margin("""|Whoops. Network address aliases are required so that the sandbox can operate as a cluster of machines.
                                               |
@@ -300,14 +298,14 @@ class TestAddrAliasSetupInstructions(TestCase):
         with patch('conductr_cli.host.loopback_device_name', mock_loopback_device_name), \
                 patch('conductr_cli.host.is_linux', mock_is_linux), \
                 patch('conductr_cli.host.is_macos', mock_is_macos):
-            result = host.addr_alias_setup_instructions(self.addrs_ipv4, self.subnet_mask_ipv4)
+            result = host.addr_alias_setup_instructions(self.addrs_ipv4, 4)
 
             expected_result = strip_margin("""|Whoops. Network address aliases are required so that the sandbox can operate as a cluster of machines.
                                               |
                                               |Please run the following and then try your command again:
                                               |
-                                              |sudo ifconfig ix0 alias 192.168.1.1 255.255.255.0
-                                              |sudo ifconfig ix0 alias 192.168.1.2 255.255.255.0
+                                              |sudo ifconfig ix0 alias 192.168.1.1 255.255.255.255
+                                              |sudo ifconfig ix0 alias 192.168.1.2 255.255.255.255
                                               |""")
             self.assertEqual(expected_result, result)
 
@@ -323,7 +321,7 @@ class TestAddrAliasSetupInstructions(TestCase):
         with patch('conductr_cli.host.loopback_device_name', mock_loopback_device_name), \
                 patch('conductr_cli.host.is_linux', mock_is_linux), \
                 patch('conductr_cli.host.is_macos', mock_is_macos):
-            result = host.addr_alias_setup_instructions(self.addrs_ipv6, self.subnet_mask_ipv6)
+            result = host.addr_alias_setup_instructions(self.addrs_ipv6, 6)
 
             expected_result = strip_margin("""|Whoops. Network address aliases are required so that the sandbox can operate as a cluster of machines.
                                               |
@@ -346,9 +344,9 @@ class TestAddrAliasSetupInstructions(TestCase):
         with patch('conductr_cli.host.loopback_device_name', mock_loopback_device_name), \
                 patch('conductr_cli.host.is_linux', mock_is_linux), \
                 patch('conductr_cli.host.is_macos', mock_is_macos):
-            result = host.addr_alias_setup_instructions(self.addrs_ipv4, self.subnet_mask_ipv4)
+            result = host.addr_alias_setup_instructions(self.addrs_ipv4, 4)
 
-            expected_result = 'Setup aliases for 192.168.1.1, 192.168.1.2 addresses with 255.255.255.0 subnet mask'
+            expected_result = 'Setup aliases for 192.168.1.1, 192.168.1.2 addresses with 255.255.255.255 subnet mask'
             self.assertEqual(expected_result, result)
 
         mock_loopback_device_name.assert_called_once_with()
@@ -363,7 +361,7 @@ class TestAddrAliasSetupInstructions(TestCase):
         with patch('conductr_cli.host.loopback_device_name', mock_loopback_device_name), \
                 patch('conductr_cli.host.is_linux', mock_is_linux), \
                 patch('conductr_cli.host.is_macos', mock_is_macos):
-            result = host.addr_alias_setup_instructions(self.addrs_ipv6, self.subnet_mask_ipv6)
+            result = host.addr_alias_setup_instructions(self.addrs_ipv6, 6)
 
             expected_result = 'Setup aliases for ::ffff:c0a8:101, ::ffff:c0a8:102 addresses with ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff subnet mask'
             self.assertEqual(expected_result, result)
@@ -380,13 +378,13 @@ class TestAddrAliasSetupInstructions(TestCase):
         with patch('conductr_cli.host.loopback_device_name', mock_loopback_device_name), \
                 patch('conductr_cli.host.is_linux', mock_is_linux), \
                 patch('conductr_cli.host.is_macos', mock_is_macos):
-            result = host.addr_alias_setup_instructions([self.addrs_ipv4[0]], self.subnet_mask_ipv4)
+            result = host.addr_alias_setup_instructions([self.addrs_ipv4[0]], 4)
 
             expected_result = strip_margin("""|Whoops. Network address aliases are required so that the sandbox can operate as a cluster of machines.
                                               |
                                               |Please run the following and then try your command again:
                                               |
-                                              |sudo ifconfig ix0:0 192.168.1.1 netmask 255.255.255.0 up
+                                              |sudo ifconfig ix0:0 192.168.1.1 netmask 255.255.255.255 up
                                               |""")
             self.assertEqual(expected_result, result)
 

--- a/conductr_cli/test/test_host.py
+++ b/conductr_cli/test/test_host.py
@@ -230,7 +230,7 @@ class TestIsListening(TestCase):
 
 
 class TestAddrAliasSetupInstructions(TestCase):
-    addr_range_ipv4 = ipaddress.ip_network('192.168.1.0/32')
+    addr_range_ipv4 = ipaddress.ip_network('192.168.1.0/24')
     addrs_ipv4 = [
         ipaddress.ip_address('192.168.1.1'),
         ipaddress.ip_address('192.168.1.2')

--- a/conductr_cli/test/test_sandbox_run_jvm.py
+++ b/conductr_cli/test/test_sandbox_run_jvm.py
@@ -370,7 +370,7 @@ class TestFindBindAddresses(CliTestCase):
             [ipaddress.ip_address('192.168.1.1'),
              ipaddress.ip_address('192.168.1.2'),
              ipaddress.ip_address('192.168.1.3')],
-            self.addr_range.netmask)
+            4)
 
     def test_partial_found(self):
         mock_can_bind = MagicMock(side_effect=[
@@ -390,7 +390,7 @@ class TestFindBindAddresses(CliTestCase):
         mock_addr_alias_setup_instructions.assert_called_once_with(
             [ipaddress.ip_address('192.168.1.2'),
              ipaddress.ip_address('192.168.1.3')],
-            self.addr_range.netmask)
+            4)
 
 
 class TestObtainSandboxImage(CliTestCase):


### PR DESCRIPTION
Fixes a bug with setting up address aliases. While we do want to use /24 (i.e. 255.255.255.0) for finding a network address to use, we actually always want to create the alias with a /32 (i.e. 255.255.255.255) subnet mask, as the alias itself is only interested in traffic sent directly to it. This fixes a bug on some operating systems (e.g. newer linux 4.x kernels) where network aliases respond to traffic in the same subnet -- even though it's destined for other IPs.

These changes are appropriate for MacOS as well. If other team members running MacOS could verify that your sandbox works when aliases are created with 255.255.255.255 as well, I think we're good to merge.