### PR TITLE
Fix for `conduct load` config bundles

### DIFF
--- a/conductr_cli/conduct_load.py
+++ b/conductr_cli/conduct_load.py
@@ -73,7 +73,8 @@ def load_v1(args):
     url = conduct_url.url('bundles', args)
     files = get_payload(bundle_file_name, bundle_open_file, with_bundle_configurations)
     if configuration_file is not None:
-        files.append(('configuration', (configuration_file_name, open(configuration_file, 'rb'))))
+        open_configuration_file, config_digest = bundle_utils.digest_extract_and_open(configuration_file)
+        files.append(('configuration', (configuration_file_name, open_configuration_file)))
 
     # TODO: Delete the bundle configuration file.
     # Currently, this results into a permission error on Windows.
@@ -184,7 +185,8 @@ def load_v2(args):
         files.append(('bundleConfOverlay', ('bundle.conf', string_io(bundle_conf_overlay))))
     files.append(('bundle', (bundle_file_name, bundle_open_file)))
     if configuration_file is not None:
-        files.append(('configuration', (configuration_file_name, open(configuration_file, 'rb'))))
+        open_configuration_file, config_digest = bundle_utils.digest_extract_and_open(configuration_file)
+        files.append(('configuration', (configuration_file_name, open_configuration_file)))
 
     # TODO: Delete the bundle configuration file.
     # Currently, this results into a permission error on Windows.

--- a/conductr_cli/test/test_conduct_load_v1.py
+++ b/conductr_cli/test/test_conduct_load_v1.py
@@ -106,7 +106,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
         create_multipart_mock = MagicMock(return_value=self.multipart_mock)
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
-        open_mock = MagicMock(return_value=1)
+        open_mock = MagicMock(return_value=(1, None))
         bundle_open_mock = MagicMock(side_effect=lambda p1, p2, p3: (p1, 1))
         wait_for_installation_mock = MagicMock()
 
@@ -118,7 +118,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
                 patch('conductr_cli.resolver.resolve_bundle_configuration', resolve_bundle_configuration_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
                 patch('requests.post', http_method), \
-                patch('builtins.open', open_mock), \
+                patch('conductr_cli.bundle_utils.digest_extract_and_open', open_mock), \
                 patch('conductr_cli.conduct_load.open_bundle', bundle_open_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
             logging_setup.configure_logging(input_args, stdout)
@@ -127,7 +127,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
 
         self.assertEqual(
             open_mock.call_args_list,
-            [call(config_file, 'rb')]
+            [call(config_file)]
         )
 
         self.assertEqual(

--- a/conductr_cli/test/test_conduct_load_v2.py
+++ b/conductr_cli/test/test_conduct_load_v2.py
@@ -157,7 +157,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
         create_multipart_mock = MagicMock(return_value=self.multipart_mock)
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
-        open_mock = MagicMock(return_value=1)
+        open_mock = MagicMock(return_value=(1, None))
         bundle_open_mock = MagicMock(side_effect=lambda p1, p2, p3: (p1, 1))
         wait_for_installation_mock = MagicMock()
 
@@ -171,7 +171,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
                 patch('conductr_cli.conduct_load.string_io', string_io_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
                 patch('requests.post', http_method), \
-                patch('builtins.open', open_mock), \
+                patch('conductr_cli.bundle_utils.digest_extract_and_open', open_mock), \
                 patch('conductr_cli.conduct_load.open_bundle', bundle_open_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
             logging_setup.configure_logging(input_args, stdout)
@@ -205,7 +205,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
 
         self.assertEqual(
             open_mock.call_args_list,
-            [call(config_file, 'rb')]
+            [call(config_file)]
         )
 
         expected_files = [
@@ -240,7 +240,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
 
         http_method = self.respond_with(200, self.default_response)
         stdout = MagicMock()
-        open_mock = MagicMock(return_value=1)
+        open_mock = MagicMock(return_value=(1, None))
         bundle_open_mock = MagicMock(side_effect=lambda p1, p2, p3: (p1, 1))
         wait_for_installation_mock = MagicMock()
 
@@ -254,7 +254,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
                 patch('conductr_cli.conduct_load.string_io', string_io_mock), \
                 patch('conductr_cli.conduct_load.create_multipart', create_multipart_mock), \
                 patch('requests.post', http_method), \
-                patch('builtins.open', open_mock), \
+                patch('conductr_cli.bundle_utils.digest_extract_and_open', open_mock), \
                 patch('conductr_cli.conduct_load.open_bundle', bundle_open_mock), \
                 patch('conductr_cli.bundle_installation.wait_for_installation', wait_for_installation_mock):
             logging_setup.configure_logging(input_args, stdout)
@@ -283,7 +283,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
 
         self.assertEqual(
             open_mock.call_args_list,
-            [call(config_file, 'rb')]
+            [call(config_file)]
         )
 
         expected_files = [


### PR DESCRIPTION
This fixes a bug with the changes merged yesterday. Config bundles were being uploaded to conductr without stripping the digest. Now, they aren't, and the tests have been updated to ensure that the proper functions are being called.