### PR TITLE
Implement conduct load-license

### DIFF
--- a/conductr_cli/conduct_load_license.py
+++ b/conductr_cli/conduct_load_license.py
@@ -1,0 +1,35 @@
+from conductr_cli import license, validation
+from conductr_cli.constants import DEFAULT_LICENSE_FILE
+from conductr_cli.exceptions import LicenseLoadError
+import logging
+import os
+
+
+@validation.handle_connection_error
+@validation.handle_http_error
+@validation.handle_license_load_error
+def load_license(args):
+    log = logging.getLogger(__name__)
+
+    license_file = DEFAULT_LICENSE_FILE
+
+    if args.offline_mode:
+        log.info('Skipping downloading license from Lightbend.com')
+    else:
+        log.info('Downloading license from Lightbend.com')
+        license.download_license(args, save_to=license_file)
+
+    if os.path.exists(license_file):
+        log.info('Loading license into ConductR at {}'.format(args.host))
+        license.post_license(args, license_file)
+
+        uploaded_license = license.get_license(args)
+        if uploaded_license:
+            license_to_display = license.format_license(uploaded_license)
+            log.info('\n{}\n'.format(license_to_display))
+            log.info('License successfully loaded')
+            return True
+        else:
+            raise LicenseLoadError('Unable to find recently loaded license')
+    else:
+        raise LicenseLoadError('Please ensure the license file exists at {}'.format(license_file))

--- a/conductr_cli/conduct_main.py
+++ b/conductr_cli/conduct_main.py
@@ -2,9 +2,8 @@ import argcomplete
 import argparse
 from conductr_cli import \
     conduct_agents, conduct_deploy, conduct_info, conduct_load, conduct_members, conduct_run, conduct_service_names, \
-    conduct_stop, conduct_unload, version, conduct_logs, \
-    conduct_events, conduct_acls, conduct_dcos, host, logging_setup, \
-    conduct_url, custom_settings
+    conduct_stop, conduct_unload, version, conduct_logs, conduct_events, conduct_acls, conduct_dcos, \
+    conduct_load_license, host, logging_setup, conduct_url, custom_settings
 from conductr_cli.constants import \
     DEFAULT_SCHEME, DEFAULT_PORT, DEFAULT_BASE_PATH, \
     DEFAULT_API_VERSION, DEFAULT_DCOS_SERVICE, DEFAULT_CLI_SETTINGS_DIR, \
@@ -179,6 +178,17 @@ def add_date_args(sub_parser):
                             help='Convert the date/time of the events to UTC')
 
 
+def add_offline_mode(sub_parser):
+    sub_parser.add_argument('--offline',
+                            default=DEFAULT_OFFLINE_MODE,
+                            dest='offline_mode',
+                            action='store_true',
+                            help='Enables offline mode to resolve bundles only locally\n'
+                                 'either by file uri or from the cache directory\n'
+                                 'True if CONDUCTR_OFFLINE_MODE environment variable is set\n'
+                                 'False if --offline flag not specified and environment variable not set')
+
+
 def add_default_arguments(sub_parser, dcos_mode):
     add_dcos_mode_args(sub_parser, dcos_mode)
     add_verbose(sub_parser)
@@ -244,14 +254,7 @@ def build_parser(dcos_mode):
                              nargs='?',
                              default=None,
                              help='The optional configuration for the bundle')
-    load_parser.add_argument('--offline',
-                             default=DEFAULT_OFFLINE_MODE,
-                             dest='offline_mode',
-                             action='store_true',
-                             help='Enables offline mode to resolve bundles only locally\n'
-                                  'either by file uri or from the cache directory\n'
-                                  'True if CONDUCTR_OFFLINE_MODE environment variable is set\n'
-                                  'False if --offline flag not specified and environment variable not set')
+    add_offline_mode(load_parser)
     add_default_arguments(load_parser, dcos_mode)
     add_bundle_resolve_cache_dir(load_parser)
     add_configuration_resolve_cache_dir(load_parser)
@@ -385,6 +388,20 @@ def build_parser(dcos_mode):
                                default=None)
 
     agents_parser.set_defaults(func=conduct_agents.agents)
+
+    # Sub-parser for `load-license` sub-command
+    load_license_parser = subparsers.add_parser('load-license',
+                                                help='Obtains license from Lightbend.com and '
+                                                     'loads the license into ConductR',
+                                                formatter_class=argparse.RawTextHelpFormatter)
+
+    add_dcos_mode_args(load_license_parser, dcos_mode)
+    add_api_version(load_license_parser)
+    add_offline_mode(load_license_parser)
+    add_cli_settings_dir(load_license_parser)
+    add_custom_settings_file(load_license_parser)
+    add_custom_plugins_dir(load_license_parser)
+    load_license_parser.set_defaults(func=conduct_load_license.load_license)
 
     return parser
 

--- a/conductr_cli/constants.py
+++ b/conductr_cli/constants.py
@@ -33,6 +33,8 @@ DEFAULT_SANDBOX_PROXY_DIR = os.path.abspath(os.getenv('CONDUCTR_SANDBOX_PROXY_DI
 DEFAULT_SANDBOX_PROXY_CONTAINER_NAME = os.getenv('CONDUCTR_SANDBOX_PROXY_CONTAINER_NAME', 'sandbox-haproxy')
 DEFAULT_ERROR_LOG_FILE = os.path.abspath(os.getenv('CONDUCTR_CLI_ERROR_LOG',
                                                    '{}/errors.log'.format(DEFAULT_CLI_SETTINGS_DIR)))
+DEFAULT_LICENSE_FILE = os.path.abspath(os.getenv('CONDUCTR_LICENSE_FILE',
+                                                 '{}/.lightbend/license'.format(os.path.expanduser('~'))))
 DEFAULT_WAIT_TIMEOUT = 60  # seconds
 
 FEATURE_PROVIDE_PROXYING = 'proxying'

--- a/conductr_cli/exceptions.py
+++ b/conductr_cli/exceptions.py
@@ -173,3 +173,11 @@ class SandboxUnsupportedOsArchError(Exception):
 
     def __str(self):
         return repr(self)
+
+
+class LicenseLoadError(Exception):
+    def __init__(self, message):
+        self.message = message
+
+    def __str(self):
+        return repr(os.linesep.join(self.message))

--- a/conductr_cli/license.py
+++ b/conductr_cli/license.py
@@ -1,0 +1,111 @@
+from conductr_cli import conduct_request, conduct_url, validation
+from conductr_cli.conduct_url import conductr_host
+import arrow
+import datetime
+import json
+
+
+EXPIRY_DATE_DISPLAY_FORMAT = '%a %d %b %Y %H:%M%p'
+
+
+def download_license(args, save_to):
+    """
+    Downloads license from Lightbend.com.
+    :param args: input args obtained from argparse.
+    :param save_to: the path where downloaded license will be saved to.
+    :return: path to the license file.
+    """
+    pass
+
+
+def post_license(args, license_file):
+    """
+    Post license file to ConductR.
+    :param args: input args obtained from argparse
+    :param license_file: the path to license file
+    """
+    url = conduct_url.url('license', args)
+    response = conduct_request.post(args.dcos_mode, conductr_host(args), url,
+                                    data=open(license_file, 'rb'),
+                                    auth=args.conductr_auth,
+                                    verify=args.server_verification_file)
+    validation.raise_for_status_inc_3xx(response)
+    return True
+
+
+def format_license(license):
+    """
+    Returns formatted license for display, or None if the input is none
+
+    :param args: input args obtained from argparse
+    """
+
+    def format(key, title_text, format_value=None):
+        if key in license:
+            if license[key]:
+                value = license[key]
+                display_value = format_value(value) if format_value else value
+                return '{}: {}'.format(title_text, display_value)
+
+        return None
+
+    def format_multiple(key, title_text):
+        if key in license:
+            values = license[key]
+            if values:
+                return '{}: {}'.format(title_text, ', '.join(values))
+
+        return None
+
+    if license:
+        license_entries = [
+            format('user', 'Licensed To'),
+            format('maxConductrAgents', 'Max ConductR agents'),
+            format('expires', 'Expires In', format_value=format_expiry),
+            format_multiple('conductrVersions', 'ConductR Version(s)'),
+            format_multiple('grants', 'Grants'),
+        ]
+        return '\n'.join([v for v in license_entries if v])
+    else:
+        return None
+
+
+def get_license(args):
+    """
+    Get license from ConductR.
+    :param args: input args obtained from argparse
+    """
+    url = conduct_url.url('license', args)
+    response = conduct_request.get(args.dcos_mode, conductr_host(args), url, auth=args.conductr_auth)
+    if response.status_code == 404:
+        return None
+    else:
+        validation.raise_for_status_inc_3xx(response)
+        return json.loads(response.text)
+
+
+def format_expiry(expiry_date):
+    expiry_date_local = arrow.get(expiry_date).to('local')
+    expiry_date_display = expiry_date_local.strftime(EXPIRY_DATE_DISPLAY_FORMAT)
+
+    now = arrow.get(current_date()).to('local')
+
+    diff = expiry_date_local - now
+    diff_day = diff.days
+
+    if diff_day > 0:
+        expiry_state = '{} days'.format(diff_day)
+    elif diff_day == 0:
+        expiry_state = 'Today'
+    else:
+        expiry_state = 'Expired'
+
+    return '{} ({})'.format(expiry_state, expiry_date_display)
+
+
+def current_date():
+    """
+    Method is created since Python's `patch` method doesn't work with datetime.datetime.now()
+    :return: datetime.now()
+    """
+    return datetime.datetime.now()

--- a/conductr_cli/test/cli_test_case.py
+++ b/conductr_cli/test/cli_test_case.py
@@ -21,7 +21,8 @@ class CliTestCase(TestCase):
     def respond_with(status_code=200, text=''):
         reasons = {
             200: 'OK',
-            404: 'Not Found'
+            404: 'Not Found',
+            500: 'Error'
         }
 
         response_mock = MagicMock(

--- a/conductr_cli/test/test_conduct_load_license.py
+++ b/conductr_cli/test/test_conduct_load_license.py
@@ -1,0 +1,252 @@
+from conductr_cli.test.cli_test_case import CliTestCase, strip_margin, as_error
+from conductr_cli import conduct_load_license, logging_setup
+from conductr_cli.constants import DEFAULT_LICENSE_FILE
+from unittest.mock import patch, MagicMock
+from requests.exceptions import ConnectionError, HTTPError
+from dcos.errors import DCOSHTTPException
+
+
+class TestConductLoadLicense(CliTestCase):
+    host = '10.0.0.1'
+
+    args = {
+        'offline_mode': False,
+        'host': host
+    }
+
+    license = {
+        'user': 'cc64df31-ec6b-4e08-bb6b-3216721a56b@lightbend',
+        'maxConductrAgents': 3,
+        'conductrVersions': ['2.1.*'],
+        'expires': '2018-03-01T00:00:00Z',
+        'grants': ['akka-sbr', 'cinnamon', 'conductr'],
+    }
+
+    license_formatted = 'test-only'
+
+    http_failure_response = {
+        'status_code': 500,
+        'reason': 'test',
+        'text': 'test'
+    }
+
+    def test_success(self):
+        mock_download_license = MagicMock()
+        mock_exists = MagicMock(return_value=True)
+        mock_post_license = MagicMock()
+        mock_get_license = MagicMock(return_value=self.license)
+        mock_format_license = MagicMock(return_value=self.license_formatted)
+
+        input_args = MagicMock(**self.args)
+
+        stdout = MagicMock()
+
+        with patch('conductr_cli.license.download_license', mock_download_license), \
+                patch('os.path.exists', mock_exists), \
+                patch('conductr_cli.license.post_license', mock_post_license), \
+                patch('conductr_cli.license.get_license', mock_get_license), \
+                patch('conductr_cli.license.format_license', mock_format_license):
+            logging_setup.configure_logging(input_args, stdout)
+            self.assertTrue(conduct_load_license.load_license(input_args))
+
+        mock_download_license.assert_called_once_with(input_args, save_to=DEFAULT_LICENSE_FILE)
+        mock_exists.assert_called_once_with(DEFAULT_LICENSE_FILE)
+        mock_post_license.assert_called_once_with(input_args, DEFAULT_LICENSE_FILE)
+        mock_get_license.assert_called_once_with(input_args)
+        mock_format_license.assert_called_once_with(self.license)
+
+        expected_output = strip_margin("""|Downloading license from Lightbend.com
+                                          |Loading license into ConductR at {}
+                                          |
+                                          |{}
+                                          |
+                                          |License successfully loaded
+                                          |""".format(self.host, self.license_formatted))
+        self.assertEqual(expected_output, self.output(stdout))
+
+    def test_offline_mode(self):
+        mock_download_license = MagicMock()
+        mock_exists = MagicMock(return_value=True)
+        mock_post_license = MagicMock()
+        mock_get_license = MagicMock(return_value=self.license)
+        mock_format_license = MagicMock(return_value=self.license_formatted)
+
+        args = self.args.copy()
+        args.pop('offline_mode', True)
+        input_args = MagicMock(**args)
+
+        stdout = MagicMock()
+
+        with patch('conductr_cli.license.download_license', mock_download_license), \
+                patch('os.path.exists', mock_exists), \
+                patch('conductr_cli.license.post_license', mock_post_license), \
+                patch('conductr_cli.license.get_license', mock_get_license), \
+                patch('conductr_cli.license.format_license', mock_format_license):
+            logging_setup.configure_logging(input_args, stdout)
+            self.assertTrue(conduct_load_license.load_license(input_args))
+
+        mock_download_license.assert_not_called()
+        mock_exists.assert_called_once_with(DEFAULT_LICENSE_FILE)
+        mock_post_license.assert_called_once_with(input_args, DEFAULT_LICENSE_FILE)
+        mock_get_license.assert_called_once_with(input_args)
+        mock_format_license.assert_called_once_with(self.license)
+
+        expected_output = strip_margin("""|Skipping downloading license from Lightbend.com
+                                          |Loading license into ConductR at {}
+                                          |
+                                          |{}
+                                          |
+                                          |License successfully loaded
+                                          |""".format(self.host, self.license_formatted))
+        self.assertEqual(expected_output, self.output(stdout))
+
+    def test_offline_mode_license_file_missing(self):
+        mock_download_license = MagicMock()
+        mock_exists = MagicMock(return_value=False)
+        mock_post_license = MagicMock()
+        mock_get_license = MagicMock(return_value=self.license)
+        mock_format_license = MagicMock(return_value=self.license_formatted)
+
+        args = self.args.copy()
+        args.pop('offline_mode', True)
+        input_args = MagicMock(**args)
+
+        stdout = MagicMock()
+        stderr = MagicMock()
+
+        with patch('conductr_cli.license.download_license', mock_download_license), \
+                patch('os.path.exists', mock_exists), \
+                patch('conductr_cli.license.post_license', mock_post_license), \
+                patch('conductr_cli.license.get_license', mock_get_license), \
+                patch('conductr_cli.license.format_license', mock_format_license):
+            logging_setup.configure_logging(input_args, stdout, stderr)
+            self.assertFalse(conduct_load_license.load_license(input_args))
+
+        mock_download_license.assert_not_called()
+        mock_exists.assert_called_once_with(DEFAULT_LICENSE_FILE)
+        mock_post_license.assert_not_called()
+        mock_get_license.assert_not_called()
+        mock_format_license.assert_not_called()
+
+        expected_output = strip_margin("""|Skipping downloading license from Lightbend.com
+                                          |""".format(self.host, self.license_formatted))
+        self.assertEqual(expected_output, self.output(stdout))
+
+        expected_error = as_error(strip_margin("""|Error: Error loading license into ConductR
+                                                  |Error: Please ensure the license file exists at {}
+                                                  |""".format(DEFAULT_LICENSE_FILE)))
+        self.assertEqual(expected_error, self.output(stderr))
+
+    def test_license_not_found_in_conductr(self):
+        mock_download_license = MagicMock()
+        mock_exists = MagicMock(return_value=True)
+        mock_post_license = MagicMock()
+        mock_get_license = MagicMock(return_value=None)
+        mock_format_license = MagicMock()
+
+        input_args = MagicMock(**self.args)
+
+        stdout = MagicMock()
+        stderr = MagicMock()
+
+        with patch('conductr_cli.license.download_license', mock_download_license), \
+                patch('os.path.exists', mock_exists), \
+                patch('conductr_cli.license.post_license', mock_post_license), \
+                patch('conductr_cli.license.get_license', mock_get_license), \
+                patch('conductr_cli.license.format_license', mock_format_license):
+            logging_setup.configure_logging(input_args, stdout, stderr)
+            self.assertFalse(conduct_load_license.load_license(input_args))
+
+        mock_download_license.assert_called_once_with(input_args, save_to=DEFAULT_LICENSE_FILE)
+        mock_exists.assert_called_once_with(DEFAULT_LICENSE_FILE)
+        mock_post_license.assert_called_once_with(input_args, DEFAULT_LICENSE_FILE)
+        mock_get_license.assert_called_once_with(input_args)
+        mock_format_license.assert_not_called()
+
+        expected_output = strip_margin("""|Downloading license from Lightbend.com
+                                          |Loading license into ConductR at {}
+                                          |""".format(self.host, self.license_formatted))
+        self.assertEqual(expected_output, self.output(stdout))
+
+        expected_error = as_error(strip_margin("""|Error: Error loading license into ConductR
+                                                  |Error: Unable to find recently loaded license
+                                                  |""".format(self.host, self.license_formatted)))
+        self.assertEqual(expected_error, self.output(stderr))
+
+    def test_http_error(self):
+        mock_download_license = MagicMock()
+        mock_exists = MagicMock(return_value=True)
+        mock_post_license = MagicMock(side_effect=HTTPError('test', response=MagicMock(**self.http_failure_response)))
+        mock_get_license = MagicMock()
+        mock_format_license = MagicMock()
+
+        input_args = MagicMock(**self.args)
+
+        stdout = MagicMock()
+        stderr = MagicMock()
+
+        with patch('conductr_cli.license.download_license', mock_download_license), \
+                patch('os.path.exists', mock_exists), \
+                patch('conductr_cli.license.post_license', mock_post_license), \
+                patch('conductr_cli.license.get_license', mock_get_license), \
+                patch('conductr_cli.license.format_license', mock_format_license):
+            logging_setup.configure_logging(input_args, stdout, stderr)
+            self.assertFalse(conduct_load_license.load_license(input_args))
+
+        mock_download_license.assert_called_once_with(input_args, save_to=DEFAULT_LICENSE_FILE)
+        mock_exists.assert_called_once_with(DEFAULT_LICENSE_FILE)
+        mock_post_license.assert_called_once_with(input_args, DEFAULT_LICENSE_FILE)
+        mock_get_license.assert_not_called()
+        mock_format_license.assert_not_called()
+
+    def test_dcos_http_error(self):
+        mock_download_license = MagicMock()
+        mock_exists = MagicMock(return_value=True)
+        mock_post_license = MagicMock(side_effect=DCOSHTTPException(MagicMock(**self.http_failure_response)))
+        mock_get_license = MagicMock()
+        mock_format_license = MagicMock()
+
+        input_args = MagicMock(**self.args)
+
+        stdout = MagicMock()
+        stderr = MagicMock()
+
+        with patch('conductr_cli.license.download_license', mock_download_license), \
+                patch('os.path.exists', mock_exists), \
+                patch('conductr_cli.license.post_license', mock_post_license), \
+                patch('conductr_cli.license.get_license', mock_get_license), \
+                patch('conductr_cli.license.format_license', mock_format_license):
+            logging_setup.configure_logging(input_args, stdout, stderr)
+            self.assertFalse(conduct_load_license.load_license(input_args))
+
+        mock_download_license.assert_called_once_with(input_args, save_to=DEFAULT_LICENSE_FILE)
+        mock_exists.assert_called_once_with(DEFAULT_LICENSE_FILE)
+        mock_post_license.assert_called_once_with(input_args, DEFAULT_LICENSE_FILE)
+        mock_get_license.assert_not_called()
+        mock_format_license.assert_not_called()
+
+    def test_connection_error(self):
+        mock_download_license = MagicMock()
+        mock_exists = MagicMock(return_value=True)
+        mock_post_license = MagicMock(side_effect=ConnectionError('test'))
+        mock_get_license = MagicMock()
+        mock_format_license = MagicMock()
+
+        input_args = MagicMock(**self.args)
+
+        stdout = MagicMock()
+        stderr = MagicMock()
+
+        with patch('conductr_cli.license.download_license', mock_download_license), \
+                patch('os.path.exists', mock_exists), \
+                patch('conductr_cli.license.post_license', mock_post_license), \
+                patch('conductr_cli.license.get_license', mock_get_license), \
+                patch('conductr_cli.license.format_license', mock_format_license):
+            logging_setup.configure_logging(input_args, stdout, stderr)
+            self.assertFalse(conduct_load_license.load_license(input_args))
+
+        mock_download_license.assert_called_once_with(input_args, save_to=DEFAULT_LICENSE_FILE)
+        mock_exists.assert_called_once_with(DEFAULT_LICENSE_FILE)
+        mock_post_license.assert_called_once_with(input_args, DEFAULT_LICENSE_FILE)
+        mock_get_license.assert_not_called()
+        mock_format_license.assert_not_called()

--- a/conductr_cli/test/test_conduct_main.py
+++ b/conductr_cli/test/test_conduct_main.py
@@ -177,6 +177,37 @@ class TestConduct(TestCase):
         self.assertEqual(args.long_ids, False)
         self.assertEqual(args.bundle, 'cassandra')
 
+    def test_parser_load_license(self):
+        args = self.parser.parse_args('load-license'.split())
+
+        self.assertEqual(args.func.__name__, 'load_license')
+        self.assertEqual(args.host, None)
+        self.assertEqual(args.port, 9005)
+        self.assertEqual(args.api_version, '2')
+        self.assertFalse(args.offline_mode)
+        self.assertEqual(args.cli_settings_dir, '{}/.conductr'.format(os.path.expanduser('~')))
+        self.assertEqual(args.custom_settings_file, '{}/.conductr/settings.conf'.format(os.path.expanduser('~')))
+        self.assertEqual(args.custom_plugins_dir, '{}/.conductr/plugins'.format(os.path.expanduser('~')))
+
+    def test_parser_load_license_custom_args(self):
+        args = self.parser.parse_args('load-license '
+                                      '--offline '
+                                      '--host 127.0.0.1 '
+                                      '--port 29005 '
+                                      '--api-version 1 '
+                                      '--settings-dir /tmp '
+                                      '--custom-settings-file /tmp/foo.conf '
+                                      '--custom-plugins-dir /tmp/plugins'.split())
+
+        self.assertEqual(args.func.__name__, 'load_license')
+        self.assertEqual(args.host, '127.0.0.1')
+        self.assertEqual(args.port, 29005)
+        self.assertEqual(args.api_version, '1')
+        self.assertTrue(args.offline_mode)
+        self.assertEqual(args.cli_settings_dir, '/tmp')
+        self.assertEqual(args.custom_settings_file, '/tmp/foo.conf')
+        self.assertEqual(args.custom_plugins_dir, '/tmp/plugins')
+
     def test_default_with_dcos(self):
         dcos_parser = build_parser(True)
 

--- a/conductr_cli/test/test_license.py
+++ b/conductr_cli/test/test_license.py
@@ -1,0 +1,243 @@
+from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
+from conductr_cli import license
+from conductr_cli.license import EXPIRY_DATE_DISPLAY_FORMAT
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+from requests.exceptions import HTTPError
+import arrow
+import datetime
+import json
+
+
+class TestPostLicense(CliTestCase):
+    auth = ('username', 'password')
+    server_verification_file = 'test_server_verification_file'
+
+    args = {
+        'dcos_mode': False,
+        'scheme': 'https',
+        'host': '10.0.0.1',
+        'port': '9005',
+        'base_path': '/',
+        'api_version': '2',
+        'conductr_auth': auth,
+        'server_verification_file': server_verification_file
+    }
+
+    def test_success(self):
+        license_file = MagicMock()
+
+        mock_license_file_content = MagicMock()
+        mock_open = MagicMock(return_value=mock_license_file_content)
+
+        mock_post = self.respond_with(status_code=200)
+
+        input_args = MagicMock(**self.args)
+
+        with patch('builtins.open', mock_open), \
+                patch('conductr_cli.conduct_request.post', mock_post):
+            self.assertTrue(license.post_license(input_args, license_file))
+
+        mock_open.assert_called_once_with(license_file, 'rb')
+        mock_post.assert_called_once_with(False, '10.0.0.1', 'https://10.0.0.1:9005/v2/license',
+                                          auth=self.auth,
+                                          data=mock_license_file_content,
+                                          verify=self.server_verification_file)
+
+    def test_http_error(self):
+        license_file = MagicMock()
+
+        mock_license_file_content = MagicMock()
+        mock_open = MagicMock(return_value=mock_license_file_content)
+
+        mock_post = self.respond_with(status_code=500)
+
+        input_args = MagicMock(**self.args)
+
+        with patch('builtins.open', mock_open), \
+                patch('conductr_cli.conduct_request.post', mock_post):
+            self.assertRaises(HTTPError, license.post_license, input_args, license_file)
+
+        mock_open.assert_called_once_with(license_file, 'rb')
+        mock_post.assert_called_once_with(False, '10.0.0.1', 'https://10.0.0.1:9005/v2/license',
+                                          auth=self.auth,
+                                          data=mock_license_file_content,
+                                          verify=self.server_verification_file)
+
+
+class TestGetLicense(CliTestCase):
+    auth = ('username', 'password')
+    server_verification_file = 'test_server_verification_file'
+
+    args = {
+        'dcos_mode': False,
+        'scheme': 'https',
+        'host': '10.0.0.1',
+        'port': '9005',
+        'base_path': '/',
+        'api_version': '2',
+        'conductr_auth': auth,
+        'server_verification_file': server_verification_file
+    }
+
+    license = {
+        'user': 'cc64df31-ec6b-4e08-bb6b-3216721a56b@lightbend',
+        'maxConductrAgents': 3,
+        'conductrVersions': ['2.1.*'],
+        'expires': '2018-03-01T00:00:00Z',
+        'grants': ['akka-sbr', 'cinnamon', 'conductr'],
+    }
+
+    license_json_text = json.dumps(license)
+
+    def test_license_found(self):
+        mock_get = self.respond_with(status_code=200, text=self.license_json_text)
+
+        input_args = MagicMock(**self.args)
+
+        with patch('conductr_cli.conduct_request.get', mock_get):
+            result = license.get_license(input_args)
+            self.assertEqual(self.license, result)
+
+        mock_get.assert_called_once_with(False, '10.0.0.1', 'https://10.0.0.1:9005/v2/license', auth=self.auth)
+
+    def test_license_not_found(self):
+        mock_get = self.respond_with(status_code=404)
+
+        input_args = MagicMock(**self.args)
+
+        with patch('conductr_cli.conduct_request.get', mock_get):
+            result = license.get_license(input_args)
+            self.assertIsNone(result)
+
+        mock_get.assert_called_once_with(False, '10.0.0.1', 'https://10.0.0.1:9005/v2/license', auth=self.auth)
+
+    def test_http_error(self):
+        mock_get = self.respond_with(status_code=500)
+
+        input_args = MagicMock(**self.args)
+
+        with patch('conductr_cli.conduct_request.get', mock_get):
+            self.assertRaises(HTTPError, license.get_license, input_args)
+
+        mock_get.assert_called_once_with(False, '10.0.0.1', 'https://10.0.0.1:9005/v2/license', auth=self.auth)
+
+
+class TestFormatLicense(TestCase):
+    license = {
+        'user': 'cc64df31-ec6b-4e08-bb6b-3216721a56b@lightbend',
+        'maxConductrAgents': 3,
+        'conductrVersions': ['2.1.*', '2.2.*'],
+        'expires': '2018-03-01T00:00:00Z',
+        'grants': ['akka-sbr', 'cinnamon', 'conductr'],
+    }
+
+    formatted_expiry = 'formatted_expiry'
+
+    def test_all_fields_present(self):
+        mock_format_expiry = MagicMock(return_value=self.formatted_expiry)
+
+        with patch('conductr_cli.license.format_expiry', mock_format_expiry):
+            result = license.format_license(self.license)
+
+            expected_result = strip_margin("""|Licensed To: cc64df31-ec6b-4e08-bb6b-3216721a56b@lightbend
+                                              |Max ConductR agents: 3
+                                              |Expires In: {}
+                                              |ConductR Version(s): 2.1.*, 2.2.*
+                                              |Grants: akka-sbr, cinnamon, conductr""".format(self.formatted_expiry))
+            self.assertEqual(expected_result, result)
+
+        mock_format_expiry.assert_called_once_with(self.license['expires'])
+
+    def test_not_present_expiry(self):
+        mock_format_expiry = MagicMock(return_value=self.formatted_expiry)
+
+        license_no_expiry = self.license.copy()
+        del license_no_expiry['expires']
+
+        with patch('conductr_cli.license.format_expiry', mock_format_expiry):
+            result = license.format_license(license_no_expiry)
+
+            expected_result = strip_margin("""|Licensed To: cc64df31-ec6b-4e08-bb6b-3216721a56b@lightbend
+                                              |Max ConductR agents: 3
+                                              |ConductR Version(s): 2.1.*, 2.2.*
+                                              |Grants: akka-sbr, cinnamon, conductr""")
+            self.assertEqual(expected_result, result)
+
+        mock_format_expiry.assert_not_called()
+
+    def test_not_present_versions(self):
+        mock_format_expiry = MagicMock(return_value=self.formatted_expiry)
+
+        license_no_versions = self.license.copy()
+        del license_no_versions['conductrVersions']
+
+        with patch('conductr_cli.license.format_expiry', mock_format_expiry):
+            result = license.format_license(license_no_versions)
+
+            expected_result = strip_margin("""|Licensed To: cc64df31-ec6b-4e08-bb6b-3216721a56b@lightbend
+                                              |Max ConductR agents: 3
+                                              |Expires In: {}
+                                              |Grants: akka-sbr, cinnamon, conductr""".format(self.formatted_expiry))
+            self.assertEqual(expected_result, result)
+
+        mock_format_expiry.assert_called_once_with(self.license['expires'])
+
+    def test_not_present_grants(self):
+        mock_format_expiry = MagicMock(return_value=self.formatted_expiry)
+
+        license_no_grants = self.license.copy()
+        del license_no_grants['grants']
+
+        with patch('conductr_cli.license.format_expiry', mock_format_expiry):
+            result = license.format_license(license_no_grants)
+
+            expected_result = strip_margin("""|Licensed To: cc64df31-ec6b-4e08-bb6b-3216721a56b@lightbend
+                                              |Max ConductR agents: 3
+                                              |Expires In: {}
+                                              |ConductR Version(s): 2.1.*, 2.2.*""".format(self.formatted_expiry))
+            self.assertEqual(expected_result, result)
+
+        mock_format_expiry.assert_called_once_with(self.license['expires'])
+
+
+class TestFormatExpiry(TestCase):
+    date_now = datetime.datetime(2018, 12, 1, 0, 0, 0, 0)
+    next_year = datetime.datetime(2019, 12, 1, 0, 0, 0, 0)
+    last_year = datetime.datetime(2017, 12, 1, 0, 0, 0, 0)
+
+    def test_valid(self):
+        mock_current_date = MagicMock(return_value=self.date_now)
+
+        with patch('conductr_cli.license.current_date', mock_current_date):
+            # License expires in 1 year
+            expiry_date = self.next_year
+            result = license.format_expiry(expiry_date=expiry_date.strftime('%Y-%m-%dT%H:%M:%SZ'))
+
+            expected_expiry_date_display = arrow.get(expiry_date).to('local').strftime(EXPIRY_DATE_DISPLAY_FORMAT)
+            expected_result = '365 days ({})'.format(expected_expiry_date_display)
+            self.assertEqual(expected_result, result)
+
+    def test_expiring_today(self):
+        mock_current_date = MagicMock(return_value=self.date_now)
+
+        with patch('conductr_cli.license.current_date', mock_current_date):
+            # License expires today
+            expiry_date = self.date_now
+            result = license.format_expiry(expiry_date=expiry_date.strftime('%Y-%m-%dT%H:%M:%SZ'))
+
+            expected_expiry_date_display = arrow.get(expiry_date).to('local').strftime(EXPIRY_DATE_DISPLAY_FORMAT)
+            expected_result = 'Today ({})'.format(expected_expiry_date_display)
+            self.assertEqual(expected_result, result)
+
+    def test_expired(self):
+        mock_current_date = MagicMock(return_value=self.date_now)
+
+        with patch('conductr_cli.license.current_date', mock_current_date):
+            # License expired last year
+            expiry_date = self.last_year
+            result = license.format_expiry(expiry_date=expiry_date.strftime('%Y-%m-%dT%H:%M:%SZ'))
+
+            expected_expiry_date_display = arrow.get(expiry_date).to('local').strftime(EXPIRY_DATE_DISPLAY_FORMAT)
+            expected_result = 'Expired ({})'.format(expected_expiry_date_display)
+            self.assertEqual(expected_result, result)

--- a/conductr_cli/validation.py
+++ b/conductr_cli/validation.py
@@ -16,7 +16,7 @@ from conductr_cli.exceptions import BindAddressNotFound, \
     WaitTimeoutError, InsecureFilePermissions, SandboxImageNotFoundError, JavaCallError, \
     JavaUnsupportedVendorError, JavaUnsupportedVersionError, JavaVersionParseError, DockerValidationError, \
     SandboxImageNotAvailableOfflineError, SandboxUnsupportedOsError, SandboxUnsupportedOsArchError, \
-    NOT_FOUND_ERROR
+    LicenseLoadError, NOT_FOUND_ERROR
 
 
 def connection_error(log, err, args):
@@ -428,6 +428,24 @@ def handle_docker_validation_error(func):
             log = get_logger_for_func(func)
             for message in e.messages:
                 log.error(message)
+            return False
+
+        # Do not change the wrapped function name,
+        # so argparse configuration can be tested.
+    handler.__name__ = func.__name__
+
+    return handler
+
+
+def handle_license_load_error(func):
+
+    def handler(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except LicenseLoadError as e:
+            log = get_logger_for_func(func)
+            log.error('Error loading license into ConductR')
+            log.error(e.message)
             return False
 
         # Do not change the wrapped function name,


### PR DESCRIPTION
- Load license file into ConductR.
- Displays the loaded license to the end user with formatting applied.

This PR doesn't include downloading the license from Lightbend.com - this will be addressed with a separate PR.
