### PR TITLE
WIP - DO NOT MERGE - idea for how shazar could calculate digest of stdin

### DIFF
--- a/conductr_cli/shazar_main.py
+++ b/conductr_cli/shazar_main.py
@@ -6,8 +6,12 @@ import hashlib
 import logging
 import os
 import shutil
+import sys
 import tempfile
 import zipfile
+
+
+READ_SIZE_BYTES = 32768
 
 
 def run(argv=None):
@@ -26,37 +30,67 @@ def build_parser():
                         default='.',
                         help="The optional output directory, defaults to '.'")
     parser.add_argument('source',
-                        help='Path to a bundle directory or bundle configuration file')
+                        help='Path to a bundle directory or bundle configuration file. If absent, stream from stdin.',
+                        nargs='?')
     parser.set_defaults(func=shazar)
     return parser
 
 
 def shazar(args):
     log = logging.getLogger(__name__)
-    source_base_name = os.path.basename(args.source.rstrip('\\/'))
-    # Create an empty tempfile
-    temp_file = tempfile.NamedTemporaryFile(suffix='.zip', delete=False)
-    temp_file.close()
-    temp_file_name = temp_file.name
 
-    with zipfile.ZipFile(temp_file_name, 'w') as zip_file:
-        if os.path.isdir(args.source):
-            for (dir_path, dir_names, file_names) in os.walk(args.source):
-                for file_name in file_names:
-                    path = os.path.join(dir_path, file_name)
-                    name = os.path.join(source_base_name, os.path.relpath(path, start=args.source))
-                    zip_file.write(path, name)
-        else:
-            zip_file.write(args.source, source_base_name)
+    # shazar has a standard zip-based format for directories that encodes
+    # the digest of a file in its file name.
 
-    dest = os.path.join(args.output_dir, '{}-{}.zip'.format(source_base_name, create_digest(temp_file_name)))
-    shutil.move(temp_file_name, dest)
-    log.info('Created digested ZIP archive at {}'.format(dest))
+    # When reading from stdin, however,  it embeds this digest at the end
+    # of stdout.
+
+    # In this case, shazar pipes the input to stdout and when finished
+    # also writes the digest. This means the output stream will always
+    # be 32 bytes longer than the input stream. To verify the digest of a stream,
+    # consuming programs that expect a streaming shazar format can
+    # calculate a running digest as they consume the stream
+    # simply decode the digest from the last 32 bytes of the stream
+    # and then check the rest of the stream.
+
+    if args.source is None:
+        done = False
+        d = hashlib.sha256()
+
+        while not done:
+            buf = sys.stdin.buffer.read(READ_SIZE_BYTES)
+
+            if buf == b'':
+                sys.stdout.buffer.write(d.digest())
+                done = True
+            else:
+                sys.stdout.buffer.write(buf)
+                d.update(buf)
+    else:
+        source_base_name = os.path.basename(args.source.rstrip('\\/'))
+        # Create an empty tempfile
+        temp_file = tempfile.NamedTemporaryFile(suffix='.zip', delete=False)
+        temp_file.close()
+        temp_file_name = temp_file.name
+
+        with zipfile.ZipFile(temp_file_name, 'w') as zip_file:
+            if os.path.isdir(args.source):
+                for (dir_path, dir_names, file_names) in os.walk(args.source):
+                    for file_name in file_names:
+                        path = os.path.join(dir_path, file_name)
+                        name = os.path.join(source_base_name, os.path.relpath(path, start=args.source))
+                        zip_file.write(path, name)
+            else:
+                zip_file.write(args.source, source_base_name)
+
+        dest = os.path.join(args.output_dir, '{}-{}.zip'.format(source_base_name, create_digest(temp_file_name)))
+        shutil.move(temp_file_name, dest)
+        log.info('Created digested ZIP archive at {}'.format(dest))
 
 
 def create_digest(file_name):
     with open(file_name, mode='rb') as f:
         d = hashlib.sha256()
-        for buf in iter(partial(f.read, 128), b''):
+        for buf in iter(partial(f.read, READ_SIZE_BYTES), b''):
             d.update(buf)
     return d.hexdigest()


### PR DESCRIPTION
This is a working example of how we could have `shazar` calculate digests of input streams. It's pretty simple - pipe stdin to stdout and calculate a running digest. Write this digest (32 bytes) to stdout when reading EOF of stdin.

Additional ideas to consider:

Perhaps `shazar verify` can verify if a file is valid: If it's a ZIP, check if its digest matches the one specified in the filename. If it's not a ZIP, calculate the digest excluding the last 32 bytes and see if the digest matches those bytes. Perhaps it has a `-q` flag where the only status indication is via exit code.

Example:

*Old Usage remains the same:*

```
$ shazar my-app
Created digested ZIP archive at ./my-app-8739c76e681f900923b900c9df0ef75cf421d39cabb54650c4b9ad19b6a76d85.zip
-> 0
```

*New usage activated when omitting a filename:*

```
$ echo 'hellofdsafdafs-world' | shazar
hellofdsafdafs-world[snippet some binary content]
-> 0
```

*New usage with `docker save` (note this would ultimately have `--format oci` but that's a WIP for them)*

```
$ docker save alpine:latest | shazar > my-shazared-oci-image.tar
-> 0

$ ls -lah my-shazared-oci-image.tar 
-rw-r--r-- 1 longshorej longshorej 4.1M Mar  1 17:37 my-shazared-oci-image.tar
-> 0
```

*Grabbing digest in shell*
```
$ tail -c 32 my-shazared-oci-image.tar | xxd -l 32 -c 32 -p
8e7d24db3adc0a3181419da17710d1790708b5e898157f2ffd288d9f9a2734fe
-> 0
```