### PR TITLE
Fix a bug in java version detection where warnings or options output would fail the version detection

### DIFF
--- a/conductr_cli/sandbox_run_jvm.py
+++ b/conductr_cli/sandbox_run_jvm.py
@@ -196,26 +196,32 @@ def validate_jvm_support():
     try:
         raw_output = subprocess.getoutput('java -version')
         lines = raw_output.splitlines()
-        if lines:
-            first_line = lines[0]
-            parts = first_line.split(' ')
-            if len(parts) == 3:
-                jvm_vendor = parts[0]
 
-                if jvm_vendor in SUPPORTED_JVM_VENDOR:
-                    jvm_version = parts[2].replace('"', '')
-                    jvm_version_parts = jvm_version.split('.')
-                    if len(jvm_version_parts) >= 2:
-                        jvm_version_major = int(jvm_version_parts[0])
-                        jvm_version_minor = int(jvm_version_parts[1])
-                        jvm_version_tuple = (jvm_version_major, jvm_version_minor)
+        parts = None
 
-                        if jvm_version_tuple >= SUPPORTED_JVM_VERSION:
-                            return
-                        else:
-                            raise JavaUnsupportedVersionError(jvm_version)
-                else:
-                    raise JavaUnsupportedVendorError(jvm_vendor)
+        for line in lines:
+            maybe_parts = line.split(' ')
+
+            if len(maybe_parts) == 3 and maybe_parts[1] == 'version':
+                parts = maybe_parts
+
+        if parts is not None:
+            jvm_vendor = parts[0]
+
+            if jvm_vendor in SUPPORTED_JVM_VENDOR:
+                jvm_version = parts[2].replace('"', '')
+                jvm_version_parts = jvm_version.split('.')
+                if len(jvm_version_parts) >= 2:
+                    jvm_version_major = int(jvm_version_parts[0])
+                    jvm_version_minor = int(jvm_version_parts[1])
+                    jvm_version_tuple = (jvm_version_major, jvm_version_minor)
+
+                    if jvm_version_tuple >= SUPPORTED_JVM_VERSION:
+                        return
+                    else:
+                        raise JavaUnsupportedVersionError(jvm_version)
+            else:
+                raise JavaUnsupportedVendorError(jvm_vendor)
 
         raise JavaVersionParseError(raw_output)
     except CalledProcessError:

--- a/conductr_cli/test/test_sandbox_run.py
+++ b/conductr_cli/test/test_sandbox_run.py
@@ -180,7 +180,7 @@ class TestSandboxRunCommand(CliTestCase):
 
         expected_output = strip_margin(as_error("""|Error: Unable to obtain java version.
                                                    |Error: test
-                                                   |Error: Please ensure Oracle JVM 1.8 and above is installed.
+                                                   |Error: Please ensure Oracle or OpenJDK JVM 1.8 and above is installed.
                                                    |"""))
         self.assertEqual(expected_output, self.output(stderr))
 
@@ -209,7 +209,7 @@ class TestSandboxRunCommand(CliTestCase):
         mock_sandbox_run_jvm.assert_called_once_with(input_args, features)
 
         expected_output = strip_margin(as_error("""|Error: Unsupported JVM vendor: test
-                                                   |Error: Please ensure Oracle JVM 1.8 and above is installed.
+                                                   |Error: Please ensure Oracle or OpenJDK JVM 1.8 and above is installed.
                                                    |"""))
         self.assertEqual(expected_output, self.output(stderr))
 
@@ -238,7 +238,7 @@ class TestSandboxRunCommand(CliTestCase):
         mock_sandbox_run_jvm.assert_called_once_with(input_args, features)
 
         expected_output = strip_margin(as_error("""|Error: Unsupported JVM version: 1.4
-                                                   |Error: Please ensure Oracle JVM 1.8 and above is installed.
+                                                   |Error: Please ensure Oracle or OpenJDK JVM 1.8 and above is installed.
                                                    |"""))
         self.assertEqual(expected_output, self.output(stderr))
 
@@ -267,7 +267,7 @@ class TestSandboxRunCommand(CliTestCase):
         mock_sandbox_run_jvm.assert_called_once_with(input_args, features)
 
         expected_output = strip_margin(as_error("""|Error: Unable to obtain java version from the `java -version` command.
-                                                   |Error: Please ensure Oracle JVM 1.8 and above is installed.
+                                                   |Error: Please ensure Oracle or OpenJDK JVM 1.8 and above is installed.
                                                    |"""))
         self.assertEqual(expected_output, self.output(stderr))
 

--- a/conductr_cli/test/test_sandbox_run_jvm.py
+++ b/conductr_cli/test/test_sandbox_run_jvm.py
@@ -1175,6 +1175,20 @@ class TestValidateJvm(CliTestCase):
 
         mock_getoutput.assert_called_once_with('java -version')
 
+    def test_supported_with_options_warnings(self):
+        cmd_output = strip_margin("""|Picked up _JAVA_OPTIONS: -Xss8m -Xms512m -Xmx2048m -XX:MaxPermSize=512m -XX:ReservedCodeCacheSize=128m -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC
+                                     |OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=512m; support was removed in 8.0
+                                     |openjdk version "1.8.0_121"
+                                     |OpenJDK Runtime Environment (build 1.8.0_121-8u121-b13-3-b13)
+                                     |OpenJDK 64-Bit Server VM (build 25.121-b13, mixed mode)""")
+
+        mock_getoutput = MagicMock(return_value=cmd_output)
+
+        with patch('subprocess.getoutput', mock_getoutput):
+            sandbox_run_jvm.validate_jvm_support()
+
+        mock_getoutput.assert_called_once_with('java -version')
+
     def test_unsupported_vendor(self):
         cmd_output = strip_margin("""|unsupported version "1.2.3.4"
                                      |UnsupportedJDK Runtime Environment (build 1.2.3.4)

--- a/conductr_cli/validation.py
+++ b/conductr_cli/validation.py
@@ -394,22 +394,22 @@ def handle_jvm_validation_error(func):
             log = get_logger_for_func(func)
             log.error('Unable to obtain java version.')
             log.error(e.message)
-            log.error('Please ensure Oracle JVM 1.8 and above is installed.')
+            log.error('Please ensure Oracle or OpenJDK JVM 1.8 and above is installed.')
             return False
         except JavaUnsupportedVendorError as e:
             log = get_logger_for_func(func)
             log.error('Unsupported JVM vendor: {}'.format(e.vendor))
-            log.error('Please ensure Oracle JVM 1.8 and above is installed.')
+            log.error('Please ensure Oracle or OpenJDK JVM 1.8 and above is installed.')
             return False
         except JavaUnsupportedVersionError as e:
             log = get_logger_for_func(func)
             log.error('Unsupported JVM version: {}'.format(e.jvm_version))
-            log.error('Please ensure Oracle JVM 1.8 and above is installed.')
+            log.error('Please ensure Oracle or OpenJDK JVM 1.8 and above is installed.')
             return False
         except JavaVersionParseError as e:
             log = get_logger_for_func(func)
             log.error('Unable to obtain java version from the `java -version` command.')
-            log.error('Please ensure Oracle JVM 1.8 and above is installed.')
+            log.error('Please ensure Oracle or OpenJDK JVM 1.8 and above is installed.')
             return False
 
         # Do not change the wrapped function name,


### PR DESCRIPTION
Fix a bug in java version detection where warnings or options output would fail the version detection.

Before:

```
~ $ export _JAVA_OPTIONS="-Xss8m -Xms512m -Xmx2048m -XX:MaxPermSize=512m -XX:ReservedCodeCacheSize=128m -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC"

~ $ sandbox run 2.0.1
Error: Unable to obtain java version from the `java -version` command.
Error: Please ensure Oracle JVM 1.8 and above is installed.
-> 1
```

After:

```
~ $ export _JAVA_OPTIONS="-Xss8m -Xms512m -Xmx2048m -XX:MaxPermSize=512m -XX:ReservedCodeCacheSize=128m -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC"

~ $ sandbox run 2.0.1
|------------------------------------------------|
| Stopping HAProxy                               |
|------------------------------------------------|
sandbox-haproxy
HAProxy has been successfully stopped
|------------------------------------------------|
| Stopping ConductR                              |
|------------------------------------------------|
ConductR core pid 2291 stopped
ConductR agent pid 2292 stopped
ConductR has been successfully stopped
|------------------------------------------------|
| Starting ConductR                              |
|------------------------------------------------|
Extracting ConductR core to /home/longshorej/.conductr/images/core
Extracting ConductR agent to /home/longshorej/.conductr/images/agent
Starting ConductR core instance on 192.168.10.1..
Starting ConductR agent instance on 192.168.10.1..
```