### PR TITLE
Load license as part of JVM-based sandbox run

### DIFF
--- a/conductr_cli/conduct_info.py
+++ b/conductr_cli/conduct_info.py
@@ -34,8 +34,10 @@ def display_default(args, is_license_success, conductr_license, bundles):
     log = logging.getLogger(__name__)
 
     if is_license_success:
-        license_to_display = license.format_license(conductr_license) if conductr_license \
-            else UNLICENSED_DISPLAY_TEXT
+        license_formatted = license.format_license(conductr_license)
+        license_to_display = license_formatted if conductr_license['isLicensed'] \
+            else '{}\n{}'.format(UNLICENSED_DISPLAY_TEXT, license_formatted)
+
         log.screen('{}\n'.format(license_to_display))
 
     data = [

--- a/conductr_cli/exceptions.py
+++ b/conductr_cli/exceptions.py
@@ -180,4 +180,12 @@ class LicenseLoadError(Exception):
         self.message = message
 
     def __str(self):
-        return repr(os.linesep.join(self.message))
+        return repr(self.message)
+
+
+class LicenseValidationError(Exception):
+    def __init__(self, messages):
+        self.messages = messages
+
+    def __str(self):
+        return repr(os.linesep.join(self.messages))

--- a/conductr_cli/license.py
+++ b/conductr_cli/license.py
@@ -7,9 +7,7 @@ import json
 EXPIRY_DATE_DISPLAY_FORMAT = '%a %d %b %Y %H:%M%p'
 
 UNLICENSED_DISPLAY_TEXT = 'UNLICENSED - please use "conduct load-license" to use more than one agent. ' \
-                          'Additional agents are freely available for registered users.\n' \
-                          'Max ConductR agents: 1\n' \
-                          'Grants: conductr, cinnamon, akka-sbr'
+                          'Additional agents are freely available for registered users.'
 
 
 def download_license(args, save_to):
@@ -88,10 +86,8 @@ def get_license(args):
     """
     url = conduct_url.url('license', args)
     response = conduct_request.get(args.dcos_mode, conductr_host(args), url, auth=args.conductr_auth)
-    if response.status_code == 503:
+    if response.status_code == 404 or response.status_code == 503:
         return False, None
-    if response.status_code == 404:
-        return True, None
     else:
         validation.raise_for_status_inc_3xx(response)
         return True, json.loads(response.text)

--- a/conductr_cli/license.py
+++ b/conductr_cli/license.py
@@ -6,7 +6,7 @@ import json
 
 EXPIRY_DATE_DISPLAY_FORMAT = '%a %d %b %Y %H:%M%p'
 
-UNLICENSED_DISPLAY_TEXT = 'UNLICENSED - please use "conduct load-license" to use more than one agent. ' \
+UNLICENSED_DISPLAY_TEXT = 'UNLICENSED - please use "conduct load-license" to use more agents. ' \
                           'Additional agents are freely available for registered users.'
 
 
@@ -97,19 +97,25 @@ def format_expiry(expiry_date):
     expiry_date_local = arrow.get(expiry_date).to('local')
     expiry_date_display = expiry_date_local.strftime(EXPIRY_DATE_DISPLAY_FORMAT)
 
-    now = arrow.get(current_date()).to('local')
+    days_to_expiry = calculate_days_to_expiry(expiry_date)
 
-    diff = expiry_date_local - now
-    diff_day = diff.days
-
-    if diff_day > 0:
-        expiry_state = '{} days'.format(diff_day)
-    elif diff_day == 0:
+    if days_to_expiry > 0:
+        expiry_state = '{} days'.format(days_to_expiry)
+    elif days_to_expiry == 0:
         expiry_state = 'Today'
     else:
         expiry_state = 'Expired'
 
     return '{} ({})'.format(expiry_state, expiry_date_display)
+
+
+def calculate_days_to_expiry(expiry_date):
+    expiry_date_local = arrow.get(expiry_date).to('local')
+
+    now = arrow.get(current_date()).to('local')
+
+    diff = expiry_date_local - now
+    return diff.days
 
 
 def current_date():

--- a/conductr_cli/license_validation.py
+++ b/conductr_cli/license_validation.py
@@ -1,0 +1,151 @@
+from conductr_cli import license, sandbox_common
+from conductr_cli.constants import DEFAULT_SCHEME, DEFAULT_PORT, DEFAULT_BASE_PATH, DEFAULT_API_VERSION
+from conductr_cli.exceptions import LicenseValidationError
+import os
+
+CONDUCTR_GRANT = 'conductr'
+DEFAULT_NUMBER_OF_AGENTS = 1
+DEFAULT_GRANTS = [CONDUCTR_GRANT]
+
+
+class LicenseArgs:
+    """
+    The `args` to be passed in the methods available on the `license` module.
+
+    This provides the equivalent of the arguments normally retrieved from the user input from `argparse` required by
+    the `license` module.
+
+    This class is meant to be used internally within this module.
+    """
+    def __init__(self, core_addr):
+        self.host = str(core_addr)
+
+    scheme = DEFAULT_SCHEME
+    port = DEFAULT_PORT
+    base_path = DEFAULT_BASE_PATH
+    api_version = DEFAULT_API_VERSION
+    dcos_mode = False
+    conductr_auth = None
+    server_verification_file = None
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__ if isinstance(other, self.__class__) else False
+
+
+def validate_license(conductr_version, core_addr, nr_of_agent_instances, license_file):
+    """
+    Validates the license contained within `license_file`.
+    Waits for ConductR to be available on the `core_addr` by checking the `/members` endpoint.
+    Once ConductR is available, `license_file` is posted, and subsequently retrieved from ConductR as JSON.
+
+    The resulting JSON payload is then validated:
+    - Version is in the list of what is allowed.
+    - Number of agent requested < what is allowed.
+    - Expiry: license must not expire.
+    - Grants must include `conductr`.
+
+     If validation failed, sandbox will be stopped and `LicenseValidationError` exception will be raised.
+
+    :param conductr_version: Version of ConductR to be run as sandbox.
+    :param core_addr: Host address of one of the core node.
+    :param nr_of_agent_instances: Number of agents requested.
+    :param license_file: License file to be validated.
+    :return:
+    """
+
+    args = LicenseArgs(core_addr)
+    sandbox_common.wait_for_start(args, log_output=False)
+
+    has_license_support, license_existing = license.get_license(args)
+    if has_license_support:
+        if os.path.exists(license_file):
+            license.post_license(args, license_file)
+
+        has_license_support, license_updated = license.get_license(args)
+        validate_license_data(conductr_version, nr_of_agent_instances, license_updated)
+
+
+def validate_license_data(conductr_version, nr_of_agent_instances, license):
+    validate_version(conductr_version, license)
+    validate_nr_of_agents(nr_of_agent_instances, license)
+    validate_expiry(license)
+    validate_grants(license)
+
+
+def validate_version(conductr_version, license_data):
+    versions = get_value(license_data, 'conductrVersions')
+    if versions:
+        for version in versions:
+            if can_run_version(version, conductr_version):
+                return
+
+        raise LicenseValidationError([
+            'Unable to run sandbox version {}'.format(conductr_version),
+            'The license allows for version {}'.format(', '.join(versions))
+        ])
+
+
+def validate_nr_of_agents(nr_of_agent_instances, license_data):
+    nr_of_allowed_agents = get_value(license_data, 'maxConductrAgents')
+    if not nr_of_allowed_agents:
+        raise LicenseValidationError([
+            'Unable to allocate {} agents'.format(nr_of_agent_instances),
+            'The license does not specify the number of allowed agents'
+        ])
+    elif nr_of_agent_instances > nr_of_allowed_agents:
+        raise LicenseValidationError([
+            'Unable to allocate {} agents'.format(nr_of_agent_instances),
+            'The license allows for {} agents'.format(nr_of_allowed_agents)
+        ])
+
+
+def validate_expiry(license_data):
+    expiry_date = get_value(license_data, 'expires')
+    if expiry_date:
+        days_to_expiry = license.calculate_days_to_expiry(expiry_date)
+        if days_to_expiry < 0:
+            raise LicenseValidationError([
+                'License has expired',
+                license.format_expiry(expiry_date)
+            ])
+
+
+def validate_grants(license_data):
+    grants = get_value(license_data, 'grants')
+    if not grants:
+        raise LicenseValidationError([
+            'License does not include grant for {}'.format(CONDUCTR_GRANT),
+            'The license does not have any grant declared'
+        ])
+    elif CONDUCTR_GRANT not in grants:
+        raise LicenseValidationError([
+            'License does not include grant for {}'.format(CONDUCTR_GRANT),
+            'The license has grants for {}'.format(', '.join(grants))
+        ])
+
+
+def get_value(license_data, key):
+    if license_data:
+        if key in license_data:
+            value = license_data[key]
+            if value:
+                return value
+
+    return None
+
+
+def can_run_version(version_pattern, version_number):
+    version_pattern_parts = version_pattern.split('.')
+    version_number_parts = version_number.split('.')
+
+    for idx, pattern in enumerate(version_pattern_parts):
+        if idx >= len(version_number_parts):
+            return False
+        elif pattern == '*':
+            return True
+
+        number_part = version_number_parts[idx]
+        if int(pattern) != int(number_part):
+            return False
+
+    return True

--- a/conductr_cli/sandbox_main.py
+++ b/conductr_cli/sandbox_main.py
@@ -168,11 +168,6 @@ def build_parser():
                             dest='no_default_features',
                             default=False,
                             action='store_true')
-    run_parser.add_argument('--no-wait',
-                            help='Disables waiting for ConductR to be started in the sandbox',
-                            default=False,
-                            dest='no_wait',
-                            action='store_true')
     run_parser.add_argument('--addr-range',
                             type=addr_range,
                             default=DEFAULT_SANDBOX_ADDR_RANGE,
@@ -280,8 +275,6 @@ def run(_args=[], configure_logging=True):
             logging_setup.configure_logging(args)
         # Check that all feature arguments are valid
         if vars(args).get('func').__name__ == 'run':
-            if args.features and args.no_wait:
-                parser.exit('Option --no-wait is not allowed when starting ConductR with option --feature')
             invalid_features = [f for f, *a in args.features if f not in feature_names]
             if invalid_features:
                 parser.exit('Invalid features: %s (choose from %s)' %

--- a/conductr_cli/sandbox_run.py
+++ b/conductr_cli/sandbox_run.py
@@ -58,12 +58,9 @@ def run(args):
 
 
 def wait_for_start(args, run_result):
-    if not args.no_wait:
-        retries = int(os.getenv('CONDUCTR_SANDBOX_WAIT_RETRIES', DEFAULT_WAIT_RETRIES))
-        interval = float(os.getenv('CONDUCTR_SANDBOX_WAIT_RETRY_INTERVAL', DEFAULT_WAIT_RETRY_INTERVAL))
-        return wait_for_conductr(args, run_result, 0, retries, interval), retries * interval
-    else:
-        return True, 0
+    retries = int(os.getenv('CONDUCTR_SANDBOX_WAIT_RETRIES', DEFAULT_WAIT_RETRIES))
+    interval = float(os.getenv('CONDUCTR_SANDBOX_WAIT_RETRY_INTERVAL', DEFAULT_WAIT_RETRY_INTERVAL))
+    return wait_for_conductr(args, run_result, 0, retries, interval), retries * interval
 
 
 def wait_for_conductr(args, run_result, current_retry, max_retries, interval):

--- a/conductr_cli/sandbox_run_docker.py
+++ b/conductr_cli/sandbox_run_docker.py
@@ -30,22 +30,21 @@ def run(args, features):
 
 
 def log_run_attempt(args, run_result, feature_results, is_conductr_started, feature_provided, wait_timeout):
+    log = logging.getLogger(__name__)
     container_names = run_result.container_names
-    if not args.no_wait:
-        log = logging.getLogger(__name__)
-        if is_conductr_started:
-            log.info(h1('Summary'))
-            log.info('ConductR has been started')
-            plural_string = 's' if len(container_names) > 1 else ''
-            log.info('Check resource consumption of Docker container{} that run the ConductR node{} with:'
-                     .format(plural_string, plural_string))
-            log.info('  docker stats {}'.format(' '.join(container_names)))
-            log.info('Check current bundle status with:')
-            log.info('  conduct info')
-        else:
-            log.info(h1('Summary'))
-            log.error('ConductR has not been started within {} seconds.'.format(wait_timeout))
-            log.error('Set the env CONDUCTR_SANDBOX_WAIT_RETRY_INTERVAL to increase the wait timeout.')
+    if is_conductr_started:
+        log.info(h1('Summary'))
+        log.info('ConductR has been started')
+        plural_string = 's' if len(container_names) > 1 else ''
+        log.info('Check resource consumption of Docker container{} that run the ConductR node{} with:'
+                 .format(plural_string, plural_string))
+        log.info('  docker stats {}'.format(' '.join(container_names)))
+        log.info('Check current bundle status with:')
+        log.info('  conduct info')
+    else:
+        log.info(h1('Summary'))
+        log.error('ConductR has not been started within {} seconds.'.format(wait_timeout))
+        log.error('Set the env CONDUCTR_SANDBOX_WAIT_RETRY_INTERVAL to increase the wait timeout.')
 
 
 def instance_count(image_version, nr_of_containers):

--- a/conductr_cli/sandbox_run_jvm.py
+++ b/conductr_cli/sandbox_run_jvm.py
@@ -114,39 +114,38 @@ def log_run_attempt(args, run_result, feature_results, is_conductr_started, feat
     :return:
     """
     log = logging.getLogger(__name__)
-    if not args.no_wait:
-        if is_conductr_started:
-            log.info(h1('Summary'))
-            log.info(h2('ConductR'))
-            log.info('ConductR has been started:')
-            plural_core = 's' if len(run_result.core_addrs) > 1 else ''
-            log.info('  core instance{} on {}'.format(plural_core, ', '.join(str(i) for i in run_result.core_addrs)))
-            plural_agent = 's' if len(run_result.agent_addrs) > 1 else ''
-            log.info('  agent instance{} on {}'.format(plural_agent, ', '.join(str(i) for i in run_result.agent_addrs)))
-            log.info('ConductR service locator has been started on:')
-            log.info('  {}:{}'.format(run_result.host, DEFAULT_SERVICE_LOCATOR_PORT))
+    if is_conductr_started:
+        log.info(h1('Summary'))
+        log.info(h2('ConductR'))
+        log.info('ConductR has been started:')
+        plural_core = 's' if len(run_result.core_addrs) > 1 else ''
+        log.info('  core instance{} on {}'.format(plural_core, ', '.join(str(i) for i in run_result.core_addrs)))
+        plural_agent = 's' if len(run_result.agent_addrs) > 1 else ''
+        log.info('  agent instance{} on {}'.format(plural_agent, ', '.join(str(i) for i in run_result.agent_addrs)))
+        log.info('ConductR service locator has been started on:')
+        log.info('  {}:{}'.format(run_result.host, DEFAULT_SERVICE_LOCATOR_PORT))
 
-            if feature_results:
-                log.info(h2('Features'))
-                log.info('The following feature related bundles have been started:')
-                for feature_result in feature_results:
-                    if FEATURE_PROVIDE_PROXYING in feature_provided:
-                        uri = '{}:{}'.format(run_result.host, feature_result.port)
-                    else:
-                        uri = '{}:{}/services/{}'.format(run_result.host, DEFAULT_SERVICE_LOCATOR_PORT,
-                                                         feature_result.name)
-                    log.info('  {} on {}'.format(feature_result.name, uri))
+        if feature_results:
+            log.info(h2('Features'))
+            log.info('The following feature related bundles have been started:')
+            for feature_result in feature_results:
+                if FEATURE_PROVIDE_PROXYING in feature_provided:
+                    uri = '{}:{}'.format(run_result.host, feature_result.port)
+                else:
+                    uri = '{}:{}/services/{}'.format(run_result.host, DEFAULT_SERVICE_LOCATOR_PORT,
+                                                     feature_result.name)
+                log.info('  {} on {}'.format(feature_result.name, uri))
 
-            log.info(h2('Bundles'))
-            log.info('Check latest bundle status with:')
-            log.info('  conduct info')
-            log.info('Current bundle status:')
-            conduct_main.run(['info', '--host', run_result.host], configure_logging=False)
+        log.info(h2('Bundles'))
+        log.info('Check latest bundle status with:')
+        log.info('  conduct info')
+        log.info('Current bundle status:')
+        conduct_main.run(['info', '--host', run_result.host], configure_logging=False)
 
-        else:
-            log.info(h1('Summary'))
-            log.error('ConductR has not been started within {} seconds.'.format(wait_timeout))
-            log.error('Set the env CONDUCTR_SANDBOX_WAIT_RETRY_INTERVAL to increase the wait timeout.')
+    else:
+        log.info(h1('Summary'))
+        log.error('ConductR has not been started within {} seconds.'.format(wait_timeout))
+        log.error('Set the env CONDUCTR_SANDBOX_WAIT_RETRY_INTERVAL to increase the wait timeout.')
 
 
 def instance_count(image_version, instance_expression):

--- a/conductr_cli/sandbox_run_jvm.py
+++ b/conductr_cli/sandbox_run_jvm.py
@@ -1,10 +1,10 @@
-from conductr_cli import conduct_main, host, sandbox_stop, sandbox_common
+from conductr_cli import conduct_main, host, license_validation, sandbox_stop, sandbox_common
 from conductr_cli.constants import DEFAULT_SCHEME, DEFAULT_PORT, DEFAULT_BASE_PATH, DEFAULT_API_VERSION, \
-    DEFAULT_SERVICE_LOCATOR_PORT, FEATURE_PROVIDE_PROXYING
+    DEFAULT_LICENSE_FILE, DEFAULT_SERVICE_LOCATOR_PORT, FEATURE_PROVIDE_PROXYING
 from conductr_cli.exceptions import BindAddressNotFound, BintrayUnreachableError, InstanceCountError, \
     SandboxImageNotFoundError, SandboxImageNotAvailableOfflineError, SandboxUnsupportedOsArchError, \
     SandboxUnsupportedOsError, JavaCallError, JavaUnsupportedVendorError, JavaUnsupportedVersionError, \
-    JavaVersionParseError
+    JavaVersionParseError, LicenseValidationError
 from conductr_cli.resolvers import bintray_resolver
 from conductr_cli.resolvers.bintray_resolver import BINTRAY_LIGHTBEND_ORG, BINTRAY_CONDUCTR_REPO
 from conductr_cli.sandbox_common import flatten
@@ -83,6 +83,15 @@ def run(args, features):
                                      args.conductr_roles,
                                      features,
                                      args.log_level)
+
+    try:
+        license_validation.validate_license(args.image_version,
+                                            core_addrs[0],
+                                            nr_of_agent_instances,
+                                            DEFAULT_LICENSE_FILE)
+    except LicenseValidationError as e:
+        sandbox_stop.stop(args)
+        raise e
 
     agent_addrs = bind_addrs[0:nr_of_agent_instances]
     agent_pids = start_agent_instances(agent_extracted_dir,

--- a/conductr_cli/test/test_conduct_info.py
+++ b/conductr_cli/test/test_conduct_info.py
@@ -82,7 +82,7 @@ class TestConductInfoCommand(CliTestCase):
         http_method.assert_called_with(self.default_url, auth=self.conductr_auth, verify=self.server_verification_file,
                                        timeout=DEFAULT_HTTP_TIMEOUT, headers={'Host': '127.0.0.1'})
         self.assertEqual(
-            strip_margin("""|UNLICENSED - please use "conduct load-license" to use more than one agent. Additional agents are freely available for registered users.
+            strip_margin("""|UNLICENSED - please use "conduct load-license" to use more agents. Additional agents are freely available for registered users.
                             |Licensed To: unknown
                             |Max ConductR agents: 1
                             |ConductR Version(s): 2.1.*

--- a/conductr_cli/test/test_conduct_info.py
+++ b/conductr_cli/test/test_conduct_info.py
@@ -30,6 +30,15 @@ class TestConductInfoCommand(CliTestCase):
         'maxConductrAgents': 3,
         'conductrVersions': ['2.1.*'],
         'grants': ['akka-sbr', 'cinnamon', 'conductr'],
+        'isLicensed': True
+    }
+
+    default_license = {
+        'user': 'unknown',
+        'maxConductrAgents': 1,
+        'conductrVersions': ['2.1.*'],
+        'grants': ['akka-sbr', 'cinnamon', 'conductr'],
+        'isLicensed': False
     }
 
     def test_no_bundles(self):
@@ -57,8 +66,8 @@ class TestConductInfoCommand(CliTestCase):
                             |"""),
             self.output(stdout))
 
-    def test_no_bundles_without_license(self):
-        mock_get_license = MagicMock(return_value=(True, None))
+    def test_no_bundles_unlicensed(self):
+        mock_get_license = MagicMock(return_value=(True, self.default_license))
         http_method = self.respond_with(text='[]')
         stdout = MagicMock()
 
@@ -74,8 +83,10 @@ class TestConductInfoCommand(CliTestCase):
                                        timeout=DEFAULT_HTTP_TIMEOUT, headers={'Host': '127.0.0.1'})
         self.assertEqual(
             strip_margin("""|UNLICENSED - please use "conduct load-license" to use more than one agent. Additional agents are freely available for registered users.
+                            |Licensed To: unknown
                             |Max ConductR agents: 1
-                            |Grants: conductr, cinnamon, akka-sbr
+                            |ConductR Version(s): 2.1.*
+                            |Grants: akka-sbr, cinnamon, conductr
                             |
                             |ID  NAME  #REP  #STR  #RUN
                             |"""),

--- a/conductr_cli/test/test_license.py
+++ b/conductr_cli/test/test_license.py
@@ -129,7 +129,7 @@ class TestGetLicense(CliTestCase):
 
         with patch('conductr_cli.conduct_request.get', mock_get):
             is_license_success, license_result = license.get_license(input_args)
-            self.assertTrue(is_license_success)
+            self.assertFalse(is_license_success)
             self.assertIsNone(license_result)
 
         mock_get.assert_called_once_with(False, '10.0.0.1', 'https://10.0.0.1:9005/v2/license', auth=self.auth)

--- a/conductr_cli/test/test_license_validation.py
+++ b/conductr_cli/test/test_license_validation.py
@@ -1,0 +1,311 @@
+from unittest import TestCase
+from unittest.mock import call, patch, MagicMock
+from conductr_cli import license_validation
+from conductr_cli.constants import DEFAULT_LICENSE_FILE
+from conductr_cli.exceptions import LicenseValidationError
+import ipaddress
+
+
+class TestValidateLicense(TestCase):
+    conductr_version = '2.1.0'
+
+    core_addr = ipaddress.ip_address('192.168.1.1')
+
+    license = {
+        'user': 'cc64df31-ec6b-4e08-bb6b-3216721a56b@lightbend',
+        'maxConductrAgents': 3,
+        'conductrVersions': ['2.1.*'],
+        'expires': '2018-03-01T00:00:00Z',
+        'grants': ['akka-sbr', 'cinnamon', 'conductr'],
+    }
+
+    nr_of_agent_instances = 3
+
+    license_file = DEFAULT_LICENSE_FILE
+
+    def test_validate_posted_license(self):
+        mock_wait_for_start = MagicMock()
+        mock_get_license = MagicMock(side_effect=[
+            (True, None),
+            (True, self.license),
+        ])
+        mock_exists = MagicMock(return_value=True)
+        mock_post_license = MagicMock()
+        mock_validate_license_data = MagicMock()
+
+        with patch('conductr_cli.sandbox_common.wait_for_start', mock_wait_for_start), \
+                patch('conductr_cli.license.get_license', mock_get_license), \
+                patch('os.path.exists', mock_exists), \
+                patch('conductr_cli.license.post_license', mock_post_license), \
+                patch('conductr_cli.license_validation.validate_license_data', mock_validate_license_data):
+            license_validation.validate_license(self.conductr_version, self.core_addr,
+                                                self.nr_of_agent_instances, self.license_file)
+
+        expected_args = license_validation.LicenseArgs(self.core_addr)
+
+        mock_wait_for_start.assert_called_once_with(expected_args, log_output=False)
+
+        self.assertEqual([
+            call(expected_args),
+            call(expected_args)
+        ], mock_get_license.call_args_list)
+
+        mock_exists.assert_called_once_with(self.license_file)
+
+        mock_post_license.assert_called_once_with(expected_args, self.license_file)
+
+        mock_validate_license_data.assert_called_once_with(self.conductr_version, self.nr_of_agent_instances,
+                                                           self.license)
+
+    def test_no_license_file(self):
+        mock_wait_for_start = MagicMock()
+        mock_get_license = MagicMock(side_effect=[
+            (True, None),
+            (True, None),
+        ])
+        mock_exists = MagicMock(return_value=False)
+        mock_post_license = MagicMock()
+        mock_validate_license_data = MagicMock()
+
+        with patch('conductr_cli.sandbox_common.wait_for_start', mock_wait_for_start), \
+                patch('conductr_cli.license.get_license', mock_get_license), \
+                patch('os.path.exists', mock_exists), \
+                patch('conductr_cli.license.post_license', mock_post_license), \
+                patch('conductr_cli.license_validation.validate_license_data', mock_validate_license_data):
+            license_validation.validate_license(self.conductr_version, self.core_addr,
+                                                self.nr_of_agent_instances, self.license_file)
+
+        expected_args = license_validation.LicenseArgs(self.core_addr)
+
+        mock_wait_for_start.assert_called_once_with(expected_args, log_output=False)
+
+        self.assertEqual([
+            call(expected_args),
+            call(expected_args)
+        ], mock_get_license.call_args_list)
+
+        mock_exists.assert_called_once_with(self.license_file)
+
+        mock_post_license.assert_not_called()
+
+        mock_validate_license_data.assert_called_once_with(self.conductr_version, self.nr_of_agent_instances,
+                                                           None)
+
+    def test_no_license_support(self):
+        mock_wait_for_start = MagicMock()
+        mock_get_license = MagicMock(return_value=(False, None))
+        mock_exists = MagicMock()
+        mock_post_license = MagicMock()
+        mock_validate_license_data = MagicMock()
+
+        with patch('conductr_cli.sandbox_common.wait_for_start', mock_wait_for_start), \
+                patch('conductr_cli.license.get_license', mock_get_license), \
+                patch('os.path.exists', mock_exists), \
+                patch('conductr_cli.license.post_license', mock_post_license), \
+                patch('conductr_cli.license_validation.validate_license_data', mock_validate_license_data):
+            license_validation.validate_license(self.conductr_version, self.core_addr,
+                                                self.nr_of_agent_instances, self.license_file)
+
+        expected_args = license_validation.LicenseArgs(self.core_addr)
+
+        mock_wait_for_start.assert_called_once_with(expected_args, log_output=False)
+
+        mock_get_license.assert_called_once_with(expected_args)
+
+        mock_exists.assert_not_called()
+
+        mock_post_license.assert_not_called()
+
+        mock_validate_license_data.assert_not_called()
+
+
+class TestValidateLicenseData(TestCase):
+    conductr_version = '2.1.0'
+
+    license = {
+        'user': 'cc64df31-ec6b-4e08-bb6b-3216721a56b@lightbend',
+        'maxConductrAgents': 3,
+        'conductrVersions': ['2.1.*'],
+        'expires': '2018-03-01T00:00:00Z',
+        'grants': ['akka-sbr', 'cinnamon', 'conductr'],
+    }
+
+    nr_of_agent_instances = 3
+
+    def test_validate(self):
+        mock_validate_version = MagicMock()
+        mock_validate_nr_of_agents = MagicMock()
+        mock_validate_expiry = MagicMock()
+        mock_validate_grants = MagicMock()
+
+        with patch('conductr_cli.license_validation.validate_version', mock_validate_version), \
+                patch('conductr_cli.license_validation.validate_nr_of_agents', mock_validate_nr_of_agents), \
+                patch('conductr_cli.license_validation.validate_expiry', mock_validate_expiry), \
+                patch('conductr_cli.license_validation.validate_grants', mock_validate_grants):
+            license_validation.validate_license_data(self.conductr_version, self.nr_of_agent_instances,
+                                                     self.license)
+
+        mock_validate_version.assert_called_once_with(self.conductr_version, self.license)
+        mock_validate_nr_of_agents.assert_called_once_with(self.nr_of_agent_instances, self.license)
+        mock_validate_expiry.assert_called_once_with(self.license)
+        mock_validate_grants.assert_called_once_with(self.license)
+
+
+class TestValidateVersion(TestCase):
+    license = {
+        'user': 'cc64df31-ec6b-4e08-bb6b-3216721a56b@lightbend',
+        'maxConductrAgents': 3,
+        'conductrVersions': ['2.1.*', '2.2.*'],
+        'expires': '2018-03-01T00:00:00Z',
+        'grants': ['akka-sbr', 'cinnamon', 'conductr'],
+    }
+
+    def test_license_multiple_versions(self):
+        license_validation.validate_version('2.1.0-SNAPSHOT', self.license)
+        license_validation.validate_version('2.1.5', self.license)
+        license_validation.validate_version('2.2.3', self.license)
+
+    def test_license_single_version(self):
+        license_single_version = self.license.copy()
+        license_single_version.update({'conductrVersions': ['2.1.*']})
+
+        license_validation.validate_version('2.1.5', self.license)
+
+    def test_license_version_not_present(self):
+        license_no_version = self.license.copy()
+
+        del license_no_version['conductrVersions']
+
+        license_validation.validate_version('2.1.0-SNAPSHOT', license_no_version)
+        license_validation.validate_version('2.0.0', license_no_version)
+        license_validation.validate_version('2.1.5', license_no_version)
+        license_validation.validate_version('2.2.3', license_no_version)
+
+    def test_license_empty_versions(self):
+        license_no_version = self.license.copy()
+        license_no_version.update({'conductrVersions': []})
+
+        license_validation.validate_version('2.1.0-SNAPSHOT', license_no_version)
+        license_validation.validate_version('2.0.0', license_no_version)
+        license_validation.validate_version('2.1.5', license_no_version)
+        license_validation.validate_version('2.2.3', license_no_version)
+
+    def test_invalid_version(self):
+        self.assertRaises(LicenseValidationError, license_validation.validate_version, '2.0.1-SNAPSHOT', self.license)
+        self.assertRaises(LicenseValidationError, license_validation.validate_version, '2.0.0', self.license)
+        self.assertRaises(LicenseValidationError, license_validation.validate_version, '2.3.0', self.license)
+
+
+class TestValidateNrOfAgents(TestCase):
+    license = {
+        'user': 'cc64df31-ec6b-4e08-bb6b-3216721a56b@lightbend',
+        'maxConductrAgents': 3,
+        'conductrVersions': ['2.1.*', '2.2.*'],
+        'expires': '2018-03-01T00:00:00Z',
+        'grants': ['akka-sbr', 'cinnamon', 'conductr'],
+    }
+
+    def test_less_then_allowed(self):
+        license_validation.validate_nr_of_agents(2, self.license)
+
+    def test_equals_to_allowed(self):
+        license_validation.validate_nr_of_agents(3, self.license)
+
+    def test_more_then_allowed(self):
+        self.assertRaises(LicenseValidationError, license_validation.validate_nr_of_agents, 5, self.license)
+
+    def test_nr_of_agents_missing(self):
+        license_no_agents = self.license.copy()
+        del license_no_agents['maxConductrAgents']
+
+        self.assertRaises(LicenseValidationError, license_validation.validate_nr_of_agents, 1, license_no_agents)
+
+
+class TestValidateExpiry(TestCase):
+    license = {
+        'user': 'cc64df31-ec6b-4e08-bb6b-3216721a56b@lightbend',
+        'maxConductrAgents': 3,
+        'conductrVersions': ['2.1.*', '2.2.*'],
+        'expires': '2018-03-01T00:00:00Z',
+        'grants': ['akka-sbr', 'cinnamon', 'conductr'],
+    }
+
+    def test_not_expired(self):
+        mock_calculate_days_to_expiry = MagicMock(return_value=30)
+        with patch('conductr_cli.license.calculate_days_to_expiry', mock_calculate_days_to_expiry):
+            license_validation.validate_expiry(self.license)
+
+    def test_expired(self):
+        mock_calculate_days_to_expiry = MagicMock(return_value=-1)
+        with patch('conductr_cli.license.calculate_days_to_expiry', mock_calculate_days_to_expiry):
+            self.assertRaises(LicenseValidationError, license_validation.validate_expiry, self.license)
+
+    def test_expiry_not_present(self):
+        mock_calculate_days_to_expiry = MagicMock(return_value=-1)
+
+        license_no_expiry = self.license.copy()
+        del license_no_expiry['expires']
+
+        with patch('conductr_cli.license.calculate_days_to_expiry', mock_calculate_days_to_expiry):
+            license_validation.validate_expiry(license_no_expiry)
+
+        mock_calculate_days_to_expiry.assert_not_called()
+
+
+class TestValidateGrants(TestCase):
+    license = {
+        'user': 'cc64df31-ec6b-4e08-bb6b-3216721a56b@lightbend',
+        'maxConductrAgents': 3,
+        'conductrVersions': ['2.1.*', '2.2.*'],
+        'expires': '2018-03-01T00:00:00Z',
+        'grants': ['akka-sbr', 'cinnamon', 'conductr'],
+    }
+
+    def test_conductr_grants_present(self):
+        license_validation.validate_grants(self.license)
+
+    def test_conductr_grants_empty(self):
+        license_no_grants = self.license.copy()
+        license_no_grants.update({'grants': ['others']})
+
+        self.assertRaises(LicenseValidationError, license_validation.validate_grants, license_no_grants)
+
+    def test_conductr_grants_not_present(self):
+        license_no_grants = self.license.copy()
+        del license_no_grants['grants']
+
+        self.assertRaises(LicenseValidationError, license_validation.validate_grants, license_no_grants)
+
+
+class TestCanRunVersion(TestCase):
+    def test_major_version(self):
+        self.assertTrue(license_validation.can_run_version('2.*.*', '2.1.5'))
+        self.assertTrue(license_validation.can_run_version('2.*.*', '2.0.1'))
+        self.assertTrue(license_validation.can_run_version('2.*.*', '2.0.0'))
+
+        self.assertTrue(license_validation.can_run_version('2.*', '2.1.5'))
+        self.assertTrue(license_validation.can_run_version('2.*', '2.0.1'))
+        self.assertTrue(license_validation.can_run_version('2.*', '2.0.0'))
+
+        self.assertFalse(license_validation.can_run_version('1.*.*', '2.1.5'))
+        self.assertFalse(license_validation.can_run_version('1.*.*', '2.0.1'))
+        self.assertFalse(license_validation.can_run_version('1.*.*', '2.0.0'))
+
+        self.assertFalse(license_validation.can_run_version('1.*', '2.1.5'))
+        self.assertFalse(license_validation.can_run_version('1.*', '2.0.1'))
+        self.assertFalse(license_validation.can_run_version('1.*', '2.0.0'))
+
+    def test_major_minor_version(self):
+        self.assertTrue(license_validation.can_run_version('2.1.*', '2.1.5'))
+
+        self.assertFalse(license_validation.can_run_version('2.1.*', '2.2.1'))
+        self.assertFalse(license_validation.can_run_version('2.1.*', '2.1'))
+        self.assertFalse(license_validation.can_run_version('2.1.*', '2'))
+
+    def test_major_minor_patch_version(self):
+        self.assertTrue(license_validation.can_run_version('2.1.5', '2.1.5'))
+        self.assertFalse(license_validation.can_run_version('2.1.5', '2.2.1'))
+
+    def test_any_version(self):
+        self.assertTrue(license_validation.can_run_version('*.*.*', '2.1.5'))
+        self.assertTrue(license_validation.can_run_version('*', '2.1.5'))

--- a/conductr_cli/test/test_sandbox_run.py
+++ b/conductr_cli/test/test_sandbox_run.py
@@ -24,7 +24,6 @@ class TestSandboxRunCommand(CliTestCase):
         'ports': [],
         'bundle_http_port': bundle_http_port,
         'features': [],
-        'no_wait': False,
         'local_connection': True
     }
 
@@ -287,9 +286,7 @@ class TestWaitForStart(CliTestCase):
                 patch('conductr_cli.conduct_url.url', mock_url), \
                 patch('conductr_cli.conduct_request.get', mock_http_get), \
                 patch('sys.stdout.isatty', is_tty_mock):
-            args = MagicMock(**{
-                'no_wait': False
-            })
+            args = MagicMock(**{})
             logging_setup.configure_logging(args, stdout)
             run_result = MagicMock(**{
                 'host': '10.0.0.1'
@@ -331,9 +328,7 @@ class TestWaitForStart(CliTestCase):
                 patch('conductr_cli.conduct_url.url', mock_url), \
                 patch('conductr_cli.conduct_request.get', mock_http_get), \
                 patch('sys.stdout.isatty', is_tty_mock):
-            args = MagicMock(**{
-                'no_wait': False
-            })
+            args = MagicMock(**{})
             logging_setup.configure_logging(args, stdout)
             run_result = MagicMock(**{
                 'host': '10.0.0.1'
@@ -359,13 +354,3 @@ class TestWaitForStart(CliTestCase):
             call.write(''),
             call.flush()
         ], stdout.method_calls)
-
-    def test_no_wait(self):
-        args = MagicMock(**{
-            'no_wait': True
-        })
-        run_result = MagicMock(**{
-            'host': '10.0.0.1'
-        })
-        result = sandbox_run.wait_for_start(args, run_result)
-        self.assertEqual((True, 0), result)

--- a/conductr_cli/test/test_sandbox_run_docker.py
+++ b/conductr_cli/test/test_sandbox_run_docker.py
@@ -23,7 +23,6 @@ class TestRun(CliTestCase):
         'ports': [],
         'bundle_http_port': 9000,
         'features': [],
-        'no_wait': False,
         'local_connection': True
     }
 
@@ -337,9 +336,7 @@ class TestLogRunAttempt(CliTestCase):
 
     def test_log_output(self):
         stdout = MagicMock()
-        input_args = MagicMock(**{
-            'no_wait': False
-        })
+        input_args = MagicMock(**{})
 
         logging_setup.configure_logging(input_args, stdout)
         sandbox_run_docker.log_run_attempt(
@@ -364,9 +361,7 @@ class TestLogRunAttempt(CliTestCase):
 
     def test_log_output_single_container(self):
         stdout = MagicMock()
-        input_args = MagicMock(**{
-            'no_wait': False
-        })
+        input_args = MagicMock(**{})
 
         logging_setup.configure_logging(input_args, stdout)
         sandbox_run_docker.log_run_attempt(
@@ -392,9 +387,7 @@ class TestLogRunAttempt(CliTestCase):
     def test_log_output_not_started(self):
         stdout = MagicMock()
         stderr = MagicMock()
-        input_args = MagicMock(**{
-            'no_wait': False
-        })
+        input_args = MagicMock(**{})
 
         logging_setup.configure_logging(input_args, stdout, stderr)
         sandbox_run_docker.log_run_attempt(
@@ -416,21 +409,3 @@ class TestLogRunAttempt(CliTestCase):
                                                    |Error: Set the env CONDUCTR_SANDBOX_WAIT_RETRY_INTERVAL to increase the wait timeout.
                                                    |"""))
         self.assertEqual(expected_stderr, self.output(stderr))
-
-    def test_log_output_no_wait(self):
-        stdout = MagicMock()
-        input_args = MagicMock(**{
-            'no_wait': True
-        })
-
-        logging_setup.configure_logging(input_args, stdout)
-        sandbox_run_docker.log_run_attempt(
-            input_args,
-            run_result=self.run_result,
-            feature_results=self.feature_results,
-            is_conductr_started=True,
-            feature_provided=[FEATURE_PROVIDE_PROXYING],
-            wait_timeout=self.wait_timeout
-        )
-
-        self.assertEqual('', self.output(stdout))

--- a/conductr_cli/test/test_sandbox_run_jvm.py
+++ b/conductr_cli/test/test_sandbox_run_jvm.py
@@ -24,7 +24,6 @@ class TestRun(CliTestCase):
         'nr_of_containers': 1,
         'addr_range': addr_range,
         'offline_mode': False,
-        'no_wait': False,
         'tmp_dir': tmp_dir,
         'envs': [],
         'envs_core': [],
@@ -973,9 +972,7 @@ class TestLogRunAttempt(CliTestCase):
     def test_log_output(self):
         run_mock = MagicMock()
         stdout = MagicMock()
-        input_args = MagicMock(**{
-            'no_wait': False
-        })
+        input_args = MagicMock(**{})
 
         with patch('conductr_cli.conduct_main.run', run_mock):
             logging_setup.configure_logging(input_args, stdout)
@@ -1110,27 +1107,6 @@ class TestLogRunAttempt(CliTestCase):
                                           |Current bundle status:
                                           |""")
         self.assertEqual(expected_stdout, self.output(stdout))
-
-    def test_no_wait(self):
-        run_mock = MagicMock()
-        stdout = MagicMock()
-        input_args = MagicMock(**{
-            'no_wait': True
-        })
-
-        with patch('conductr_cli.conduct_main.run', run_mock):
-            logging_setup.configure_logging(input_args, stdout)
-            sandbox_run_jvm.log_run_attempt(
-                input_args,
-                run_result=self.run_result,
-                feature_results=self.feature_results,
-                is_conductr_started=True,
-                feature_provided=[FEATURE_PROVIDE_PROXYING],
-                wait_timeout=self.wait_timeout
-            )
-
-        run_mock.assert_not_called()
-        self.assertEqual('', self.output(stdout))
 
 
 class TestValidateJvm(CliTestCase):

--- a/conductr_cli/test/test_sandbox_run_jvm.py
+++ b/conductr_cli/test/test_sandbox_run_jvm.py
@@ -1,10 +1,10 @@
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
 from conductr_cli import logging_setup, sandbox_run_jvm, sandbox_features
-from conductr_cli.constants import FEATURE_PROVIDE_PROXYING
+from conductr_cli.constants import DEFAULT_LICENSE_FILE, FEATURE_PROVIDE_PROXYING
 from conductr_cli.exceptions import BindAddressNotFound, InstanceCountError, BintrayUnreachableError, \
     SandboxImageNotFoundError, SandboxImageNotAvailableOfflineError, SandboxUnsupportedOsError, \
     SandboxUnsupportedOsArchError, JavaCallError, JavaUnsupportedVendorError, JavaUnsupportedVersionError, \
-    JavaVersionParseError
+    JavaVersionParseError, LicenseValidationError
 from conductr_cli.sandbox_features import LoggingFeature
 from conductr_cli.sandbox_run_jvm import BIND_TEST_PORT
 from unittest.mock import call, patch, MagicMock
@@ -51,6 +51,8 @@ class TestRun(CliTestCase):
         mock_core_pids = MagicMock()
         mock_start_core_instances = MagicMock(return_value=mock_core_pids)
 
+        mock_validate_license = MagicMock()
+
         mock_agent_pids = MagicMock()
         mock_start_agent_instances = MagicMock(return_value=mock_agent_pids)
 
@@ -62,14 +64,16 @@ class TestRun(CliTestCase):
                 patch('conductr_cli.sandbox_run_jvm.cleanup_tmp_dir', mock_cleanup_tmp_dir), \
                 patch('conductr_cli.sandbox_run_jvm.find_bind_addrs', mock_find_bind_addrs), \
                 patch('conductr_cli.sandbox_run_jvm.obtain_sandbox_image', mock_obtain_sandbox_image), \
-                patch('conductr_cli.sandbox_run_jvm.sandbox_stop', mock_sandbox_stop), \
+                patch('conductr_cli.sandbox_stop.stop', mock_sandbox_stop), \
                 patch('conductr_cli.sandbox_run_jvm.start_core_instances', mock_start_core_instances), \
+                patch('conductr_cli.license_validation.validate_license', mock_validate_license), \
                 patch('conductr_cli.sandbox_run_jvm.start_agent_instances', mock_start_agent_instances):
             result = sandbox_run_jvm.run(input_args, features)
             expected_result = sandbox_run_jvm.SandboxRunResult(mock_core_pids, bind_addrs,
                                                                mock_agent_pids, bind_addrs)
             self.assertEqual(expected_result, result)
 
+        mock_sandbox_stop.assert_called_once_with(input_args)
         mock_validate_jvm_support.assert_called_once_with()
         mock_validate_64bit_support.assert_called_once_with()
         mock_cleanup_tmp_dir.assert_called_once_with(self.tmp_dir)
@@ -84,6 +88,7 @@ class TestRun(CliTestCase):
                                                      [],
                                                      features,
                                                      'info')
+        mock_validate_license.assert_called_once_with('2.0.0', bind_addr, 1, DEFAULT_LICENSE_FILE)
         mock_start_agent_instances.assert_called_with(mock_agent_extracted_dir,
                                                       self.tmp_dir,
                                                       [],
@@ -116,6 +121,8 @@ class TestRun(CliTestCase):
         mock_core_pids = MagicMock()
         mock_start_core_instances = MagicMock(return_value=mock_core_pids)
 
+        mock_validate_license = MagicMock()
+
         mock_agent_pids = MagicMock()
         mock_start_agent_instances = MagicMock(return_value=mock_agent_pids)
 
@@ -131,14 +138,16 @@ class TestRun(CliTestCase):
                 patch('conductr_cli.sandbox_run_jvm.cleanup_tmp_dir', mock_cleanup_tmp_dir), \
                 patch('conductr_cli.sandbox_run_jvm.find_bind_addrs', mock_find_bind_addrs), \
                 patch('conductr_cli.sandbox_run_jvm.obtain_sandbox_image', mock_obtain_sandbox_image), \
-                patch('conductr_cli.sandbox_run_jvm.sandbox_stop', mock_sandbox_stop), \
+                patch('conductr_cli.sandbox_stop.stop', mock_sandbox_stop), \
                 patch('conductr_cli.sandbox_run_jvm.start_core_instances', mock_start_core_instances), \
+                patch('conductr_cli.license_validation.validate_license', mock_validate_license), \
                 patch('conductr_cli.sandbox_run_jvm.start_agent_instances', mock_start_agent_instances):
             result = sandbox_run_jvm.run(input_args, features)
             expected_result = sandbox_run_jvm.SandboxRunResult(mock_core_pids, [bind_addr1],
                                                                mock_agent_pids, [bind_addr1, bind_addr2, bind_addr3])
             self.assertEqual(expected_result, result)
 
+        mock_sandbox_stop.assert_called_once_with(input_args)
         mock_validate_jvm_support.assert_called_once_with()
         mock_validate_64bit_support.assert_called_once_with()
         mock_cleanup_tmp_dir.assert_called_once_with(self.tmp_dir)
@@ -153,6 +162,7 @@ class TestRun(CliTestCase):
                                                      [],
                                                      features,
                                                      'info')
+        mock_validate_license.assert_called_once_with('2.0.0', bind_addr1, 3, DEFAULT_LICENSE_FILE)
         mock_start_agent_instances.assert_called_with(mock_agent_extracted_dir,
                                                       self.tmp_dir,
                                                       [],
@@ -184,6 +194,8 @@ class TestRun(CliTestCase):
         mock_core_pids = MagicMock()
         mock_start_core_instances = MagicMock(return_value=mock_core_pids)
 
+        mock_validate_license = MagicMock()
+
         mock_agent_pids = MagicMock()
         mock_start_agent_instances = MagicMock(return_value=mock_agent_pids)
 
@@ -211,14 +223,16 @@ class TestRun(CliTestCase):
                 patch('conductr_cli.sandbox_run_jvm.validate_64bit_support', mock_validate_64bit_support), \
                 patch('conductr_cli.sandbox_run_jvm.find_bind_addrs', mock_find_bind_addrs), \
                 patch('conductr_cli.sandbox_run_jvm.obtain_sandbox_image', mock_obtain_sandbox_image), \
-                patch('conductr_cli.sandbox_run_jvm.sandbox_stop', mock_sandbox_stop), \
+                patch('conductr_cli.sandbox_stop.stop', mock_sandbox_stop), \
                 patch('conductr_cli.sandbox_run_jvm.start_core_instances', mock_start_core_instances), \
+                patch('conductr_cli.license_validation.validate_license', mock_validate_license), \
                 patch('conductr_cli.sandbox_run_jvm.start_agent_instances', mock_start_agent_instances):
             result = sandbox_run_jvm.run(input_args, features)
             expected_result = sandbox_run_jvm.SandboxRunResult(mock_core_pids, [bind_addr1],
                                                                mock_agent_pids, [bind_addr1])
             self.assertEqual(expected_result, result)
 
+        mock_sandbox_stop.assert_called_once_with(input_args)
         mock_validate_jvm_support.assert_called_once_with()
         mock_validate_64bit_support.assert_called_once_with()
         mock_find_bind_addrs.assert_called_with(1, self.addr_range)
@@ -232,6 +246,7 @@ class TestRun(CliTestCase):
                                                      [],
                                                      features,
                                                      'info')
+        mock_validate_license.assert_called_once_with('2.0.0', bind_addr1, 1, DEFAULT_LICENSE_FILE)
         mock_start_agent_instances.assert_called_with(mock_agent_extracted_dir,
                                                       self.tmp_dir,
                                                       envs,
@@ -262,6 +277,8 @@ class TestRun(CliTestCase):
         mock_core_pids = MagicMock()
         mock_start_core_instances = MagicMock(return_value=mock_core_pids)
 
+        mock_validate_license = MagicMock()
+
         mock_agent_pids = MagicMock()
         mock_start_agent_instances = MagicMock(return_value=mock_agent_pids)
 
@@ -279,14 +296,16 @@ class TestRun(CliTestCase):
                 patch('conductr_cli.sandbox_run_jvm.cleanup_tmp_dir', mock_cleanup_tmp_dir), \
                 patch('conductr_cli.sandbox_run_jvm.find_bind_addrs', mock_find_bind_addrs), \
                 patch('conductr_cli.sandbox_run_jvm.obtain_sandbox_image', mock_obtain_sandbox_image), \
-                patch('conductr_cli.sandbox_run_jvm.sandbox_stop', mock_sandbox_stop), \
+                patch('conductr_cli.sandbox_stop.stop', mock_sandbox_stop), \
                 patch('conductr_cli.sandbox_run_jvm.start_core_instances', mock_start_core_instances), \
+                patch('conductr_cli.license_validation.validate_license', mock_validate_license), \
                 patch('conductr_cli.sandbox_run_jvm.start_agent_instances', mock_start_agent_instances):
             result = sandbox_run_jvm.run(input_args, features)
             expected_result = sandbox_run_jvm.SandboxRunResult(mock_core_pids, bind_addrs,
                                                                mock_agent_pids, bind_addrs)
             self.assertEqual(expected_result, result)
 
+        mock_sandbox_stop.assert_called_once_with(input_args)
         mock_validate_jvm_support.assert_called_once_with()
         mock_validate_64bit_support.assert_called_once_with()
         mock_cleanup_tmp_dir.assert_called_once_with(self.tmp_dir)
@@ -301,6 +320,7 @@ class TestRun(CliTestCase):
                                                      [['role1', 'role2'], ['role3']],
                                                      features,
                                                      'info')
+        mock_validate_license.assert_called_once_with('2.0.0', bind_addr, 1, DEFAULT_LICENSE_FILE)
         mock_start_agent_instances.assert_called_with(mock_agent_extracted_dir,
                                                       self.tmp_dir,
                                                       [],
@@ -312,6 +332,64 @@ class TestRun(CliTestCase):
                                                       [['role1', 'role2'], ['role3']],
                                                       features,
                                                       'info')
+
+    def test_license_validation_error(self):
+        mock_validate_jvm_support = MagicMock()
+        mock_validate_64bit_support = MagicMock()
+        mock_cleanup_tmp_dir = MagicMock()
+
+        bind_addr = MagicMock()
+        bind_addrs = [bind_addr]
+        mock_find_bind_addrs = MagicMock(return_value=bind_addrs)
+
+        mock_core_extracted_dir = MagicMock()
+        mock_agent_extracted_dir = MagicMock()
+        mock_obtain_sandbox_image = MagicMock(return_value=(mock_core_extracted_dir, mock_agent_extracted_dir))
+
+        mock_sandbox_stop = MagicMock()
+
+        mock_core_pids = MagicMock()
+        mock_start_core_instances = MagicMock(return_value=mock_core_pids)
+
+        mock_validate_license = MagicMock(side_effect=LicenseValidationError('test only'))
+
+        mock_agent_pids = MagicMock()
+        mock_start_agent_instances = MagicMock(return_value=mock_agent_pids)
+
+        input_args = MagicMock(**self.default_args)
+        features = []
+
+        with patch('conductr_cli.sandbox_run_jvm.validate_jvm_support', mock_validate_jvm_support), \
+                patch('conductr_cli.sandbox_run_jvm.validate_64bit_support', mock_validate_64bit_support), \
+                patch('conductr_cli.sandbox_run_jvm.cleanup_tmp_dir', mock_cleanup_tmp_dir), \
+                patch('conductr_cli.sandbox_run_jvm.find_bind_addrs', mock_find_bind_addrs), \
+                patch('conductr_cli.sandbox_run_jvm.obtain_sandbox_image', mock_obtain_sandbox_image), \
+                patch('conductr_cli.sandbox_stop.stop', mock_sandbox_stop), \
+                patch('conductr_cli.sandbox_run_jvm.start_core_instances', mock_start_core_instances), \
+                patch('conductr_cli.license_validation.validate_license', mock_validate_license), \
+                patch('conductr_cli.sandbox_run_jvm.start_agent_instances', mock_start_agent_instances):
+            self.assertRaises(LicenseValidationError, sandbox_run_jvm.run, input_args, features)
+
+        mock_validate_jvm_support.assert_called_once_with()
+        mock_validate_64bit_support.assert_called_once_with()
+        mock_cleanup_tmp_dir.assert_called_once_with(self.tmp_dir)
+        mock_find_bind_addrs.assert_called_with(1, self.addr_range)
+        mock_start_core_instances.assert_called_with(mock_core_extracted_dir,
+                                                     self.tmp_dir,
+                                                     [],
+                                                     [],
+                                                     [],
+                                                     [],
+                                                     bind_addrs,
+                                                     [],
+                                                     features,
+                                                     'info')
+        mock_validate_license.assert_called_once_with('2.0.0', bind_addr, 1, DEFAULT_LICENSE_FILE)
+        mock_start_agent_instances.assert_not_called()
+        self.assertEqual([
+            call(input_args),
+            call(input_args)
+        ], mock_sandbox_stop.call_args_list)
 
 
 class TestInstanceCount(CliTestCase):

--- a/conductr_cli/test/test_validation.py
+++ b/conductr_cli/test/test_validation.py
@@ -21,9 +21,11 @@ class TestTerminal(CliTestCase):
         expect_pass('1')
         expect_pass('1.1')
         expect_pass('1.1.0')
+        expect_pass('1.1.0-SNAPSHOT')
         expect_pass('1.2.3.4.5')
         expect_pass('2')
         expect_pass('2.0.0')
+        expect_pass('2.0.0-SNAPSHOT')
 
         expect_fail('potato')
         expect_fail('1.')

--- a/conductr_cli/validation.py
+++ b/conductr_cli/validation.py
@@ -470,7 +470,7 @@ def argparse_version(value):
     import argparse
     import re
 
-    if re.match("^[0-9]+([.][0-9]+)*$", value):
+    if re.match("^[0-9]+([.][0-9]+)*(\\-SNAPSHOT)?$", value):
         return value
 
     raise argparse.ArgumentTypeError("'%s' is not a valid version number" % value)

--- a/conductr_cli/validation.py
+++ b/conductr_cli/validation.py
@@ -16,7 +16,7 @@ from conductr_cli.exceptions import BindAddressNotFound, \
     WaitTimeoutError, InsecureFilePermissions, SandboxImageNotFoundError, JavaCallError, \
     JavaUnsupportedVendorError, JavaUnsupportedVersionError, JavaVersionParseError, DockerValidationError, \
     SandboxImageNotAvailableOfflineError, SandboxUnsupportedOsError, SandboxUnsupportedOsArchError, \
-    LicenseLoadError, NOT_FOUND_ERROR
+    LicenseLoadError, LicenseValidationError, NOT_FOUND_ERROR
 
 
 def connection_error(log, err, args):
@@ -446,6 +446,25 @@ def handle_license_load_error(func):
             log = get_logger_for_func(func)
             log.error('Error loading license into ConductR')
             log.error(e.message)
+            return False
+
+        # Do not change the wrapped function name,
+        # so argparse configuration can be tested.
+    handler.__name__ = func.__name__
+
+    return handler
+
+
+def handle_license_validation_error(func):
+
+    def handler(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except LicenseValidationError as e:
+            log = get_logger_for_func(func)
+            log.error('Unable to start ConductR due to license validation failure')
+            for message in e.messages:
+                log.error(message)
             return False
 
         # Do not change the wrapped function name,


### PR DESCRIPTION
- Remove `--no-wait` flag from `sandbox run` command.
- Modify `sandbox run` version validation to allow versions ending with `-SNAPSHOT`.
- HTTP 404 and 503 are both considered as license endpoint not supported.
- Implement loading the license as part of sandbox run if the license file is present.