### PR TITLE
Catching license 503 errors

### DIFF
--- a/conductr_cli/conduct_info.py
+++ b/conductr_cli/conduct_info.py
@@ -24,18 +24,19 @@ def info(args):
     if args.quiet:
         display_quiet(args, bundles)
     else:
-        conductr_license = license.get_license(args)
-        display_default(args, conductr_license, bundles)
+        is_license_success, conductr_license = license.get_license(args)
+        display_default(args, is_license_success, conductr_license, bundles)
 
     return True
 
 
-def display_default(args, conductr_license, bundles):
+def display_default(args, is_license_success, conductr_license, bundles):
     log = logging.getLogger(__name__)
 
-    license_to_display = license.format_license(conductr_license) if conductr_license \
-        else UNLICENSED_DISPLAY_TEXT
-    log.screen('\n{}\n'.format(license_to_display))
+    if is_license_success:
+        license_to_display = license.format_license(conductr_license) if conductr_license \
+            else UNLICENSED_DISPLAY_TEXT
+        log.screen('{}\n'.format(license_to_display))
 
     data = [
         {

--- a/conductr_cli/conduct_main.py
+++ b/conductr_cli/conduct_main.py
@@ -57,7 +57,7 @@ def add_dcos_settings(sub_parser):
 
 def add_verbose(sub_parser):
     sub_parser.add_argument('-v', '--verbose',
-                            help='Print JSON response to the command',
+                            help='Print detailed information of the command',
                             default=False,
                             dest='verbose',
                             action='store_true')
@@ -405,6 +405,7 @@ def build_parser(dcos_mode):
     add_cli_settings_dir(load_license_parser)
     add_custom_settings_file(load_license_parser)
     add_custom_plugins_dir(load_license_parser)
+    add_quiet_flag(load_license_parser)
     load_license_parser.set_defaults(func=conduct_load_license.load_license)
 
     return parser

--- a/conductr_cli/test/cli_test_case.py
+++ b/conductr_cli/test/cli_test_case.py
@@ -22,7 +22,8 @@ class CliTestCase(TestCase):
         reasons = {
             200: 'OK',
             404: 'Not Found',
-            500: 'Error'
+            500: 'Error',
+            503: 'Service unavailable'
         }
 
         response_mock = MagicMock(

--- a/conductr_cli/test/test_conduct_load_license.py
+++ b/conductr_cli/test/test_conduct_load_license.py
@@ -1,7 +1,7 @@
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin, as_error
 from conductr_cli import conduct_load_license, logging_setup
 from conductr_cli.constants import DEFAULT_LICENSE_FILE
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, call
 from requests.exceptions import ConnectionError, HTTPError
 from dcos.errors import DCOSHTTPException
 
@@ -33,8 +33,8 @@ class TestConductLoadLicense(CliTestCase):
     def test_success(self):
         mock_download_license = MagicMock()
         mock_exists = MagicMock(return_value=True)
-        mock_post_license = MagicMock()
-        mock_get_license = MagicMock(return_value=self.license)
+        mock_post_license = MagicMock(return_value=True)
+        mock_get_license = MagicMock(return_value=(True, self.license))
         mock_format_license = MagicMock(return_value=self.license_formatted)
 
         input_args = MagicMock(**self.args)
@@ -52,7 +52,7 @@ class TestConductLoadLicense(CliTestCase):
         mock_download_license.assert_called_once_with(input_args, save_to=DEFAULT_LICENSE_FILE)
         mock_exists.assert_called_once_with(DEFAULT_LICENSE_FILE)
         mock_post_license.assert_called_once_with(input_args, DEFAULT_LICENSE_FILE)
-        mock_get_license.assert_called_once_with(input_args)
+        mock_get_license.assert_has_calls([call(input_args), call(input_args)])
         mock_format_license.assert_called_once_with(self.license)
 
         expected_output = strip_margin("""|Downloading license from Lightbend.com
@@ -67,8 +67,8 @@ class TestConductLoadLicense(CliTestCase):
     def test_offline_mode(self):
         mock_download_license = MagicMock()
         mock_exists = MagicMock(return_value=True)
-        mock_post_license = MagicMock()
-        mock_get_license = MagicMock(return_value=self.license)
+        mock_post_license = MagicMock(return_value=True)
+        mock_get_license = MagicMock(return_value=(True, self.license))
         mock_format_license = MagicMock(return_value=self.license_formatted)
 
         args = self.args.copy()
@@ -88,7 +88,7 @@ class TestConductLoadLicense(CliTestCase):
         mock_download_license.assert_not_called()
         mock_exists.assert_called_once_with(DEFAULT_LICENSE_FILE)
         mock_post_license.assert_called_once_with(input_args, DEFAULT_LICENSE_FILE)
-        mock_get_license.assert_called_once_with(input_args)
+        mock_get_license.assert_has_calls([call(input_args), call(input_args)])
         mock_format_license.assert_called_once_with(self.license)
 
         expected_output = strip_margin("""|Skipping downloading license from Lightbend.com
@@ -103,8 +103,8 @@ class TestConductLoadLicense(CliTestCase):
     def test_offline_mode_license_file_missing(self):
         mock_download_license = MagicMock()
         mock_exists = MagicMock(return_value=False)
-        mock_post_license = MagicMock()
-        mock_get_license = MagicMock(return_value=self.license)
+        mock_post_license = MagicMock(return_value=True)
+        mock_get_license = MagicMock(return_value=(True, self.license))
         mock_format_license = MagicMock(return_value=self.license_formatted)
 
         args = self.args.copy()
@@ -125,7 +125,7 @@ class TestConductLoadLicense(CliTestCase):
         mock_download_license.assert_not_called()
         mock_exists.assert_called_once_with(DEFAULT_LICENSE_FILE)
         mock_post_license.assert_not_called()
-        mock_get_license.assert_not_called()
+        mock_get_license.assert_called_once_with(input_args)
         mock_format_license.assert_not_called()
 
         expected_output = strip_margin("""|Skipping downloading license from Lightbend.com
@@ -140,8 +140,8 @@ class TestConductLoadLicense(CliTestCase):
     def test_license_not_found_in_conductr(self):
         mock_download_license = MagicMock()
         mock_exists = MagicMock(return_value=True)
-        mock_post_license = MagicMock()
-        mock_get_license = MagicMock(return_value=None)
+        mock_post_license = MagicMock(return_value=True)
+        mock_get_license = MagicMock(return_value=(True, None))
         mock_format_license = MagicMock()
 
         input_args = MagicMock(**self.args)
@@ -160,7 +160,7 @@ class TestConductLoadLicense(CliTestCase):
         mock_download_license.assert_called_once_with(input_args, save_to=DEFAULT_LICENSE_FILE)
         mock_exists.assert_called_once_with(DEFAULT_LICENSE_FILE)
         mock_post_license.assert_called_once_with(input_args, DEFAULT_LICENSE_FILE)
-        mock_get_license.assert_called_once_with(input_args)
+        mock_get_license.assert_has_calls([call(input_args), call(input_args)])
         mock_format_license.assert_not_called()
 
         expected_output = strip_margin("""|Downloading license from Lightbend.com
@@ -196,7 +196,7 @@ class TestConductLoadLicense(CliTestCase):
         mock_download_license.assert_called_once_with(input_args, save_to=DEFAULT_LICENSE_FILE)
         mock_exists.assert_called_once_with(DEFAULT_LICENSE_FILE)
         mock_post_license.assert_called_once_with(input_args, DEFAULT_LICENSE_FILE)
-        mock_get_license.assert_not_called()
+        mock_get_license.assert_called_once_with(input_args)
         mock_format_license.assert_not_called()
 
     def test_dcos_http_error(self):
@@ -222,7 +222,7 @@ class TestConductLoadLicense(CliTestCase):
         mock_download_license.assert_called_once_with(input_args, save_to=DEFAULT_LICENSE_FILE)
         mock_exists.assert_called_once_with(DEFAULT_LICENSE_FILE)
         mock_post_license.assert_called_once_with(input_args, DEFAULT_LICENSE_FILE)
-        mock_get_license.assert_not_called()
+        mock_get_license.assert_called_once_with(input_args)
         mock_format_license.assert_not_called()
 
     def test_connection_error(self):
@@ -248,5 +248,5 @@ class TestConductLoadLicense(CliTestCase):
         mock_download_license.assert_called_once_with(input_args, save_to=DEFAULT_LICENSE_FILE)
         mock_exists.assert_called_once_with(DEFAULT_LICENSE_FILE)
         mock_post_license.assert_called_once_with(input_args, DEFAULT_LICENSE_FILE)
-        mock_get_license.assert_not_called()
+        mock_get_license.assert_called_once_with(input_args)
         mock_format_license.assert_not_called()

--- a/conductr_cli/test/test_license.py
+++ b/conductr_cli/test/test_license.py
@@ -64,6 +64,26 @@ class TestPostLicense(CliTestCase):
                                           data=mock_license_file_content,
                                           verify=self.server_verification_file)
 
+    def test_endpoint_not_supported(self):
+        license_file = MagicMock()
+
+        mock_license_file_content = MagicMock()
+        mock_open = MagicMock(return_value=mock_license_file_content)
+
+        mock_post = self.respond_with(status_code=503)
+
+        input_args = MagicMock(**self.args)
+
+        with patch('builtins.open', mock_open), \
+                patch('conductr_cli.conduct_request.post', mock_post):
+            self.assertFalse(license.post_license(input_args, license_file))
+
+        mock_open.assert_called_once_with(license_file, 'rb')
+        mock_post.assert_called_once_with(False, '10.0.0.1', 'https://10.0.0.1:9005/v2/license',
+                                          auth=self.auth,
+                                          data=mock_license_file_content,
+                                          verify=self.server_verification_file)
+
 
 class TestGetLicense(CliTestCase):
     auth = ('username', 'password')
@@ -96,8 +116,9 @@ class TestGetLicense(CliTestCase):
         input_args = MagicMock(**self.args)
 
         with patch('conductr_cli.conduct_request.get', mock_get):
-            result = license.get_license(input_args)
-            self.assertEqual(self.license, result)
+            is_license_success, license_result = license.get_license(input_args)
+            self.assertTrue(is_license_success)
+            self.assertEqual(self.license, license_result)
 
         mock_get.assert_called_once_with(False, '10.0.0.1', 'https://10.0.0.1:9005/v2/license', auth=self.auth)
 
@@ -107,8 +128,9 @@ class TestGetLicense(CliTestCase):
         input_args = MagicMock(**self.args)
 
         with patch('conductr_cli.conduct_request.get', mock_get):
-            result = license.get_license(input_args)
-            self.assertIsNone(result)
+            is_license_success, license_result = license.get_license(input_args)
+            self.assertTrue(is_license_success)
+            self.assertIsNone(license_result)
 
         mock_get.assert_called_once_with(False, '10.0.0.1', 'https://10.0.0.1:9005/v2/license', auth=self.auth)
 
@@ -119,6 +141,18 @@ class TestGetLicense(CliTestCase):
 
         with patch('conductr_cli.conduct_request.get', mock_get):
             self.assertRaises(HTTPError, license.get_license, input_args)
+
+        mock_get.assert_called_once_with(False, '10.0.0.1', 'https://10.0.0.1:9005/v2/license', auth=self.auth)
+
+    def test_endpoint_not_supported(self):
+        mock_get = self.respond_with(status_code=503)
+
+        input_args = MagicMock(**self.args)
+
+        with patch('conductr_cli.conduct_request.get', mock_get):
+            is_license_success, license_result = license.get_license(input_args)
+            self.assertFalse(is_license_success)
+            self.assertIsNone(license_result)
 
         mock_get.assert_called_once_with(False, '10.0.0.1', 'https://10.0.0.1:9005/v2/license', auth=self.auth)
 


### PR DESCRIPTION
The license calls `GET /license` and `POST /license` catching now the HTTP status code 503 and then returning a `LICENSE_ENDPOINT_NOT_SUPPORTED` flag. Calling methods can then use this response to perform alternate logic.

The `conduct info` and `conduct load-license` commands have been modified accordingly.

**conduct info**
If a 503 is of `GET /license` is returned then no license info is printed. This is different to the return type None which means that no license has been uploaded to ConductR which will print the no license information

**conduct load-license**
Before posting a license we now perform a `GET /license` call to check if a 503 is returned. If so the message `conduct load-license is only supported by ConductR 2.0.3+` is printed to the console. Note that this message can be suppressed if `args.quite` is et to True. This might be helpful if the function is called from another Python function that don’t want to print any license output for ConductR versions 2.0.2-

Fixes https://github.com/typesafehub/conductr-cli/issues/340