### PR TITLE
`sandbox run` now validates the version number it is given. Fixes #338

### DIFF
--- a/conductr_cli/sandbox_main.py
+++ b/conductr_cli/sandbox_main.py
@@ -33,6 +33,7 @@ def build_parser():
     add_image_dir(run_parser)
     run_parser.add_argument('image_version',
                             nargs='?',
+                            type=validation.argparse_version,
                             help='Version of the ConductR docker image to use\n'
                                  'To obtain the current version and additional information, please visit\n'
                                  'http://lightbend.com/product/conductr/developer')

--- a/conductr_cli/test/test_validation.py
+++ b/conductr_cli/test/test_validation.py
@@ -1,0 +1,30 @@
+from argparse import ArgumentTypeError
+from conductr_cli.validation import argparse_version
+from conductr_cli.test.cli_test_case import CliTestCase
+
+
+class TestTerminal(CliTestCase):
+    def test_argparse_version_number(self):
+        def expect_fail(value):
+            passed = False
+
+            try:
+                argparse_version(value)
+            except ArgumentTypeError:
+                passed = True
+
+            self.assertTrue(passed)
+
+        def expect_pass(value):
+            self.assertEqual(argparse_version(value), value)
+
+        expect_pass('1')
+        expect_pass('1.1')
+        expect_pass('1.1.0')
+        expect_pass('1.2.3.4.5')
+        expect_pass('2')
+        expect_pass('2.0.0')
+
+        expect_fail('potato')
+        expect_fail('1.')
+        expect_fail(' asdf 1 hello')

--- a/conductr_cli/validation.py
+++ b/conductr_cli/validation.py
@@ -464,3 +464,13 @@ def format_timestamp(timestamp, args):
 
 def get_logger_for_func(func):
     return logging.getLogger('conductr_cli.{}'.format(func.__name__))
+
+
+def argparse_version(value):
+    import argparse
+    import re
+
+    if re.match("^[0-9]+([.][0-9]+)*$", value):
+        return value
+
+    raise argparse.ArgumentTypeError("'%s' is not a valid version number" % value)


### PR DESCRIPTION
`sandbox run` now validates the version number it is given. Fixes #338 

*Before this change*

```bash
~/work/lightbend/conductr-cli#fix-version $ sandbox run potato
Error: Encountered unexpected error.
Error: Reason: ValueError invalid literal for int() with base 10: 'p'
Error: Further information of the error can be found in the error log file: /home/longshorej/.conductr/errors.log
-> 1
```

*After this change*
```
~/work/lightbend/conductr-cli#fix-version $ sandbox run potato
usage: sandbox run IMAGE_VERSION [ARGS]
sandbox run: error: argument image_version: 'potato' is not a valid version number
-> 2
```