### PR TITLE
Proxy feature no longer calls `conductr_post_start` when `image_version` = 1

### DIFF
--- a/conductr_cli/sandbox_features.py
+++ b/conductr_cli/sandbox_features.py
@@ -55,10 +55,11 @@ class ProxyingFeature:
         self.proxy_ports = None
 
     def conductr_post_start(self, args, run_result):
-        self.host = run_result.host
-        self.proxy_bind_addr = run_result.core_addrs[0]
-        self.bundle_http_port = args.bundle_http_port
-        self.proxy_ports = sorted(args.ports)
+        if major_version(self.image_version) != 1:
+            self.host = run_result.host
+            self.proxy_bind_addr = run_result.core_addrs[0]
+            self.bundle_http_port = args.bundle_http_port
+            self.proxy_ports = sorted(args.ports)
 
     @staticmethod
     def conductr_args():


### PR DESCRIPTION
This is a fix for a bug introduced with refactoring proxying to a feature. Sandbox version 1 would fail to launch unless launched with `--no-default-features`.

*Before this fix*
```
~ $ sandbox run 1.1.12 --feature monitoring
|------------------------------------------------|
| Stopping ConductR                              |
|------------------------------------------------|
cond-0
ConductR has been successfully stopped
|------------------------------------------------|
| Starting ConductR                              |
|------------------------------------------------|
Starting container cond-0 exposing 127.0.0.1:3000, 127.0.0.1:5601, 127.0.0.1:9200..
6a3b50bdf62d205f08c71fe69636c646f1de6a27e20f4762574ee4f4165aae31
Waiting for ConductR to start.
Error: Encountered unexpected error.
Error: Reason: AttributeError 'SandboxRunResult' object has no attribute 'core_addrs'
Error: Further information of the error can be found in the error log file: /home/longshorej/.conductr/errors.log
-> 1
```

*After this fix*
```
~ $ sandbox run 1.1.12 --feature monitoring
|------------------------------------------------|
| Stopping ConductR                              |
|------------------------------------------------|
cond-0
ConductR has been successfully stopped
|------------------------------------------------|
| Starting ConductR                              |
|------------------------------------------------|
Starting container cond-0 exposing 127.0.0.1:3000, 127.0.0.1:5601, 127.0.0.1:9200..
64ffa7ede3ed85188c4af2e604f4b0628f685eb4127f8e37f86ffcb3fc73b003
Waiting for ConductR to start.
|------------------------------------------------|
| Starting monitoring feature                    |
|------------------------------------------------|
Deploying bundle cinnamon-grafana..
Retrieving bundle..
Loading bundle from cache typesafe/bundle/cinnamon-grafana
Bintray credentials loaded from /home/longshorej/.lightbend/commercial.credentials
Retrieving from cache /home/longshorej/.conductr/cache/bundle/cinnamon-grafana-v2-aa505676c726bb5887d339dc1031e469368e0fab0867195a3384aa1e0e5ab59a.zip
Loading bundle to ConductR..
[#################################################] 100%
Bundle aa505676c726bb5887d339dc1031e469 waiting to be installed
Bundle aa505676c726bb5887d339dc1031e469 installed
Bundle loaded.
Bundle run request sent.
Bundle aa505676c726bb5887d339dc1031e469 waiting to reach expected scale 1
Bundle aa505676c726bb5887d339dc1031e469 has scale 0, expected 1..........
Bundle aa505676c726bb5887d339dc1031e469 expected scale 1 is met
|------------------------------------------------|
| Summary                                        |
|------------------------------------------------|
ConductR has been started
Check resource consumption of Docker container that run the ConductR node with:
  docker stats cond-0
Check current bundle status with:
  conduct info
```