### PR TITLE
`conduct load` and `shazar` now accept stdin input, support new digest format

### DIFF
--- a/conductr_cli/bundle_utils.py
+++ b/conductr_cli/bundle_utils.py
@@ -1,3 +1,6 @@
+from conductr_cli.constants import DIGEST_TRAIL_SIZE, IO_CHUNK_SIZE
+import os
+import tempfile
 from zipfile import ZipFile
 
 
@@ -9,3 +12,107 @@ def conf(bundle_path):
     bundle_zip = ZipFile(bundle_path)
     bundle_configuration = [bundle_zip.read(name) for name in bundle_zip.namelist() if name.endswith('bundle.conf')]
     return bundle_configuration[0].decode('utf-8') if len(bundle_configuration) == 1 else ''
+
+
+def digest_extract_and_open(path):
+    """
+    Inspects a given `path` for a digest marker at the end of the file and returns
+    an open file object that will not include the digest.
+
+    :param path:
+    :return: file object without digest, possible digest
+    """
+
+    input = open(path, 'rb')
+    input.seek(
+        -DIGEST_TRAIL_SIZE,
+        os.SEEK_END
+    )
+    digest, trailer_starts, trailer_len = digest_calculate(input.read())
+    input.seek(0)
+
+    if trailer_len > 0:
+        output = tempfile.NamedTemporaryFile()
+        reader = DigestedRead(input)
+        done = False
+
+        while not done:
+            chunk = reader.read(IO_CHUNK_SIZE)
+
+            if chunk:
+                output.write(chunk)
+            else:
+                done = True
+
+        output.seek(0)
+
+        return output, digest
+    else:
+        return input, None
+
+
+def digest_calculate(data):
+    digests = ['sha-256']
+    digest = None
+    trailer_starts = None
+    trailer_bytes = []
+
+    for i, v in reversed(list(enumerate(data))):
+        if v == 10:
+            trailer_starts = i
+            break
+        else:
+            trailer_bytes.insert(0, v)
+
+    if len(trailer_bytes) > 0:
+        try:
+            parts = bytes(trailer_bytes).decode('UTF-8').split('/')
+
+            if len(parts) == 2 and parts[0] in digests:
+                digest = parts[0], parts[1]
+        except UnicodeDecodeError:
+            pass
+
+    return digest, trailer_starts, 0 if trailer_starts is None else len(trailer_bytes) + 1
+
+
+class DigestedRead(object):
+    def __init__(self, r):
+        self.reader = r
+        self.digest = None
+        self.buffer = b''
+        self.done = False
+        self.emitted = 0
+
+    def read(self, num_bytes):
+        if self.done:
+            return b''
+        else:
+            chunk = self.reader.read(num_bytes)
+
+            if chunk:
+                self.buffer += chunk
+
+                if len(self.buffer) > DIGEST_TRAIL_SIZE:
+                    data = self.buffer[0:len(self.buffer) - DIGEST_TRAIL_SIZE]
+
+                    self.buffer = self.buffer[-DIGEST_TRAIL_SIZE:]
+
+                    self.emitted += len(data)
+
+                    return data
+                else:
+                    return self.read(num_bytes)
+            else:
+                digest, trailer_starts, trailer_length = digest_calculate(self.buffer)
+
+                self.digest = digest
+                self.done = True
+
+                return_value = self.buffer if digest is None else self.buffer[0:trailer_starts]
+
+                self.emitted += len(return_value)
+
+                self.buffer = b''
+
+                return return_value

--- a/conductr_cli/conduct_main.py
+++ b/conductr_cli/conduct_main.py
@@ -238,8 +238,12 @@ def build_parser(dcos_mode):
     load_parser = subparsers.add_parser('load',
                                         help='Load a bundle',
                                         formatter_class=argparse.RawTextHelpFormatter)
+
     load_parser.add_argument('bundle',
-                             help='The path to the bundle')
+                             nargs=None if sys.stdin.isatty() else '?',
+                             default=None if sys.stdin.isatty() else '-',
+                             help='The path to the bundle. Specify "-" to skip when providing stdin')
+
     load_parser.add_argument('configuration',
                              nargs='?',
                              default=None,

--- a/conductr_cli/constants.py
+++ b/conductr_cli/constants.py
@@ -38,3 +38,6 @@ DEFAULT_WAIT_TIMEOUT = 60  # seconds
 FEATURE_PROVIDE_PROXYING = 'proxying'
 
 FEATURE_PROVIDE_LOGGING = 'logging'
+
+# When reading and writing to IO devices, buffer this many bytes at a time
+IO_CHUNK_SIZE = 32768

--- a/conductr_cli/constants.py
+++ b/conductr_cli/constants.py
@@ -35,6 +35,9 @@ DEFAULT_ERROR_LOG_FILE = os.path.abspath(os.getenv('CONDUCTR_CLI_ERROR_LOG',
                                                    '{}/errors.log'.format(DEFAULT_CLI_SETTINGS_DIR)))
 DEFAULT_WAIT_TIMEOUT = 60  # seconds
 
+# Must be able to hold the digest value, name of algorithm, and newline character
+DIGEST_TRAIL_SIZE = 100
+
 FEATURE_PROVIDE_PROXYING = 'proxying'
 
 FEATURE_PROVIDE_LOGGING = 'logging'

--- a/conductr_cli/resolver.py
+++ b/conductr_cli/resolver.py
@@ -1,12 +1,12 @@
 from conductr_cli.exceptions import BundleResolutionError, ContinuousDeliveryError
-from conductr_cli.resolvers import bintray_resolver, uri_resolver, offline_resolver
+from conductr_cli.resolvers import bintray_resolver, stdin_resolver, uri_resolver, offline_resolver
 import importlib
 import logging
 
 
 # Try to resolve from local file system before we attempting resolution using bintray
-DEFAULT_RESOLVERS = [uri_resolver, bintray_resolver]
-OFFLINE_RESOLVERS = [offline_resolver]
+DEFAULT_RESOLVERS = [stdin_resolver, uri_resolver, bintray_resolver]
+OFFLINE_RESOLVERS = [stdin_resolver, offline_resolver]
 
 
 def resolve_bundle(custom_settings, cache_dir, uri, offline_mode=False):

--- a/conductr_cli/resolvers/stdin_resolver.py
+++ b/conductr_cli/resolvers/stdin_resolver.py
@@ -1,0 +1,55 @@
+from conductr_cli.constants import IO_CHUNK_SIZE
+import sys
+import tempfile
+
+ALLOCATED_FILES = []
+
+
+def resolve_bundle(cache_dir, uri, auth=None):
+    if sys.stdin.isatty() or uri != '-':
+        return False, None, None
+    else:
+        temp = tempfile.NamedTemporaryFile(delete=False)
+
+        done = False
+
+        while not done:
+            chunk = sys.stdin.buffer.read(IO_CHUNK_SIZE)
+
+            if chunk:
+                temp.write(chunk)
+            else:
+                done = True
+
+        temp.flush()
+
+        # keep a reference to the tempfile around, so it's properly deleted on program exit instead of
+        # us having to manually manage that
+
+        ALLOCATED_FILES.append(temp)
+
+        return True, None, temp.name
+
+
+def load_bundle_from_cache(cache_dir, uri):
+    return False, None, None
+
+
+def resolve_bundle_configuration(cache_dir, uri, auth=None):
+    return False, None, None
+
+
+def load_bundle_configuration_from_cache(cache_dir, uri):
+    return False, None, None
+
+
+def resolve_bundle_version(uri):
+    return None
+
+
+def continuous_delivery_uri(resolved_version):
+    return None
+
+
+def is_bundle_name(uri):
+    return uri.count('/') == 0 and uri.count('.') == 0

--- a/conductr_cli/test/cli_test_case.py
+++ b/conductr_cli/test/cli_test_case.py
@@ -54,6 +54,16 @@ class CliTestCase(TestCase):
     def output(logger):
         return ''.join([args[0] for name, args, kwargs in logger.method_calls if len(args) > 0])
 
+    @staticmethod
+    def output_bytes(logger):
+        out = []
+
+        for name, args, kwargs in logger.method_calls:
+            if len(args) > 0:
+                out.extend(args[0])
+
+        return bytes(out)
+
 
 def strip_margin(string, margin_char='|'):
     return '\n'.join([line[line.find(margin_char) + 1:] for line in string.split('\n')])

--- a/conductr_cli/test/conduct_load_test_base.py
+++ b/conductr_cli/test/conduct_load_test_base.py
@@ -1,5 +1,5 @@
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin, as_error
-from conductr_cli import conduct_load, logging_setup
+from conductr_cli import bundle_utils, conduct_load, logging_setup
 from conductr_cli.exceptions import BundleResolutionError, WaitTimeoutError
 from zipfile import BadZipFile
 from urllib.error import HTTPError, URLError
@@ -60,7 +60,7 @@ class ConductLoadTestBase(CliTestCase):
         create_multipart_mock = MagicMock(return_value=self.multipart_mock)
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
-        open_mock = MagicMock(return_value=1)
+        bundle_open_mock = MagicMock(side_effect=lambda p1, p2, p3: (p1, 1))
         wait_for_installation_mock = MagicMock()
         cleanup_old_bundles_mock = MagicMock()
 
@@ -69,13 +69,15 @@ class ConductLoadTestBase(CliTestCase):
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
                 patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('requests.post', http_method), \
-                patch('builtins.open', open_mock), \
+                patch('conductr_cli.conduct_load.open_bundle', bundle_open_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_load.load(input_args)
             self.assertTrue(result)
 
-        open_mock.assert_called_with(self.bundle_file, 'rb')
+        bundle_open_mock.assert_called_with(self.bundle_file_name,
+                                            self.bundle_file,
+                                            bundle_utils.conf(self.bundle_file))
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
                                                self.bundle_file, self.offline_mode)
         create_multipart_mock.assert_called_with(self.conduct_load_logger, self.default_files)
@@ -98,7 +100,8 @@ class ConductLoadTestBase(CliTestCase):
         create_multipart_mock = MagicMock(return_value=self.multipart_mock)
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
-        open_mock = MagicMock(return_value=1)
+        bundle_open_mock = MagicMock(side_effect=lambda p1, p2, p3: (p1, 1))
+
         wait_for_installation_mock = MagicMock()
         cleanup_old_bundles_mock = MagicMock()
 
@@ -107,13 +110,15 @@ class ConductLoadTestBase(CliTestCase):
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
                 patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('dcos.http.post', http_method), \
-                patch('builtins.open', open_mock), \
+                patch('conductr_cli.conduct_load.open_bundle', bundle_open_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_load.load(input_args)
             self.assertTrue(result)
 
-        open_mock.assert_called_with(self.bundle_file, 'rb')
+        bundle_open_mock.assert_called_with(self.bundle_file_name,
+                                            self.bundle_file,
+                                            bundle_utils.conf(self.bundle_file))
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
                                                self.bundle_file, self.offline_mode)
         create_multipart_mock.assert_called_with(self.conduct_load_logger, self.default_files)
@@ -133,7 +138,7 @@ class ConductLoadTestBase(CliTestCase):
         create_multipart_mock = MagicMock(return_value=self.multipart_mock)
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
-        open_mock = MagicMock(return_value=1)
+        bundle_open_mock = MagicMock(side_effect=lambda p1, p2, p3: (p1, 1))
         wait_for_installation_mock = MagicMock()
         cleanup_old_bundles_mock = MagicMock()
 
@@ -145,13 +150,15 @@ class ConductLoadTestBase(CliTestCase):
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
                 patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('requests.post', http_method), \
-                patch('builtins.open', open_mock), \
+                patch('conductr_cli.conduct_load.open_bundle', bundle_open_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_load.load(input_args)
             self.assertTrue(result)
 
-        open_mock.assert_called_with(self.bundle_file, 'rb')
+        bundle_open_mock.assert_called_with(self.bundle_file_name,
+                                            self.bundle_file,
+                                            bundle_utils.conf(self.bundle_file))
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
                                                self.bundle_file, self.offline_mode)
         create_multipart_mock.assert_called_with(self.conduct_load_logger, self.default_files)
@@ -171,7 +178,7 @@ class ConductLoadTestBase(CliTestCase):
         create_multipart_mock = MagicMock(return_value=self.multipart_mock)
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
-        open_mock = MagicMock(return_value=1)
+        bundle_open_mock = MagicMock(side_effect=lambda p1, p2, p3: (p1, 1))
         wait_for_installation_mock = MagicMock()
         cleanup_old_bundles_mock = MagicMock()
 
@@ -183,13 +190,15 @@ class ConductLoadTestBase(CliTestCase):
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
                 patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('requests.post', http_method), \
-                patch('builtins.open', open_mock), \
+                patch('conductr_cli.conduct_load.open_bundle', bundle_open_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_load.load(input_args)
             self.assertTrue(result)
 
-        open_mock.assert_called_with(self.bundle_file, 'rb')
+        bundle_open_mock.assert_called_with(self.bundle_file_name,
+                                            self.bundle_file,
+                                            bundle_utils.conf(self.bundle_file))
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
                                                self.bundle_file, self.offline_mode)
         create_multipart_mock.assert_called_with(self.conduct_load_logger, self.default_files)
@@ -209,7 +218,7 @@ class ConductLoadTestBase(CliTestCase):
         create_multipart_mock = MagicMock(return_value=self.multipart_mock)
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
-        open_mock = MagicMock(return_value=1)
+        bundle_open_mock = MagicMock(side_effect=lambda p1, p2, p3: (p1, 1))
         wait_for_installation_mock = MagicMock()
         cleanup_old_bundles_mock = MagicMock()
 
@@ -221,13 +230,15 @@ class ConductLoadTestBase(CliTestCase):
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
                 patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('requests.post', http_method), \
-                patch('builtins.open', open_mock), \
+                patch('conductr_cli.conduct_load.open_bundle', bundle_open_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_load.load(input_args)
             self.assertTrue(result)
 
-        open_mock.assert_called_with(self.bundle_file, 'rb')
+        bundle_open_mock.assert_called_with(self.bundle_file_name,
+                                            self.bundle_file,
+                                            bundle_utils.conf(self.bundle_file))
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
                                                self.bundle_file, self.offline_mode)
         create_multipart_mock.assert_called_with(self.conduct_load_logger, self.default_files)
@@ -247,7 +258,7 @@ class ConductLoadTestBase(CliTestCase):
         create_multipart_mock = MagicMock(return_value=self.multipart_mock)
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
-        open_mock = MagicMock(return_value=1)
+        bundle_open_mock = MagicMock(side_effect=lambda p1, p2, p3: (p1, 1))
         wait_for_installation_mock = MagicMock()
         cleanup_old_bundles_mock = MagicMock()
 
@@ -260,13 +271,15 @@ class ConductLoadTestBase(CliTestCase):
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
                 patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('requests.post', http_method), \
-                patch('builtins.open', open_mock), \
+                patch('conductr_cli.conduct_load.open_bundle', bundle_open_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_load.load(input_args)
             self.assertTrue(result)
 
-        open_mock.assert_called_with(self.bundle_file, 'rb')
+        bundle_open_mock.assert_called_with(self.bundle_file_name,
+                                            self.bundle_file,
+                                            bundle_utils.conf(self.bundle_file))
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
                                                self.bundle_file, self.offline_mode)
         create_multipart_mock.assert_called_with(self.conduct_load_logger, self.default_files)
@@ -288,7 +301,7 @@ class ConductLoadTestBase(CliTestCase):
         create_multipart_mock = MagicMock(return_value=self.multipart_mock)
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
-        open_mock = MagicMock(return_value=1)
+        bundle_open_mock = MagicMock(side_effect=lambda p1, p2, p3: (p1, 1))
         wait_for_installation_mock = MagicMock()
         cleanup_old_bundles_mock = MagicMock()
 
@@ -301,13 +314,15 @@ class ConductLoadTestBase(CliTestCase):
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
                 patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('requests.post', http_method), \
-                patch('builtins.open', open_mock), \
+                patch('conductr_cli.conduct_load.open_bundle', bundle_open_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_load.load(input_args)
             self.assertTrue(result)
 
-        open_mock.assert_called_with(self.bundle_file, 'rb')
+        bundle_open_mock.assert_called_with(self.bundle_file_name,
+                                            self.bundle_file,
+                                            bundle_utils.conf(self.bundle_file))
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
                                                self.bundle_file, self.offline_mode)
         create_multipart_mock.assert_called_with(self.conduct_load_logger, self.default_files)
@@ -334,7 +349,7 @@ class ConductLoadTestBase(CliTestCase):
         create_multipart_mock = MagicMock(return_value=self.multipart_mock)
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
-        open_mock = MagicMock(return_value=1)
+        bundle_open_mock = MagicMock(side_effect=lambda p1, p2, p3: (p1, 1))
         wait_for_installation_mock = MagicMock()
         cleanup_old_bundles_mock = MagicMock()
 
@@ -343,13 +358,15 @@ class ConductLoadTestBase(CliTestCase):
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
                 patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('requests.post', http_method), \
-                patch('builtins.open', open_mock), \
+                patch('conductr_cli.conduct_load.open_bundle', bundle_open_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_load.load(input_args)
             self.assertTrue(result)
 
-        open_mock.assert_called_with(self.bundle_file, 'rb')
+        bundle_open_mock.assert_called_with(self.bundle_file_name,
+                                            self.bundle_file,
+                                            bundle_utils.conf(self.bundle_file))
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
                                                self.bundle_file, self.offline_mode)
         create_multipart_mock.assert_called_with(self.conduct_load_logger, self.default_files)
@@ -369,7 +386,7 @@ class ConductLoadTestBase(CliTestCase):
         create_multipart_mock = MagicMock(return_value=self.multipart_mock)
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
-        open_mock = MagicMock(return_value=1)
+        bundle_open_mock = MagicMock(side_effect=lambda p1, p2, p3: (p1, 1))
         cleanup_old_bundles_mock = MagicMock()
 
         args = self.default_args.copy()
@@ -380,12 +397,14 @@ class ConductLoadTestBase(CliTestCase):
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
                 patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('requests.post', http_method), \
-                patch('builtins.open', open_mock):
+                patch('conductr_cli.conduct_load.open_bundle', bundle_open_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_load.load(input_args)
             self.assertTrue(result)
 
-        open_mock.assert_called_with(self.bundle_file, 'rb')
+        bundle_open_mock.assert_called_with(self.bundle_file_name,
+                                            self.bundle_file,
+                                            bundle_utils.conf(self.bundle_file))
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
                                                self.bundle_file, self.offline_mode)
         create_multipart_mock.assert_called_with(self.conduct_load_logger, self.default_files)
@@ -404,7 +423,7 @@ class ConductLoadTestBase(CliTestCase):
         create_multipart_mock = MagicMock(return_value=self.multipart_mock)
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
-        open_mock = MagicMock(return_value=1)
+        bundle_open_mock = MagicMock(side_effect=lambda p1, p2, p3: (p1, 1))
         cleanup_old_bundles_mock = MagicMock()
         wait_for_installation_mock = MagicMock()
 
@@ -416,13 +435,15 @@ class ConductLoadTestBase(CliTestCase):
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
                 patch('conductr_cli.conduct_load.cleanup_old_bundles', cleanup_old_bundles_mock), \
                 patch('requests.post', http_method), \
-                patch('builtins.open', open_mock), \
+                patch('conductr_cli.conduct_load.open_bundle', bundle_open_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_load.load(input_args)
             self.assertTrue(result)
 
-        open_mock.assert_called_with(self.bundle_file, 'rb')
+        bundle_open_mock.assert_called_with(self.bundle_file_name,
+                                            self.bundle_file,
+                                            bundle_utils.conf(self.bundle_file))
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
                                                self.bundle_file, True)
         create_multipart_mock.assert_called_with(self.conduct_load_logger, self.default_files)
@@ -442,18 +463,20 @@ class ConductLoadTestBase(CliTestCase):
         http_method = self.respond_with(404)
         stdout = MagicMock()
         stderr = MagicMock()
-        open_mock = MagicMock(return_value=1)
+        bundle_open_mock = MagicMock(side_effect=lambda p1, p2, p3: (p1, 1))
 
         input_args = MagicMock(**self.default_args)
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
                 patch('requests.post', http_method), \
-                patch('builtins.open', open_mock):
+                patch('conductr_cli.conduct_load.open_bundle', bundle_open_mock):
             logging_setup.configure_logging(input_args, stdout, stderr)
             result = conduct_load.load(input_args)
             self.assertFalse(result)
 
-        open_mock.assert_called_with(self.bundle_file, 'rb')
+        bundle_open_mock.assert_called_with(self.bundle_file_name,
+                                            self.bundle_file,
+                                            bundle_utils.conf(self.bundle_file))
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
                                                self.bundle_file, self.offline_mode)
         create_multipart_mock.assert_called_with(self.conduct_load_logger, self.default_files)
@@ -474,18 +497,20 @@ class ConductLoadTestBase(CliTestCase):
         http_method = self.raise_connection_error('test reason', self.default_url)
         stdout = MagicMock()
         stderr = MagicMock()
-        open_mock = MagicMock(return_value=1)
+        bundle_open_mock = MagicMock(side_effect=lambda p1, p2, p3: (p1, 1))
 
         input_args = MagicMock(**self.default_args)
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
                 patch('requests.post', http_method), \
-                patch('builtins.open', open_mock):
+                patch('conductr_cli.conduct_load.open_bundle', bundle_open_mock):
             logging_setup.configure_logging(input_args, stdout, stderr)
             result = conduct_load.load(input_args)
             self.assertFalse(result)
 
-        open_mock.assert_called_with(self.bundle_file, 'rb')
+        bundle_open_mock.assert_called_with(self.bundle_file_name,
+                                            self.bundle_file,
+                                            bundle_utils.conf(self.bundle_file))
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
                                                self.bundle_file, self.offline_mode)
         create_multipart_mock.assert_called_with(self.conduct_load_logger, self.default_files)
@@ -505,18 +530,20 @@ class ConductLoadTestBase(CliTestCase):
         http_method = self.raise_read_timeout_error('test reason', self.default_url)
         stdout = MagicMock()
         stderr = MagicMock()
-        open_mock = MagicMock(return_value=1)
+        bundle_open_mock = MagicMock(side_effect=lambda p1, p2, p3: (p1, 1))
 
         input_args = MagicMock(**self.default_args)
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
                 patch('requests.post', http_method), \
-                patch('builtins.open', open_mock):
+                patch('conductr_cli.conduct_load.open_bundle', bundle_open_mock):
             logging_setup.configure_logging(input_args, stdout, stderr)
             result = conduct_load.load(input_args)
             self.assertFalse(result)
 
-        open_mock.assert_called_with(self.bundle_file, 'rb')
+        bundle_open_mock.assert_called_with(self.bundle_file_name,
+                                            self.bundle_file,
+                                            bundle_utils.conf(self.bundle_file))
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
                                                self.bundle_file, self.offline_mode)
         create_multipart_mock.assert_called_with(self.conduct_load_logger, self.default_files)
@@ -580,17 +607,21 @@ class ConductLoadTestBase(CliTestCase):
     def base_test_failure_bad_zip(self):
         resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, self.bundle_file))
         stderr = MagicMock()
-        open_mock = MagicMock(side_effect=BadZipFile('test bad zip error'))
+        bundle_open_mock = MagicMock(side_effect=BadZipFile('test bad zip error'))
 
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
-                patch('builtins.open', open_mock):
+                patch('conductr_cli.conduct_load.open_bundle', bundle_open_mock):
             logging_setup.configure_logging(MagicMock(**self.default_args), err_output=stderr)
             result = conduct_load.load(MagicMock(**self.default_args))
             self.assertFalse(result)
 
         resolve_bundle_mock.assert_called_with(self.custom_settings, self.bundle_resolve_cache_dir,
                                                self.bundle_file, self.offline_mode)
-        open_mock.assert_called_with(self.bundle_file, 'rb')
+        bundle_open_mock.assert_called_with(
+            self.bundle_file_name,
+            self.bundle_file,
+            bundle_utils.conf(self.bundle_file)
+        )
 
         self.assertEqual(
             as_error(strip_margin("""|Error: Problem with the bundle: test bad zip error
@@ -637,20 +668,22 @@ class ConductLoadTestBase(CliTestCase):
         create_multipart_mock = MagicMock(return_value=self.multipart_mock)
         http_method = self.respond_with(200, self.default_response)
         stderr = MagicMock()
-        open_mock = MagicMock(return_value=1)
+        bundle_open_mock = MagicMock(side_effect=lambda p1, p2, p3: (p1, 1))
         wait_for_installation_mock = MagicMock(side_effect=WaitTimeoutError('test timeout'))
 
         input_args = MagicMock(**self.default_args)
         with patch('conductr_cli.resolver.resolve_bundle', resolve_bundle_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
                 patch('requests.post', http_method), \
-                patch('builtins.open', open_mock), \
+                patch('conductr_cli.conduct_load.open_bundle', bundle_open_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
             logging_setup.configure_logging(input_args, err_output=stderr)
             result = conduct_load.load(input_args)
             self.assertFalse(result)
 
-        open_mock.assert_called_with(self.bundle_file, 'rb')
+        bundle_open_mock.assert_called_with(self.bundle_file_name,
+                                            self.bundle_file,
+                                            bundle_utils.conf(self.bundle_file))
         create_multipart_mock.assert_called_with(self.conduct_load_logger, self.default_files)
         http_method.assert_called_with(self.default_url,
                                        data=self.multipart_mock,

--- a/conductr_cli/test/test_bundle_utils.py
+++ b/conductr_cli/test/test_bundle_utils.py
@@ -1,11 +1,11 @@
 from unittest import TestCase
-from conductr_cli import bundle_utils
+from conductr_cli import bundle_utils, constants
 from conductr_cli.test.cli_test_case import create_temp_bundle
 import shutil
+import tempfile
 
 
 class ShortId(TestCase):
-
     def test(self):
         self.assertEqual(
             bundle_utils.short_id('45e0c477d3e5ea92aa8d85c0d8f3e25c'),
@@ -17,7 +17,6 @@ class ShortId(TestCase):
 
 
 class Conf(TestCase):
-
     def setUp(self):  # noqa
         self.tmpdir, self.bundle_path = create_temp_bundle('bundle conf contents')
 
@@ -27,3 +26,130 @@ class Conf(TestCase):
 
     def tearDown(self):  # noqa
         shutil.rmtree(self.tmpdir)
+
+
+class Digest(TestCase):
+    def test_digest_calculate_short(self):
+        data = b'hello\nsha-256/6ae881d57578a07900c4eb37e21afa4c2095beb8e852fb6ed8d0c9f343bc7fa8'
+
+        digest, starts, length = bundle_utils.digest_calculate(data)
+
+        self.assertEqual(digest, ('sha-256', '6ae881d57578a07900c4eb37e21afa4c2095beb8e852fb6ed8d0c9f343bc7fa8'))
+        self.assertEqual(starts, 5)
+        self.assertEqual(length, 73)
+
+    def test_digest_calculate_long(self):
+        some_raw_test_data = b'abc' * 1000
+
+        data = some_raw_test_data + b'\nsha-256/6ae881d57578a07900c4eb37e21afa4c2095beb8e852fb6ed8d0c9f343bc7fa8'
+
+        digest, starts, length = bundle_utils.digest_calculate(data)
+
+        self.assertEqual(digest, ('sha-256', '6ae881d57578a07900c4eb37e21afa4c2095beb8e852fb6ed8d0c9f343bc7fa8'))
+        self.assertEqual(starts, 3000)
+        self.assertEqual(length, 73)
+
+    def test_digested_read_no_digest_small(self):
+        with tempfile.NamedTemporaryFile() as file:
+            some_test_data = b'this is a test file'
+
+            self.assertLess(len(some_test_data), constants.DIGEST_TRAIL_SIZE)
+
+            file.write(some_test_data)
+            file.flush()
+            file.seek(0)
+
+            reader = bundle_utils.DigestedRead(file)
+
+            data = reader.read(1024)
+
+            self.assertEqual(data, some_test_data)
+            self.assertEqual(reader.digest, None)
+
+    def test_digested_read_with_digest_small(self):
+        with tempfile.NamedTemporaryFile() as file:
+            some_raw_test_data = b'this is a test file'
+
+            some_test_data = \
+                some_raw_test_data + b'\nsha-256/6ae881d57578a07900c4eb37e21afa4c2095beb8e852fb6ed8d0c9f343bc7fa8'
+
+            self.assertLess(len(some_test_data), constants.DIGEST_TRAIL_SIZE)
+
+            file.write(some_test_data)
+            file.flush()
+            file.seek(0)
+
+            reader = bundle_utils.DigestedRead(file)
+
+            data = reader.read(1024)
+
+            self.assertEqual(reader.emitted, len(some_raw_test_data))
+
+            self.assertEqual(data, some_raw_test_data)
+
+            self.assertEqual(
+                reader.digest,
+                ('sha-256', '6ae881d57578a07900c4eb37e21afa4c2095beb8e852fb6ed8d0c9f343bc7fa8')
+            )
+
+    def test_digested_read_no_digest_large(self):
+        some_test_data = b'abc' * 1000
+
+        self.assertGreater(len(some_test_data), constants.DIGEST_TRAIL_SIZE)
+
+        with tempfile.NamedTemporaryFile() as file:
+            file.write(some_test_data)
+            file.flush()
+            file.seek(0)
+            reader = bundle_utils.DigestedRead(file)
+
+            data = b''
+
+            done = False
+
+            while not done:
+                chunk = reader.read(128)
+
+                if chunk:
+                    data += chunk
+                else:
+                    done = True
+
+            self.assertEqual(reader.digest, None)
+            self.assertEqual(reader.emitted, len(some_test_data))
+            self.assertEqual(data, some_test_data)
+
+    def test_digested_read_with_digest_large(self):
+        some_raw_test_data = b'abc' * 1000
+
+        some_test_data = \
+            some_raw_test_data + b'\nsha-256/6ae881d57578a07900c4eb37e21afa4c2095beb8e852fb6ed8d0c9f343bc7fa8'
+
+        self.assertGreater(len(some_test_data), constants.DIGEST_TRAIL_SIZE)
+
+        with tempfile.NamedTemporaryFile() as file:
+            file.write(some_test_data)
+            file.flush()
+            file.seek(0)
+            reader = bundle_utils.DigestedRead(file)
+
+            data = b''
+
+            done = False
+
+            while not done:
+                chunk = reader.read(128)
+
+                if chunk:
+                    data += chunk
+                else:
+                    done = True
+
+            self.assertEqual(data, some_raw_test_data)
+
+            self.assertEqual(reader.emitted, len(some_raw_test_data))
+
+            self.assertEqual(
+                reader.digest,
+                ('sha-256', '6ae881d57578a07900c4eb37e21afa4c2095beb8e852fb6ed8d0c9f343bc7fa8')
+            )

--- a/conductr_cli/test/test_conduct_load_v2.py
+++ b/conductr_cli/test/test_conduct_load_v2.py
@@ -158,6 +158,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
+        bundle_open_mock = MagicMock(side_effect=lambda p1, p2, p3: (p1, 1))
         wait_for_installation_mock = MagicMock()
 
         args = self.default_args.copy()
@@ -171,6 +172,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
+                patch('conductr_cli.conduct_load.open_bundle', bundle_open_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_load.load(input_args)
@@ -197,8 +199,13 @@ class TestConductLoadCommand(ConductLoadTestBase):
         )
 
         self.assertEqual(
+            bundle_open_mock.call_args_list,
+            [call(self.bundle_file_name, self.bundle_file, 'mock bundle.conf')]
+        )
+
+        self.assertEqual(
             open_mock.call_args_list,
-            [call(self.bundle_file, 'rb'), call(config_file, 'rb')]
+            [call(config_file, 'rb')]
         )
 
         expected_files = [
@@ -234,6 +241,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
         open_mock = MagicMock(return_value=1)
+        bundle_open_mock = MagicMock(side_effect=lambda p1, p2, p3: (p1, 1))
         wait_for_installation_mock = MagicMock()
 
         args = self.default_args.copy()
@@ -247,6 +255,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
                 patch('requests.post', http_method), \
                 patch('builtins.open', open_mock), \
+                patch('conductr_cli.conduct_load.open_bundle', bundle_open_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
             logging_setup.configure_logging(input_args, stdout)
             result = conduct_load.load(input_args)
@@ -268,8 +277,13 @@ class TestConductLoadCommand(ConductLoadTestBase):
         string_io_mock.assert_called_with('mock bundle.conf')
 
         self.assertEqual(
+            bundle_open_mock.call_args_list,
+            [call(self.bundle_file_name, self.bundle_file, 'mock bundle.conf')]
+        )
+
+        self.assertEqual(
             open_mock.call_args_list,
-            [call(self.bundle_file, 'rb'), call(config_file, 'rb')]
+            [call(config_file, 'rb')]
         )
 
         expected_files = [

--- a/conductr_cli/test/test_shazar_main.py
+++ b/conductr_cli/test/test_shazar_main.py
@@ -1,33 +1,38 @@
 from unittest import TestCase
 import shutil
+import sys
 import tempfile
 import os
 from os import remove
 from conductr_cli import logging_setup
-from conductr_cli.shazar_main import create_digest, build_parser, run
-from conductr_cli.test.cli_test_case import CliTestCase
+from conductr_cli.shazar_main import build_parser, run, write_with_digest
+from conductr_cli.test.cli_test_case import as_error, CliTestCase
 from unittest.mock import patch, MagicMock
 
 
 class TestShazar(TestCase):
-
-    def test_create_digest(self):
-        temp = tempfile.NamedTemporaryFile(mode='w+b', delete=False)
+    def test_write_with_digest(self):
+        temp = tempfile.NamedTemporaryFile(mode='w+b')
         temp.write(b'test file data')
-        temp_name = temp.name
-        temp.close()
+        temp.seek(0)
+
+        output = MagicMock()
+
+        write_with_digest(temp, output)
+
         self.assertEqual(
-            create_digest(temp_name),
-            '1be7aaf1938cc19af7d2fdeb48a11c381dff8a98d4c4b47b3b0a5044a5255c04'
+            CliTestCase.output_bytes(output),
+            'test file data\nsha-256/1be7aaf1938cc19af7d2fdeb48a11c381dff8a98d4c4b47b3b0a5044a5255c04'.encode("UTF-8")
         )
-        remove(temp_name)
 
     def test_parser_success(self):
         parser = build_parser()
-        args = parser.parse_args('--output-dir output-dir source'.split())
+        args = parser.parse_args('--output-dir output-dir source -o output-file --tar'.split())
 
         self.assertEqual(args.output_dir, 'output-dir')
         self.assertEqual(args.source, 'source')
+        self.assertTrue(args.tar)
+        self.assertEqual(args.output, 'output-file')
 
 
 class TestIntegration(CliTestCase):
@@ -44,20 +49,139 @@ class TestIntegration(CliTestCase):
     def test(self):
         stdout = MagicMock()
 
-        logging_setup.configure_logging(MagicMock(), stdout)
-
-        # Patch configure logging to preserve the output to mock stdout
-        configure_logging_mock = MagicMock()
-        with patch('conductr_cli.logging_setup.configure_logging', configure_logging_mock):
+        with patch('sys.stdout.write', stdout):
             run('--output-dir {} {}'.format(self.tmpdir, self.tmpfile.name).split())
+
+        self.assertEqual(stdout.call_count, 1)
 
         # The file separator on Windows `\` need to be escaped before used as part of regex comparison,
         # otherwise it will form an incomplete escape character.
         bundle_dir = '{}{}'.format(self.tmpdir, os.sep).replace('\\', '\\\\')
+
         self.assertRegex(
-            self.output(stdout),
-            'Created digested ZIP archive at {}tmp[a-z0-9_]{{6,8}}-[a-f0-9]{{64}}\.zip'.format(bundle_dir)
+            stdout.call_args[0][0],
+            ('^{}tmp[a-z0-9_]{{6,8}}-[a-f0-9]{{64}}\.zip' + os.linesep + '$').format(bundle_dir)
         )
+
+    def test_inputs_tty_help(self):
+        parser_print_help_mock = MagicMock()
+
+        with patch('sys.stdout.isatty', lambda: True), patch('sys.stdin.isatty', lambda: True), \
+                patch('argparse.ArgumentParser.print_help', parser_print_help_mock):
+
+            run('')
+
+        parser_print_help_mock.assert_called_once_with()
+
+    def test_warn_output_tty(self):
+        stdout = MagicMock()
+        stderr = MagicMock()
+        logging_setup.configure_logging(MagicMock(), stdout, stderr)
+
+        configure_logging_mock = MagicMock()
+
+        with patch('sys.stdout.isatty', lambda: True), patch('sys.stdin.isatty', lambda: False), \
+                patch('conductr_cli.logging_setup.configure_logging', configure_logging_mock), \
+                patch('sys.exit', lambda _: ()):
+
+            run('')
+
+        self.assertEqual(
+            self.output(stderr),
+            as_error('Error: shazar: Refusing to write to terminal. Provide -o or redirect elsewhere\n')
+        )
+
+    def test_tar_no_source(self):
+        tarfile = MagicMock()
+        zipfile = MagicMock()
+
+        file = tempfile.NamedTemporaryFile()
+
+        with patch('sys.stdout.isatty', lambda: False), patch('sys.stdin.isatty', lambda: False), \
+                patch('zipfile.ZipFile', zipfile), patch('tarfile.open', tarfile), \
+                patch('tempfile.NamedTemporaryFile', MagicMock(return_value=file)):
+
+            run('')
+
+        tarfile.assert_called_once_with(fileobj=sys.stdin.buffer, mode='r|')
+        zipfile.assert_called_once_with(file, 'w')
+
+    def test_tar_source(self):
+        tarfile = MagicMock()
+        zipfile = MagicMock()
+
+        file = tempfile.NamedTemporaryFile()
+
+        with patch('sys.stdout.isatty', lambda: False), patch('sys.stdin.isatty', lambda: False), \
+                patch('zipfile.ZipFile', zipfile), patch('tarfile.open', tarfile), \
+                patch('tempfile.NamedTemporaryFile', MagicMock(return_value=file)):
+
+            run(['--tar', 'testing.tar'])
+
+        tarfile.assert_called_once_with('testing.tar', mode='r')
+        zipfile.assert_called_once_with(file, 'w')
+
+    def test_regular_source(self):
+        tarfile = MagicMock()
+        zipfile = MagicMock()
+        move = MagicMock()
+
+        file = tempfile.NamedTemporaryFile()
+
+        with patch('sys.stdout.isatty', lambda: False), patch('sys.stdin.isatty', lambda: False), \
+                patch('zipfile.ZipFile', zipfile), patch('tarfile.open', tarfile), \
+                patch('shutil.move', move), \
+                patch('tempfile.NamedTemporaryFile', MagicMock(return_value=file)):
+                run(['testing.tar'])
+
+        move.assert_called_once_with(
+            file.name,
+            './testing.tar-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.zip'
+        )
+
+        tarfile.assert_not_called()
+        zipfile.assert_called_once_with(file, 'w')
+
+    def test_output(self):
+        mock_tarfile = MagicMock()
+        mock_zipfile = MagicMock()
+        mock_move = MagicMock()
+        mock_open = MagicMock()
+
+        file = tempfile.NamedTemporaryFile()
+
+        with patch('sys.stdout.isatty', lambda: False), patch('sys.stdin.isatty', lambda: False), \
+                patch('zipfile.ZipFile', mock_zipfile), patch('tarfile.open', mock_tarfile), \
+                patch('builtins.open', mock_open), \
+                patch('shutil.move', mock_move), \
+                patch('tempfile.NamedTemporaryFile', MagicMock(return_value=file)):
+
+            run(['-o', 'test.zip'])
+
+            mock_tarfile.assert_called_once_with(fileobj=sys.stdin.buffer, mode='r|')
+            mock_move.assert_not_called()
+            mock_open.assert_called_once_with('test.zip', 'wb')
+            mock_zipfile.assert_called_once_with(file, 'w')
+
+    def test_output_dash(self):
+        # tests that providing "-o -" goes through stdout
+
+        tarfile = MagicMock()
+        zipfile = MagicMock()
+        move = MagicMock()
+
+        file = tempfile.NamedTemporaryFile()
+
+        with patch('sys.stdout.isatty', lambda: False), patch('sys.stdin.isatty', lambda: False), \
+                patch('zipfile.ZipFile', zipfile), patch('tarfile.open', tarfile), \
+                patch('shutil.move', move), \
+                patch('tempfile.NamedTemporaryFile', MagicMock(return_value=file)):
+
+            run(['-o', '-'])
+
+            tarfile.assert_called_once_with(fileobj=sys.stdin.buffer, mode='r|')
+            move.assert_not_called()
+            zipfile.assert_called_once_with(file, 'w')
 
     def tearDown(self):  # noqa
         shutil.rmtree(self.tmpdir)


### PR DESCRIPTION
***Updated 2017-03-08***

`conduct load` and `shazar` have both been updated to stream input from `stdin` and handle a new format where the digest is at the end of the file or stream. Below are manual tests that are also captured in this PR's automated tests:

# Manual Tests

**Loading new format on disk**
```bash
$ tar c conductr-crash-v0 | shazar -o new-format.zip
$ conduct load new-format.zip 
Retrieving bundle..
Retrieving file:///home/longshorej/work/conductr-crash/target/bundle/new-format.zip
Loading bundle to ConductR..
[#################################################] 100%
Bundle 9274f89add3d963ab17ab3df5ce50d1a is installed
Bundle loaded.
Start bundle with: conduct run 9274f89
Unload bundle with: conduct unload 9274f89
Print ConductR info with: conduct info
-> 0
```

**Loading new format via pipes**
```bash
$ tar c conductr-crash-v0 | shazar | conduct load
Retrieving bundle..
Loading bundle from cache typesafe/bundle/-
Bintray credentials loaded from /home/longshorej/.lightbend/commercial.credentials
Loading bundle to ConductR..
[#################################################] 100%
Bundle 9274f89add3d963ab17ab3df5ce50d1a is installed
Bundle loaded.
Start bundle with: conduct run 9274f89
Unload bundle with: conduct unload 9274f89
Print ConductR info with: conduct info
-> 0
```

**Loading old format on disk**
```bash
$ conduct load conductr-crash-v0-644a7fdbf335af40bbe1e00cce3654482d21fc75b6dd3153a6bbb6f19f499129.zip
Retrieving bundle..
Retrieving file:///home/longshorej/work/conductr-crash/target/bundle/conductr-crash-v0-644a7fdbf335af40bbe1e00cce3654482d21fc75b6dd3153a6bbb6f19f499129.zip
Loading bundle to ConductR..
[#################################################] 100%
Bundle 644a7fdbf335af40bbe1e00cce365448 is installed
Bundle loaded.
Start bundle with: conduct run 644a7fd
Unload bundle with: conduct unload 644a7fd
Print ConductR info with: conduct info
-> 0
```

**`shazar` saving with traditional usage (output slightly modified to be more scriptable)**
```bash
$ shazar conductr-crash-v0
./conductr-crash-v0-854298c953044af5ad750edb6fa76d53f612d7cd0c4b83cf11d36959bacf5e55.zip
-> 0
```

***Saving with `shazar` with traditional usage but using `-o` flag, loading with `conduct load`***
```bash
$ shazar conductr-crash-v0 -o i-can-name-my-own-files.zip
-> 0
$ conduct load i-can-name-my-own-files.zip
~/work/conductr-crash/target/bundle $ conduct load i-can-name-my-own-files.zip 
Retrieving bundle..
Retrieving file:///home/longshorej/work/conductr-crash/target/bundle/i-can-name-my-own-files.zip
Loading bundle to ConductR..
[#################################################] 100%
Bundle 854298c953044af5ad750edb6fa76d53 is installed
Bundle loaded.
Start bundle with: conduct run 854298c
Unload bundle with: conduct unload 854298c
Print ConductR info with: conduct info
-> 0
```

**Loading old format**
```bash
$ conduct load visualizer
Retrieving bundle..
Loading bundle from cache typesafe/bundle/visualizer
Bintray credentials loaded from /home/longshorej/.lightbend/commercial.credentials
Retrieving from cache /home/longshorej/.conductr/cache/bundle/visualizer-v2-73595ecbdad1f01a05db5304046b4ad5c0a98ef83e201e507a153cea21087078.zip
Loading bundle to ConductR..
[#################################################] 100%
Bundle 73595ecbdad1f01a05db5304046b4ad5 is installed
Bundle loaded.
Start bundle with: conduct run 73595ec
Unload bundle with: conduct unload 73595ec
Print ConductR info with: conduct info
-> 0
```