### PR TITLE
Calculate loopback interface name correctly

### DIFF
--- a/conductr_cli/host.py
+++ b/conductr_cli/host.py
@@ -98,8 +98,8 @@ def addr_alias_setup_instructions(addrs, ip_version):
     subnet_mask = masks[ip_version]
 
     if is_linux():
-        commands = ['sudo ifconfig {}:{} {} netmask {} up'.format(if_name, idx, addr.exploded, subnet_mask)
-                    for idx, addr in enumerate(addrs)]
+        commands = ['sudo ifconfig {}:{} {} netmask {} up'
+                    .format(if_name, int(addr.exploded[-1:]) - 1, addr.exploded, subnet_mask) for addr in addrs]
 
         return '{}\n' \
                '\n' \

--- a/conductr_cli/sandbox_run_jvm.py
+++ b/conductr_cli/sandbox_run_jvm.py
@@ -253,7 +253,7 @@ def find_bind_addrs(nr_of_addrs, addr_range):
     - Let's say 3 address aliases is required.
     - The address range is 192.168.128.0/24
 
-    These addresses requires setup using ifconfig as such (MacOS example):
+    These addresses requires setup using ifconfig as such (macOS example):
 
     sudo ifconfig lo0 alias 192.168.128.1 255.255.255.255
     sudo ifconfig lo0 alias 192.168.128.2 255.255.255.255


### PR DESCRIPTION
The loopback interface name always started with `lo0`, no matter if an alias with `lo0` already exists. This resulted into false output when someone first started the sandbox with `-n 1` and afterwards with a higher number, e.g. `-n3`.

Now the loopback interface name on linux is calculated based on the corresponding IP address. If the IP address is `192.168.0.2` then the loopback name is `lo1`.

This solution works both for IP4 and IP6.