### PR TITLE
Update conduct Info to display license info

### DIFF
--- a/conductr_cli/conduct_info.py
+++ b/conductr_cli/conduct_info.py
@@ -1,5 +1,6 @@
-from conductr_cli import bundle_utils, conduct_request, conduct_url, validation, screen_utils
+from conductr_cli import bundle_utils, conduct_request, conduct_url, license, validation, screen_utils
 from conductr_cli.conduct_url import conductr_host
+from conductr_cli.license import UNLICENSED_DISPLAY_TEXT
 import json
 import logging
 from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
@@ -23,13 +24,18 @@ def info(args):
     if args.quiet:
         display_quiet(args, bundles)
     else:
-        display_default(args, bundles)
+        conductr_license = license.get_license(args)
+        display_default(args, conductr_license, bundles)
 
     return True
 
 
-def display_default(args, bundles):
+def display_default(args, conductr_license, bundles):
     log = logging.getLogger(__name__)
+
+    license_to_display = license.format_license(conductr_license) if conductr_license \
+        else UNLICENSED_DISPLAY_TEXT
+    log.screen('\n{}\n'.format(license_to_display))
 
     data = [
         {

--- a/conductr_cli/license.py
+++ b/conductr_cli/license.py
@@ -7,6 +7,11 @@ import json
 
 EXPIRY_DATE_DISPLAY_FORMAT = '%a %d %b %Y %H:%M%p'
 
+UNLICENSED_DISPLAY_TEXT = 'UNLICENSED - please use "conduct load-license" to use more than one agent. ' \
+                          'Additional agents are freely available for registered users.\n' \
+                          'Max ConductR agents: 1\n' \
+                          'Grants: conductr, cinnamon, akka-sbr'
+
 
 def download_license(args, save_to):
     """


### PR DESCRIPTION
- Display only bundle id if `-q` is supplied.
- Display license information as part of `conduct info`