### PR TITLE
Fixes sandbox run error when docker is not started

### DIFF
--- a/conductr_cli/sandbox_features.py
+++ b/conductr_cli/sandbox_features.py
@@ -98,10 +98,7 @@ class ProxyingFeature:
 
     @staticmethod
     def stop():
-        if sandbox_proxy.get_running_haproxy():
-            return sandbox_proxy.stop_proxy()
-        else:
-            return True
+        return sandbox_proxy.stop_proxy()
 
 
 class VisualizationFeature:

--- a/conductr_cli/test/test_sandbox_features.py
+++ b/conductr_cli/test/test_sandbox_features.py
@@ -110,21 +110,10 @@ class TestProxyingFeature(TestCase):
 
         proxy_start.assert_called_once_with(proxy_bind_addr='192.168.100.1', bundle_http_port=9000, proxy_ports=[], all_feature_ports=[3000, 5601, 9200, 9999])
 
-    def test_stop_not_running(self):
-        proxy_stop = MagicMock()
+    def test_stop(self):
+        proxy_stop = MagicMock(return_value=True)
 
-        with patch('conductr_cli.sandbox_proxy.get_running_haproxy', lambda: False):
-            feature = ProxyingFeature([], '2.0.0', False)
-
-            self.assertTrue(feature.stop())
-
-        proxy_stop.assert_not_called()
-
-    def test_stop_running(self):
-        proxy_stop = MagicMock()
-
-        with patch('conductr_cli.sandbox_proxy.get_running_haproxy', lambda: True), \
-                patch('conductr_cli.sandbox_proxy.stop_proxy', proxy_stop):
+        with patch('conductr_cli.sandbox_proxy.stop_proxy', proxy_stop):
             feature = ProxyingFeature([], '2.0.0', False)
 
             self.assertTrue(feature.stop())


### PR DESCRIPTION
Proxying feature now invokes sandbox_proxy.stop_proxy() without check.

This is since the check for Docker presence, including the `CalledProcessError` handler is done within `sandbox_proxy.stop_proxy()`.

Also include assertion for the log output generated by Proxying feature.

