### PR TITLE
Initial implementation of `bndl` tool used to generate and modify ConductR bundles

### DIFF
--- a/conductr_cli/bndl.py
+++ b/conductr_cli/bndl.py
@@ -1,0 +1,13 @@
+from conductr_cli import bndl_main, main_handler
+
+
+def main_method():
+    bndl_main.run()
+
+
+def run():
+    main_handler.run(main_method)
+
+
+if __name__ == '__main__':
+    run()

--- a/conductr_cli/bndl_create.py
+++ b/conductr_cli/bndl_create.py
@@ -1,0 +1,135 @@
+from conductr_cli.bndl_oci import oci_image_bundle_conf, oci_image_unpack
+from conductr_cli.bndl_docker import docker_unpack
+from conductr_cli.bndl_utils import detect_format_dir, detect_format_stream
+from conductr_cli.constants import BNDL_PEEK_SIZE, IO_CHUNK_SIZE
+from conductr_cli.shazar_main import dir_to_zip, write_with_digest
+from io import BufferedReader, BytesIO
+import logging
+import os
+import shutil
+import sys
+import tarfile
+import tempfile
+import zipfile
+
+
+def bndl_create(args):
+    log = logging.getLogger(__name__)
+
+    if args.source is not None and not (os.path.isfile(args.source) or os.path.isdir(args.source)):
+        log.error('bndl: Unable to read {}. Must be the path to a valid file or directory'.format(args.source))
+
+        return 2
+
+    buff_in = BufferedReader(sys.stdin.buffer, IO_CHUNK_SIZE)
+
+    if args.format is None:
+        if args.source is None:
+            args.format = detect_format_stream(buff_in.peek(BNDL_PEEK_SIZE))
+        elif os.path.isdir(args.source):
+            args.format = detect_format_dir(args.source)
+        elif os.path.isfile(args.source):
+            with open(args.source, 'rb') as source_in:
+                args.format = detect_format_stream(source_in.read(BNDL_PEEK_SIZE))
+
+    output = sys.stdout.buffer if args.output is None else open(args.output, 'wb')
+
+    temp_dir = tempfile.mkdtemp()
+
+    component_name = 'oci-image'
+
+    oci_image_dir = os.path.join(temp_dir, component_name)
+
+    os.mkdir(oci_image_dir)
+
+    try:
+        if args.format is None:
+            log.error('bndl: Unable to detect format. Provide a -f or --format argument')
+
+            return 2
+        elif args.format == 'docker':
+            if args.source is None:
+                with tarfile.open(fileobj=buff_in, mode='r|') as tar_in:
+                    name = docker_unpack(oci_image_dir, tar_in, is_dir=False, maybe_name=args.name, maybe_tag=args.tag)
+            elif os.path.isfile(args.source):
+                with tarfile.open(args.source, mode='r') as tar_in:
+                    name = docker_unpack(oci_image_dir, tar_in, is_dir=False, maybe_name=args.name, maybe_tag=args.tag)
+            else:
+                name = docker_unpack(oci_image_dir, args.source, is_dir=True, maybe_name=args.name, maybe_tag=args.tag)
+
+            if name is None:
+                log.error('bndl: Not a Docker image')
+                return 3
+            elif args.name is None:
+                args.name = name
+        elif args.format == 'oci-image':
+            if args.name is None:
+                log.error('bndl: OCI Image support requires that you provide a --name argument')
+                return 2
+            elif args.source is None:
+                with tarfile.open(fileobj=buff_in, mode='r|') as tar_in:
+                    valid_image = oci_image_unpack(oci_image_dir, tar_in, is_dir=False)
+            elif os.path.isfile(args.source):
+                with tarfile.open(args.source, mode='r') as tar_in:
+                    valid_image = oci_image_unpack(oci_image_dir, tar_in, is_dir=False)
+            else:
+                valid_image = oci_image_unpack(oci_image_dir, args.source, is_dir=True)
+
+            if not valid_image:
+                log.error('bndl: Not an OCI Image')
+                return 2
+
+        has_oci_layout = os.path.isfile(os.path.join(oci_image_dir, 'oci-layout'))
+
+        refs_dir = os.path.join(oci_image_dir, 'refs')
+
+        if args.tag is None and os.path.isdir(refs_dir):
+            for ref in os.listdir(refs_dir):
+                args.tag = ref
+                break
+
+        ref_exists = args.tag is not None and os.path.isfile(os.path.join(refs_dir, args.tag))
+
+        if not ref_exists:
+            log.error('bndl: Invalid OCI Image. Cannot find requested tag "{}" in OCI Image'.format(args.tag))
+
+            return 2
+
+        if not has_oci_layout:
+            log.error('bndl: Invalid OCI Image. Missing oci-layout')
+
+            return 2
+
+        bundle_conf = oci_image_bundle_conf(args, component_name)
+        bundle_conf_name = os.path.join(args.name, 'bundle.conf')
+        bundle_conf_data = bundle_conf.encode('UTF-8')
+
+        # bundle.conf must be written first, so we explicitly do that for zip and tar
+
+        if args.use_shazar:
+            with tempfile.NamedTemporaryFile() as zip_file_data:
+                with zipfile.ZipFile(zip_file_data, 'w') as zip_file:
+                    zip_file.writestr(bundle_conf_name, bundle_conf_data)
+                    dir_to_zip(temp_dir, zip_file, args.name)
+
+                zip_file_data.flush()
+                zip_file_data.seek(0)
+
+                write_with_digest(zip_file_data, output)
+        else:
+            with tarfile.open(fileobj=output, mode='w|') as tar:
+                info = tarfile.TarInfo(name=bundle_conf_name)
+                info.size = len(bundle_conf_data)
+                tar.addfile(tarinfo=info, fileobj=BytesIO(bundle_conf_data))
+
+                for (dir_path, dir_names, file_names) in os.walk(temp_dir):
+                    for file_name in file_names:
+                        path = os.path.join(dir_path, file_name)
+                        name = os.path.join(args.name, os.path.relpath(path, start=temp_dir))
+                        tar.add(path, arcname=name)
+
+        output.flush()
+
+        return 0
+    finally:
+        shutil.rmtree(temp_dir)

--- a/conductr_cli/bndl_docker.py
+++ b/conductr_cli/bndl_docker.py
@@ -1,0 +1,277 @@
+from conductr_cli.bndl_utils import DigestReaderWriter, file_write_bytes
+import gzip
+import hashlib
+import json
+import os
+import shutil
+import tempfile
+
+
+def docker_parse_image_name(name):
+    """
+    Parses a docker image name into a tuple containing the name and tag. Examples:
+
+    "conductr:latest"           -> "conductr", "latest"
+    "lightbend/conductr:latest" -> "conductr", "latest"
+
+    :param name:
+    :return:
+    """
+    image_tag = name.split(':')
+
+    if len(image_tag) != 2:
+        raise ValueError('Invalid tag format')
+
+    return os.path.basename(image_tag[0]), image_tag[1]
+
+
+def docker_image_name_matches(wanted_name, wanted_tag, image_name):
+    return \
+        (wanted_tag is None or image_name.endswith(':{}'.format(wanted_tag))) and \
+        (wanted_name is None or os.path.basename(image_name).startswith('{}:'.format(wanted_name)))
+
+
+def docker_parse_cmd(line):
+    """
+    Docker's `CMD` entries have several different funky formats. This parses those. Examples:
+
+    CMD ["/bin/sh" "-c"]
+    CMD ["/bin/sh", "-c"]
+    CMD "/bin/sh" "-c"
+    CMD /bin/sh -c
+    CMD /bin/sh "-c"
+
+    :param line: CMD line from docker image
+    :return: parsed array of arguments
+    """
+
+    args_line = line[3:].strip() if line.startswith('CMD') else ''
+    args_brackets = args_line.startswith('[') and args_line.endswith(']')
+    args_portion = args_line[1:-1] if args_brackets else args_line
+
+    args = []
+    arg = ''
+    escaped = False
+    quoted = False
+
+    for c in args_portion:
+        if quoted and escaped:
+            arg += c
+            escaped = False
+        elif quoted and not escaped:
+            if c == '\\':
+                escaped = True
+            elif c == '"':
+                args.append(arg)
+                quoted = False
+                arg = ''
+            else:
+                arg += c
+        elif not quoted and escaped:
+            arg += c
+            escaped = False
+        else:
+            # not quoted and not escaped:
+
+            if c.isspace():
+                if arg != '':
+                    args.append(arg)
+                    arg = ''
+            elif c == '"':
+                if arg != '':
+                    args.append(arg)
+                    arg = ''
+
+                quoted = True
+            elif c == ',' and args_brackets:
+                pass
+            elif c == '\\':
+                escaped = True
+            else:
+                arg += c
+
+    if arg != '':
+        args.append(arg)
+
+    return args
+
+
+def docker_config_to_oci_image(manifest, config, sizes, layers_to_digests):
+    oci_config = {
+        'created': config['created'],
+        'architecture': config['architecture'],
+        'os': config['os'],
+        'config': {
+            k: v for k, v in {
+                'Env': config['config']['Env'] if 'Env' in config['config'] else None,
+                'Cmd': config['config']['Cmd'] if 'Cmd' in config['config'] else None,
+                'Entrypoint': config['config']['Entrypoint'] if 'Entrypoint' in config['config'] else None
+            }.items()
+
+            if v is not None
+        },
+        'rootfs': config['rootfs'],
+        'history': config['history']
+    }
+
+    oci_config_data = json.dumps(oci_config, sort_keys=True).encode('UTF-8')
+
+    digest = hashlib.sha256()
+    digest.update(oci_config_data)
+
+    oci_config_digest = digest.hexdigest()
+
+    oci_manifest = {
+        'schemaVersion': 2,
+        'config': {
+            'mediaType': 'application/vnd.oci.image.config.v1+json',
+            'size': len(oci_config_data),
+            'digest': 'sha256:{}'.format(oci_config_digest)
+        },
+        'layers': [
+            {
+                'mediaType': 'application/vnd.oci.image.layer.v1.tar+gzip',
+                'size': sizes[layers_to_digests[layer]],
+                'digest': 'sha256:{}'.format(layers_to_digests[layer])
+            } for layer in manifest['Layers']
+        ]
+    }
+
+    oci_manifest_data = json.dumps(oci_manifest, sort_keys=True).encode('UTF-8')
+
+    digest = hashlib.sha256()
+    digest.update(oci_manifest_data)
+
+    oci_manifest_digest = digest.hexdigest()
+
+    refs = {
+        'mediaType': 'application/vnd.oci.image.manifest.v1+json',
+        'digest': 'sha256:{}'.format(oci_manifest_digest),
+        'size': len(oci_manifest_data)
+    }
+
+    refs_data = json.dumps(refs, sort_keys=True).encode('UTF-8')
+
+    digest = hashlib.sha256()
+    digest.update(refs_data)
+
+    refs_digest = digest.hexdigest()
+
+    return {
+        'config': oci_config_data,
+        'config_digest': oci_config_digest,
+        'manifest': oci_manifest_data,
+        'manifest_digest': oci_manifest_digest,
+        'refs': refs_data,
+        'refs_digest': refs_digest
+    }
+
+
+def docker_unpack(destination, data, is_dir, maybe_name, maybe_tag):
+    temp_dir = tempfile.mkdtemp()
+
+    try:
+        os.makedirs(os.path.join(destination, 'blobs/sha256'))
+        os.makedirs(os.path.join(destination, 'refs'))
+
+        file_write_bytes(os.path.join(destination, 'oci-layout'), '{"imageLayoutVersion": "1.0.0"}'.encode('UTF-8'))
+
+        layers_to_digests = {}
+        digests = {}
+        sizes = {}
+
+        def handle_entry(name, fileobj, isdir, isfile):
+            parent_dir = os.path.dirname(name)
+            immediate_parent_dir = os.path.basename(parent_dir)
+
+            if parent_dir != '':
+                os.makedirs(os.path.join(temp_dir, 'layers', parent_dir), exist_ok=True)
+
+            file_name = os.path.basename(name)
+
+            if isdir:
+                os.makedirs(os.path.join(temp_dir, 'layers', file_name))
+            elif isfile and parent_dir == '':
+                with open(os.path.join(temp_dir, file_name), 'wb') as dest:
+                    shutil.copyfileobj(fileobj, dest)
+            elif isfile and file_name == 'layer.tar':
+                dest_path = os.path.join(temp_dir, 'layers', parent_dir, 'data')
+
+                with open(dest_path, 'wb') as dest_file:
+                    dest_file_digest = DigestReaderWriter(dest_file)
+
+                    # TODO investigate if below is still the case
+                    # bundles are packaged into zips, so we don't want to compress, but OCI tooling
+                    # as of 2017-03-14 is broken for plain tar files; they must be gzip
+
+                    with gzip.GzipFile(fileobj=dest_file_digest, mode='wb', compresslevel=0) as dest:
+                        shutil.copyfileobj(fileobj, dest)
+
+                    dest_file_hexdigest = dest_file_digest.digest_out.hexdigest()
+                    dest_file_size = dest_file_digest.size_out
+                    digests[dest_file_hexdigest] = dest_path
+                    sizes[dest_file_hexdigest] = dest_file_size
+                    layers_to_digests[os.path.join(immediate_parent_dir, file_name)] = dest_file_hexdigest
+
+                os.renames(dest_path, '{}/blobs/sha256/{}'.format(destination, dest_file_hexdigest))
+            else:
+                with open(os.path.join(temp_dir, 'layers', parent_dir, file_name), 'wb') as dest:
+                    shutil.copyfileobj(fileobj, dest)
+
+        if is_dir:
+            for base, dirs, files in os.walk(data):
+                for file in files:
+                    name = os.path.join(base, file)
+
+                    with open(name, 'rb') as fileobj:
+                        handle_entry(name, fileobj, isdir=False, isfile=True)
+        else:
+            for entry in data:
+                if entry.isfile():
+                    handle_entry(entry.name, data.extractfile(entry), isdir=False, isfile=True)
+
+        contents_dir = None
+
+        for base, dirs, files in os.walk(temp_dir):
+            if 'manifest.json' in files:
+                contents_dir = base
+                break
+
+        if contents_dir is None:
+            return None
+        else:
+            with open(os.path.join(contents_dir, 'manifest.json'), 'r') as manifest_file:
+                manifests = json.load(manifest_file)
+                manifest = None
+
+                for m in manifests:
+                    if m['RepoTags'] and \
+                            any(t for t in m['RepoTags'] if docker_image_name_matches(maybe_name, maybe_tag, t)):
+                        manifest = m
+                        break
+
+                image_name, image_tag = docker_parse_image_name(manifest['RepoTags'][0])
+
+                with open(os.path.join(contents_dir, manifest['Config'])) as config_file:
+                    config = json.load(config_file)
+
+                    oci_spec = docker_config_to_oci_image(manifest, config, sizes, layers_to_digests)
+
+                    file_write_bytes(
+                        '{}/blobs/sha256/{}'.format(destination, oci_spec['config_digest']),
+                        oci_spec['config']
+                    )
+
+                    file_write_bytes(
+                        '{}/blobs/sha256/{}'.format(destination, oci_spec['manifest_digest']),
+                        oci_spec['manifest']
+                    )
+
+                    file_write_bytes(
+                        '{}/refs/{}'.format(destination, image_tag),
+                        oci_spec['refs']
+                    )
+
+                return image_name
+    finally:
+        shutil.rmtree(temp_dir)

--- a/conductr_cli/bndl_main.py
+++ b/conductr_cli/bndl_main.py
@@ -1,0 +1,85 @@
+from conductr_cli import logging_setup
+from conductr_cli.bndl_create import bndl_create
+from conductr_cli.bndl_utils import mappings
+import argcomplete
+import argparse
+import logging
+import sys
+
+
+def run(argv=None):
+    log = logging.getLogger(__name__)
+    parser = build_parser()
+    argcomplete.autocomplete(parser)
+    args = parser.parse_args(argv)
+
+    if args.source == '-':
+        args.source = None
+
+    if args.output == '-':
+        args.output = None
+
+    if sys.stdout.isatty() and sys.stdin.isatty() and args.source is None:
+        parser.print_help()
+    elif sys.stdout.isatty() and args.output is None:
+        log.error('bndl: Refusing to write to terminal. Provide -o or redirect elsewhere')
+        sys.exit(2)
+    else:
+        logging_setup.configure_logging(args)
+
+        sys.exit(args.func(args))
+
+
+def build_parser():
+    parser = argparse.ArgumentParser('bndl', formatter_class=argparse.RawTextHelpFormatter)
+
+    parser.add_argument('-f', '--format',
+                        choices=['docker', 'oci-image'],
+                        required=False,
+                        help='The input format. When absent, auto-detection is attempted')
+
+    parser.add_argument('-t', '--tag',
+                        required=False,
+                        help='The name of the tag to create a ConductR bundle from. '
+                             'For use with docker and oci-image formats. When absent,'
+                             'the first tag present is used.')
+
+    parser.add_argument('-o', '--output',
+                        nargs='?',
+                        help='The target output file. When absent, stdout is used')
+
+    parser.add_argument('source',
+                        help='Optional path to a directory or tar file'
+                             'When absent, stdin is used',
+                        nargs='?')
+
+    parser.add_argument('--no-shazar',
+                        help='If enabled, a bundle will not be run through shazar',
+                        default=True,
+                        dest='use_shazar',
+                        action='store_false')
+
+    parser.add_argument('--component-description',
+                        help='Description to use for the generated ConductR component',
+                        default='')
+
+    zero_or_more_mappings = {'--roles'}
+    type_mappings = {'--memory': int, '--disk-space': int, '--nr-of-cpus': float}
+
+    for argument, bundle_key in mappings.items():
+        help_text = 'Sets the "{}" bundle.conf value'.format(bundle_key)
+
+        parser.add_argument(argument,
+                            nargs='*' if argument in zero_or_more_mappings else '?',
+                            type=type_mappings[argument] if argument in type_mappings else None,
+                            required=False,
+                            help=help_text,
+                            dest=bundle_key)
+
+    parser.set_defaults(func=bndl)
+
+    return parser
+
+
+def bndl(args):
+    return bndl_create(args)

--- a/conductr_cli/bndl_oci.py
+++ b/conductr_cli/bndl_oci.py
@@ -1,0 +1,43 @@
+from pyhocon import HOCONConverter, ConfigFactory, ConfigTree
+from conductr_cli.bndl_utils import load_bundle_args_into_conf
+import os
+import shutil
+import tempfile
+
+
+def oci_image_bundle_conf(args, component_name):
+    conf = ConfigFactory.parse_string('')
+    load_bundle_args_into_conf(conf, args)
+
+    oci_tree = ConfigTree()
+    oci_tree.put('description', args.component_description)
+    oci_tree.put('file-system-type', 'oci-image')
+    oci_tree.put('start-command', ['ociImageTag', args.tag])
+    oci_tree.put('endpoints', {})
+
+    components_tree = ConfigTree()
+    components_tree.put(component_name, oci_tree)
+
+    conf.put('components', components_tree)
+
+    return HOCONConverter.to_hocon(conf)
+
+
+def oci_image_unpack(destination, data, is_dir):
+    temp_dir = tempfile.mkdtemp()
+
+    try:
+        if is_dir:
+            shutil.copytree(data, os.path.join(temp_dir, 'image'))
+        else:
+            data.extractall(temp_dir)
+
+        for base, dirs, files in os.walk(temp_dir):
+            if 'oci-layout' in files or 'refs' in dirs:
+                os.renames(base, destination)
+                return True
+
+        return False
+    finally:
+        if os.path.isdir(temp_dir):
+            shutil.rmtree(temp_dir)

--- a/conductr_cli/bndl_utils.py
+++ b/conductr_cli/bndl_utils.py
@@ -1,0 +1,114 @@
+from collections import OrderedDict
+import hashlib
+import os
+import re
+
+mappings = OrderedDict([
+    ('--name', 'name'),
+    ('--version', 'version'),
+    ('--compatibility-version', 'compatibilityVersion'),
+    ('--system', 'system'),
+    ('--system-version', 'systemVersion'),
+    ('--nr-of-cpus', 'nrOfCpus'),
+    ('--memory', 'memory'),
+    ('--disk-space', 'diskSpace'),
+    ('--roles', 'roles')
+])
+
+
+def detect_format_dir(dir):
+    """
+    Detects the format of a directory on disk.
+    :param dir:
+    :return: one of 'docker', 'oci-image', or None
+    """
+    if \
+            os.path.isfile(os.path.join(dir, 'oci-layout')) and \
+            os.path.isdir(os.path.join(dir, 'refs')) and \
+            os.path.isdir(os.path.join(dir, 'blobs')):
+        return 'oci-image'
+    elif \
+            os.path.isfile(os.path.join(dir, 'repositories')) and \
+            os.path.isfile(os.path.join(dir, 'manifest.json')):
+        return 'docker'
+    else:
+        return None
+
+
+def detect_format_stream(initial_chunk):
+    def try_match(pattern, slice):
+        try:
+            return not not re.match(pattern, slice.decode('UTF-8'))
+        except UnicodeError:
+            # we're attempting to decode binary data as UTF8 to check for certain markers,
+            # but it's possible we aren't actually given UTF8 data so in that case the
+            # decode calls above will throw a UnicodeError.
+
+            return False
+
+    """
+    Detects the format of a stream given some initial chunk of data. This is fairly crude
+    but does work pretty well with detecting `docker save` streams. OCI detection may need
+    to be expanded as the tooling matures.
+
+    :param initial_chunk:
+    :return: one of 'docker', 'oci-image', or None
+    """
+    if try_match('^[0-9a-f]{64}[/]', initial_chunk[0:65]):
+        # docker save <image>
+        return 'docker'
+    elif try_match('^[0-9a-f]{64}[.]json$', initial_chunk[0:69]):
+        # docker save <image>:<tag>
+        return 'docker'
+    elif b'/oci-layout\x00\x00\x00' in initial_chunk and b'/refs/\x00\x00\x00' in initial_chunk:
+        # tar c on an oci folder (somewhat unreliable)
+        return 'oci-image'
+    elif b'/manifest.json\x00\x00\x00' in initial_chunk and b'/layer.tar\x00\x00\x00' in initial_chunk:
+        # tar c on a docker folder (somewhat unreliable)
+        return 'docker'
+    else:
+        return None
+
+
+def load_bundle_args_into_conf(config, args):
+    if args.name is not None:
+        config.put('name', args.name)
+
+    for argument, bundle_key in mappings.items():
+        value = getattr(args, bundle_key, None)
+
+        if value is not None:
+            config.put(bundle_key, value)
+
+    if 'roles' not in config:
+        config.put('roles', [])
+
+
+def file_write_bytes(path, bs):
+    with open(path, 'wb') as file:
+        file.write(bs)
+
+
+class DigestReaderWriter(object):
+    def __init__(self, fileobj):
+        self.digest_in = hashlib.sha256()
+        self.digest_out = hashlib.sha256()
+        self.fileobj = fileobj
+        self.size_in = 0
+        self.size_out = 0
+
+    def read(self, size):
+        data = self.fileobj.read(size)
+
+        self.digest_in.update(data)
+        self.size_in += len(data)
+
+        return data
+
+    def write(self, data):
+        length = self.fileobj.write(data)
+
+        self.digest_out.update(data)
+        self.size_out += len(data)
+
+        return length

--- a/conductr_cli/constants.py
+++ b/conductr_cli/constants.py
@@ -1,5 +1,8 @@
 import os
 
+# Preload this much data in the bndl tool to determine input type of a stream
+BNDL_PEEK_SIZE = 16384
+
 CONDUCTR_SCHEME = 'CONDUCTR_SCHEME'
 
 DEFAULT_SCHEME = os.getenv(CONDUCTR_SCHEME, 'http')

--- a/conductr_cli/test/cli_test_case.py
+++ b/conductr_cli/test/cli_test_case.py
@@ -94,6 +94,18 @@ def create_temp_bundle_with_contents(contents):
     return tmpdir, shutil.make_archive(os.path.join(tmpdir, 'bundle'), 'zip', unpacked, 'bundle-1.0.0')
 
 
+def create_attributes_object(obj):
+    class Empty(object):
+        pass
+
+    ins = Empty()
+
+    for key in obj:
+        setattr(ins, key, obj[key])
+
+    return ins
+
+
 def create_temp_bundle(bundle_conf):
     return create_temp_bundle_with_contents({'bundle.conf': bundle_conf, 'password.txt': 'monkey'})
 

--- a/conductr_cli/test/test_bndl_create.py
+++ b/conductr_cli/test/test_bndl_create.py
@@ -1,0 +1,145 @@
+from conductr_cli import bndl_create, logging_setup
+from conductr_cli.test.cli_test_case import CliTestCase, create_attributes_object, as_error
+from io import BytesIO
+from unittest.mock import patch, MagicMock
+import os
+import shutil
+import tempfile
+import zipfile
+
+
+class TestBndlCreate(CliTestCase):
+    def test_no_format(self):
+        attributes = create_attributes_object({
+            'source': None,
+            'format': None,
+            'tag': 'latest',
+            'output': None
+        })
+
+        stdout_mock = MagicMock()
+        stderr_mock = MagicMock()
+        logging_setup.configure_logging(MagicMock(), stdout_mock, stderr_mock)
+
+        with \
+                patch('sys.stdin', MagicMock(**{'buffer': BytesIO(b'')})), \
+                patch('sys.stdout.buffer', stdout_mock):
+            bndl_create.bndl_create(attributes)
+
+        self.assertEqual(
+            self.output(stderr_mock),
+            as_error('Error: bndl: Unable to detect format. Provide a -f or --format argument\n')
+        )
+
+    def test_not_oci(self):
+        tmpdir = tempfile.mkdtemp()
+
+        with tempfile.NamedTemporaryFile() as output:
+            attributes = create_attributes_object({
+                'name': 'test',
+                'source': tmpdir,
+                'format': 'oci-image',
+                'tag': 'latest',
+                'output': output.name
+            })
+
+        stdout_mock = MagicMock()
+        stderr_mock = MagicMock()
+        logging_setup.configure_logging(MagicMock(), stdout_mock, stderr_mock)
+
+        with \
+                patch('sys.stdin', MagicMock(**{'buffer': BytesIO(b'')})), \
+                patch('sys.stdout.buffer', stdout_mock):
+            bndl_create.bndl_create(attributes)
+
+        self.assertEqual(
+            self.output(stderr_mock),
+            as_error('Error: bndl: Not an OCI Image\n')
+        )
+
+    def test_no_ref(self):
+        tmpdir = tempfile.mkdtemp()
+
+        with tempfile.NamedTemporaryFile() as output:
+            attributes = create_attributes_object({
+                'name': 'test',
+                'source': tmpdir,
+                'format': 'oci-image',
+                'tag': 'latest',
+                'output': output.name
+            })
+
+        stdout_mock = MagicMock()
+        stderr_mock = MagicMock()
+        logging_setup.configure_logging(MagicMock(), stdout_mock, stderr_mock)
+
+        os.mkdir(os.path.join(tmpdir, 'refs'))
+        open(os.path.join(tmpdir, 'oci-layout'), 'w').close()
+
+        with \
+                patch('sys.stdin', MagicMock(**{'buffer': BytesIO(b'')})), \
+                patch('sys.stdout.buffer', stdout_mock):
+            bndl_create.bndl_create(attributes)
+
+        self.assertEqual(
+            self.output(stderr_mock),
+            as_error('Error: bndl: Invalid OCI Image. Cannot find requested tag "latest" in OCI Image\n')
+        )
+
+    def test_with_shazar(self):
+        stdout_mock = MagicMock()
+        tmpdir = tempfile.mkdtemp()
+        tmpfile = os.path.join(tmpdir, 'output')
+
+        try:
+            attributes = create_attributes_object({
+                'name': 'test',
+                'source': tmpdir,
+                'format': 'oci-image',
+                'tag': 'latest',
+                'output': tmpfile,
+                'component_description': '',
+                'use_shazar': True
+            })
+
+            os.mkdir(os.path.join(tmpdir, 'refs'))
+            open(os.path.join(tmpdir, 'oci-layout'), 'w').close()
+            open(os.path.join(tmpdir, 'refs/latest'), 'w').close()
+
+            with \
+                    patch('sys.stdin', MagicMock(**{'buffer': BytesIO(b'')})), \
+                    patch('sys.stdout.buffer', stdout_mock):
+                self.assertEqual(bndl_create.bndl_create(attributes), 0)
+
+            self.assertTrue(zipfile.is_zipfile(tmpfile))
+        finally:
+            shutil.rmtree(tmpdir)
+
+    def test_without_shazar(self):
+        stdout_mock = MagicMock()
+        tmpdir = tempfile.mkdtemp()
+        tmpfile = os.path.join(tmpdir, 'output')
+
+        try:
+            attributes = create_attributes_object({
+                'name': 'test',
+                'source': tmpdir,
+                'format': 'oci-image',
+                'tag': 'latest',
+                'output': tmpfile,
+                'component_description': '',
+                'use_shazar': False
+            })
+
+            os.mkdir(os.path.join(tmpdir, 'refs'))
+            open(os.path.join(tmpdir, 'oci-layout'), 'w').close()
+            open(os.path.join(tmpdir, 'refs/latest'), 'w').close()
+
+            with \
+                    patch('sys.stdin', MagicMock(**{'buffer': BytesIO(b'')})), \
+                    patch('sys.stdout.buffer', stdout_mock):
+                self.assertEqual(bndl_create.bndl_create(attributes), 0)
+
+            self.assertFalse(zipfile.is_zipfile(tmpfile))
+        finally:
+            shutil.rmtree(tmpdir)

--- a/conductr_cli/test/test_bndl_docker.py
+++ b/conductr_cli/test/test_bndl_docker.py
@@ -1,0 +1,169 @@
+from conductr_cli import bndl_docker
+from conductr_cli.test.cli_test_case import CliTestCase
+from io import BytesIO
+import json
+import os
+import shutil
+import tarfile
+import tempfile
+
+
+class TestBndlDocker(CliTestCase):
+    def test_docker_parse_cmd(self):
+        self.assertEqual(
+            bndl_docker.docker_parse_cmd('CMD /bin/bash test.sh'),
+            ['/bin/bash', 'test.sh']
+        )
+
+        self.assertEqual(
+            bndl_docker.docker_parse_cmd('CMD [/bin/bash test.sh]'),
+            ['/bin/bash', 'test.sh']
+        )
+
+        self.assertEqual(
+            bndl_docker.docker_parse_cmd('CMD ["hello", "world"]'),
+            ['hello', 'world']
+        )
+
+        self.assertEqual(
+            bndl_docker.docker_parse_cmd('CMD ["hello world"]'),
+            ['hello world']
+        )
+
+        self.assertEqual(
+            bndl_docker.docker_parse_cmd('CMD hello\\ world'),
+            ['hello world']
+        )
+
+        self.assertEqual(
+            bndl_docker.docker_parse_cmd('CMD ["quoted" "no" "commas"]'),
+            ['quoted', 'no', 'commas']
+        )
+
+        self.assertEqual(
+            bndl_docker.docker_parse_cmd('CMD ["escaped \\"quote\\""]'),
+            ['escaped "quote"']
+        )
+
+        self.assertEqual(
+            bndl_docker.docker_parse_cmd('CMD ["weird"quotes""]'),
+            ['weird', 'quotes', '']
+        )
+
+        self.assertEqual(
+            bndl_docker.docker_parse_cmd('CMD [hello, "mismatched quote add anyways]'),
+            ['hello', 'mismatched quote add anyways']
+        )
+
+    def test_docker_parse_image_name(self):
+        self.assertEqual(bndl_docker.docker_parse_image_name('alpine:latest'), ('alpine', 'latest'))
+        self.assertEqual(bndl_docker.docker_parse_image_name('lightbend/conductr:2'), ('conductr', '2'))
+
+        with self.assertRaises(ValueError):
+            bndl_docker.docker_parse_image_name('alpine')
+
+    def test_docker_tag_matches(self):
+        self.assertTrue(bndl_docker.docker_image_name_matches('conductr', None, 'conductr:latest'))
+        self.assertFalse(bndl_docker.docker_image_name_matches('sherpa', None, 'conductr:latest'))
+        self.assertTrue(bndl_docker.docker_image_name_matches('conductr', None, 'lightbend/conductr:latest'))
+        self.assertFalse(bndl_docker.docker_image_name_matches('conductr', None, 'lightbend/sherpa:latest'))
+        self.assertTrue(bndl_docker.docker_image_name_matches('conductr', 'latest', 'conductr:latest'))
+        self.assertTrue(bndl_docker.docker_image_name_matches('conductr', 'latest', 'lightbend/conductr:latest'))
+        self.assertFalse(bndl_docker.docker_image_name_matches('conductr', 'oldest', 'conductr:latest'))
+        self.assertFalse(bndl_docker.docker_image_name_matches('conductr', 'oldest', 'lightbend/conductr:latest'))
+        self.assertFalse(bndl_docker.docker_image_name_matches('conductr', 'latest', 'conductr:oldest'))
+        self.assertFalse(bndl_docker.docker_image_name_matches('conductr', 'latest', 'lightbend/conductr:oldest'))
+
+    def test_docker_config_to_oci_image(self):
+        data = bndl_docker.docker_config_to_oci_image(
+            manifest={
+                'Config': '4a415e3663882fbc554ee830889c68a33b3585503892cc718a4698e91ef2a526.json',
+                'RepoTags': ['alpine:latest'],
+                'Layers': [
+                    '693bdf455e7bf0952f8a4539f9f96aa70c489ca239a7dbed0afb481c87cbe131/layer.tar'
+                ]
+            },
+            config={
+                'created': '2017-01-13T22:50:56.415736637Z',
+                'os': 'linux',
+                'architecture': 'amd64',
+                'history': [{'created': '2017-01-13T22:50:55.903893599Z', 'created_by': '/bin/sh'}],
+                'rootfs': {
+                    'type': 'layers',
+                    'diff_ids': [
+                        'sha256:98c944e98de8d35097100ff70a31083ec57704be0991a92c51700465e4544d08'
+                    ]
+                },
+                'config': {
+                    'Env': ['TEST=123'],
+                    'Cmd': ['/bin']
+                }
+            },
+            sizes={'some digest': 1234},
+            layers_to_digests={
+                '693bdf455e7bf0952f8a4539f9f96aa70c489ca239a7dbed0afb481c87cbe131/layer.tar': 'some digest'
+            }
+        )
+
+        self.assertEqual(json.loads(data['config'].decode('UTF-8')), {
+            'rootfs': {
+                'type': 'layers',
+                'diff_ids': ['sha256:98c944e98de8d35097100ff70a31083ec57704be0991a92c51700465e4544d08']
+            },
+            'created': '2017-01-13T22:50:56.415736637Z',
+            'history': [{'created': '2017-01-13T22:50:55.903893599Z', 'created_by': '/bin/sh'}],
+            'config': {
+                'Cmd': ['/bin'],
+                'Env': ['TEST=123']
+            },
+            'os': 'linux',
+            'architecture': 'amd64'
+        })
+
+        self.assertEqual(json.loads(data['manifest'].decode('UTF-8')), {
+            'layers': [{
+                'digest': 'sha256:some digest',
+                'size': 1234,
+                'mediaType': 'application/vnd.oci.image.layer.v1.tar+gzip'
+            }],
+            'config': {
+                'digest': 'sha256:d1cbc4434ff3dc404a0fe22c7c2d232edb3bf39ced50952144924570878ea043',
+                'size': 339,
+                'mediaType': 'application/vnd.oci.image.config.v1+json'
+            },
+            'schemaVersion': 2
+        })
+
+        self.assertEqual(json.loads(data['refs'].decode('UTF-8')), {
+            'digest': 'sha256:9dadab903288242e1732b4a4f038d5a9ce57c1e0a9e1398093e7ba1ddd13357d',
+            'mediaType': 'application/vnd.oci.image.manifest.v1+json',
+            'size': 307
+        })
+
+    def test_docker_unpack_tar_wrong_format(self):
+        file = tempfile.NamedTemporaryFile()
+        dest_tmpdir = tempfile.mkdtemp()
+
+        try:
+            with tarfile.open(fileobj=file, mode='w') as tar:
+                tar.addfile(tarfile.TarInfo('testing'), BytesIO(b'hello'))
+
+            file.seek(0)
+
+            with tarfile.open(fileobj=file, mode='r') as tar:
+                self.assertIsNone(bndl_docker.docker_unpack(dest_tmpdir, tar, False, None, None))
+        finally:
+            shutil.rmtree(dest_tmpdir)
+
+    def test_docker_unpack_dir_wrong_format(self):
+        tmpdir = tempfile.mkdtemp()
+        dest_tmpdir = tempfile.mkdtemp()
+
+        try:
+            with open(os.path.join(tmpdir, 'testing'), 'wb') as file:
+                file.write('hello'.encode('UTF-8'))
+
+            self.assertFalse(bndl_docker.docker_unpack(dest_tmpdir, tmpdir, True, None, None))
+        finally:
+            shutil.rmtree(tmpdir)
+            shutil.rmtree(dest_tmpdir)

--- a/conductr_cli/test/test_bndl_main.py
+++ b/conductr_cli/test/test_bndl_main.py
@@ -1,0 +1,201 @@
+from conductr_cli import bndl_main
+from conductr_cli.test.cli_test_case import CliTestCase, as_error
+from io import BytesIO
+from unittest.mock import patch, MagicMock
+import os
+import shutil
+import tempfile
+
+
+class TestBndl(CliTestCase):
+    parser = bndl_main.build_parser()
+
+    def test_parser_with_min_params(self):
+        args = self.parser.parse_args(['--name', 'hello', '-t', 'latest'])
+
+        self.assertEqual(args.func.__name__, 'bndl')
+        self.assertEqual(args.name, 'hello')
+        self.assertEqual(args.tag, 'latest')
+        self.assertTrue(args.use_shazar)
+
+    def test_parser_with_all_params(self):
+        args = self.parser.parse_args([
+            'oci-image-dir',
+            '--name',
+            'world',
+            '-t',
+            'earliest',
+            '-o',
+            '/dev/null',
+            '--no-shazar',
+            '--component-description',
+            'some description',
+            '--version',
+            '4',
+            '--compatibility-version',
+            '5',
+            '--system',
+            'myapp',
+            '--system-version',
+            '3',
+            '--nr-of-cpus',
+            '8',
+            '--memory',
+            '65536',
+            '--disk-space',
+            '16384',
+            '--roles',
+            'web',
+            'backend'
+        ])
+
+        self.assertEqual(args.source, 'oci-image-dir')
+        self.assertEqual(args.func.__name__, 'bndl')
+        self.assertEqual(args.name, 'world')
+        self.assertEqual(args.tag, 'earliest')
+        self.assertEqual(args.output, '/dev/null')
+        self.assertFalse(args.use_shazar)
+        self.assertEqual(args.component_description, 'some description')
+        self.assertEqual(args.version, '4')
+        self.assertEqual(args.compatibilityVersion, '5')
+        self.assertEqual(args.system, 'myapp')
+        self.assertEqual(args.systemVersion, '3')
+        self.assertEqual(args.nrOfCpus, 8.0)
+        self.assertEqual(args.memory, 65536)
+        self.assertEqual(args.diskSpace, 16384)
+        self.assertEqual(args.roles, ['web', 'backend'])
+
+    def test_parser_no_args(self):
+        args = self.parser.parse_args([])
+
+        self.assertEqual(args.func.__name__, 'bndl')
+        self.assertTrue(args.use_shazar)
+
+    def test_run_dash_rewrite(self):
+        bndl_mock = MagicMock()
+        exit_mock = MagicMock()
+
+        with \
+                patch('conductr_cli.bndl_main.bndl', bndl_mock), \
+                patch('sys.exit', exit_mock):
+            bndl_main.run(['-o', '-', '-'])
+
+        self.assertEqual(bndl_mock.call_count, 1)
+        self.assertIsNone(bndl_mock.call_args[0][0].output)
+        self.assertIsNone(bndl_mock.call_args[0][0].source)
+
+    def test_bndl_oci_image_missing_args(self):
+        stdout_mock = MagicMock()
+        stderr_mock = MagicMock()
+        exit_mock = MagicMock()
+        configure_logging_mock = MagicMock()
+        bndl_main.logging_setup.configure_logging(MagicMock(), stdout_mock, stderr_mock)
+
+        with \
+                patch('sys.stdin', MagicMock(**{'buffer': BytesIO(b'')})), \
+                patch('sys.stdout.isatty', lambda: False), \
+                patch('conductr_cli.logging_setup.configure_logging', configure_logging_mock), \
+                patch('sys.exit', exit_mock):
+            bndl_main.run(['-f', 'oci-image'])
+
+        self.assertEqual(
+            self.output(stderr_mock),
+            as_error('Error: bndl: OCI Image support requires that you provide a --name argument\n')
+        )
+
+        exit_mock.assert_called_once_with(2)
+
+    def test_warn_output_tty(self):
+        stdout_mock = MagicMock()
+        stderr_mock = MagicMock()
+        exit_mock = MagicMock()
+        configure_logging_mock = MagicMock()
+        bndl_main.logging_setup.configure_logging(MagicMock(), stdout_mock, stderr_mock)
+
+        with \
+                patch('sys.stdin', MagicMock(**{'buffer': BytesIO(b''), 'isatty': MagicMock(return_value=False)})), \
+                patch('sys.stdout.isatty', lambda: True), \
+                patch('conductr_cli.logging_setup.configure_logging', configure_logging_mock), \
+                patch('sys.exit', exit_mock):
+            bndl_main.run(['--name', 'test', '--tag', 'latest'])
+
+        self.assertEqual(
+            self.output(stderr_mock),
+            as_error('Error: bndl: Refusing to write to terminal. Provide -o or redirect elsewhere\n')
+        )
+
+        exit_mock.assert_called_once_with(2)
+
+    def test_warn_bad_file(self):
+        stdout_mock = MagicMock()
+        stderr_mock = MagicMock()
+        exit_mock = MagicMock()
+        configure_logging_mock = MagicMock()
+        bndl_main.logging_setup.configure_logging(MagicMock(), stdout_mock, stderr_mock)
+
+        with \
+                patch('sys.stdin', MagicMock(**{'buffer': BytesIO(b'')})), \
+                patch('sys.stdout.isatty', lambda: False), \
+                patch('conductr_cli.logging_setup.configure_logging', configure_logging_mock), \
+                patch('sys.exit', exit_mock):
+            bndl_main.run(['--name', 'test', '-f', 'docker', '/some/file'])
+
+        self.assertEqual(
+            self.output(stderr_mock),
+            as_error('Error: bndl: Unable to read /some/file. Must be the path to a valid file or directory\n')
+        )
+
+        exit_mock.assert_called_once_with(2)
+
+    def test_warn_bad_oci_image_format_no_tag(self):
+        stdout_mock = MagicMock()
+        stderr_mock = MagicMock()
+        exit_mock = MagicMock()
+        configure_logging_mock = MagicMock()
+        bndl_main.logging_setup.configure_logging(MagicMock(), stdout_mock, stderr_mock)
+        temp = tempfile.mkdtemp()
+
+        try:
+            with \
+                    patch('sys.stdin', MagicMock(**{'buffer': BytesIO(b'')})), \
+                    patch('sys.stdout.isatty', lambda: False), \
+                    patch('conductr_cli.logging_setup.configure_logging', configure_logging_mock), \
+                    patch('sys.exit', exit_mock):
+                bndl_main.run(['--name', 'test', '-f', 'oci-image', '-t', 'latest', temp])
+
+            self.assertEqual(
+                self.output(stderr_mock),
+                as_error('Error: bndl: Not an OCI Image\n')
+            )
+
+            exit_mock.assert_called_once_with(2)
+        finally:
+            shutil.rmtree(temp)
+
+    def test_warn_bad_oci_image_format_no_layout(self):
+        stdout_mock = MagicMock()
+        stderr_mock = MagicMock()
+        exit_mock = MagicMock()
+        configure_logging_mock = MagicMock()
+        bndl_main.logging_setup.configure_logging(MagicMock(), stdout_mock, stderr_mock)
+        temp = tempfile.mkdtemp()
+
+        try:
+            os.mkdir(os.path.join(temp, 'refs'))
+            open(os.path.join(temp, 'refs/latest'), 'a').close()
+
+            with \
+                    patch('sys.stdin', MagicMock(**{'buffer': BytesIO(b'')})), \
+                    patch('sys.stdout.isatty', lambda: False), \
+                    patch('conductr_cli.logging_setup.configure_logging', configure_logging_mock), \
+                    patch('sys.exit', exit_mock):
+                bndl_main.run(['--name', 'test', '-f', 'oci-image', '-t', 'latest', temp])
+
+            self.assertEqual(
+                self.output(stderr_mock),
+                as_error('Error: bndl: Invalid OCI Image. Missing oci-layout\n')
+            )
+
+            exit_mock.assert_called_once_with(2)
+        finally:
+            shutil.rmtree(temp)

--- a/conductr_cli/test/test_bndl_oci.py
+++ b/conductr_cli/test/test_bndl_oci.py
@@ -1,0 +1,197 @@
+from conductr_cli import bndl_utils, bndl_oci
+from conductr_cli.test.cli_test_case import CliTestCase, create_attributes_object, strip_margin
+from io import BytesIO
+from pyhocon import ConfigFactory
+import os
+import shutil
+import tarfile
+import tempfile
+
+
+class TestBndlOci(CliTestCase):
+    def test_oci_image_unpack_tar_wrong_format(self):
+        file = tempfile.NamedTemporaryFile()
+        dest_tmpdir = tempfile.mkdtemp()
+
+        try:
+            with tarfile.open(fileobj=file, mode='w') as tar:
+                tar.addfile(tarfile.TarInfo('testing'), BytesIO(b'hello'))
+
+            file.seek(0)
+
+            with tarfile.open(fileobj=file, mode='r') as tar:
+                self.assertFalse(bndl_oci.oci_image_unpack(dest_tmpdir, tar, is_dir=False))
+        finally:
+            shutil.rmtree(dest_tmpdir)
+
+    def test_oci_image_unpack_dir_wrong_format(self):
+        tmpdir = tempfile.mkdtemp()
+        dest_tmpdir = tempfile.mkdtemp()
+
+        try:
+            with open(os.path.join(tmpdir, 'testing'), 'wb') as file:
+                file.write('hello'.encode('UTF-8'))
+
+            self.assertFalse(bndl_oci.oci_image_unpack(dest_tmpdir, tmpdir, is_dir=True))
+        finally:
+            shutil.rmtree(tmpdir)
+            shutil.rmtree(dest_tmpdir)
+
+    def test_oci_image_unpack_toplevel_tar(self):
+        file = tempfile.NamedTemporaryFile()
+        dest_tmpdir = tempfile.mkdtemp()
+
+        try:
+            with tarfile.open(fileobj=file, mode='w') as tar:
+                tar.addfile(tarfile.TarInfo('oci-layout'), BytesIO(b'hello'))
+
+            file.seek(0)
+
+            with tarfile.open(fileobj=file, mode='r') as tar:
+                self.assertTrue(bndl_oci.oci_image_unpack(dest_tmpdir, tar, is_dir=False))
+
+            self.assertTrue(os.path.exists(os.path.join(dest_tmpdir, 'oci-layout')))
+        finally:
+            shutil.rmtree(dest_tmpdir)
+
+    def test_oci_image_unpack_nested_tar(self):
+        file = tempfile.NamedTemporaryFile()
+        dest_tmpdir = tempfile.mkdtemp()
+
+        try:
+            with tarfile.open(fileobj=file, mode='w') as tar:
+                tar.addfile(tarfile.TarInfo('testing/nested/dirs/oci-layout'), BytesIO(b'hello'))
+
+            file.seek(0)
+
+            with tarfile.open(fileobj=file, mode='r') as tar:
+                self.assertTrue(bndl_oci.oci_image_unpack(dest_tmpdir, tar, is_dir=False))
+
+            self.assertTrue(os.path.exists(os.path.join(dest_tmpdir, 'oci-layout')))
+        finally:
+            shutil.rmtree(dest_tmpdir)
+
+    def test_oci_image_unpack_toplevel_dir(self):
+        tmpdir = tempfile.mkdtemp()
+        dest_tmpdir = tempfile.mkdtemp()
+
+        try:
+            with open(os.path.join(tmpdir, 'oci-layout'), 'wb') as file:
+                file.write('testing'.encode('UTF-8'))
+
+            self.assertTrue(bndl_oci.oci_image_unpack(dest_tmpdir, tmpdir, is_dir=True))
+
+            self.assertTrue(os.path.exists(os.path.join(dest_tmpdir, 'oci-layout')))
+        finally:
+            shutil.rmtree(tmpdir)
+            shutil.rmtree(dest_tmpdir)
+
+    def test_oci_image_unpack_nested_dir(self):
+        tmpdir = tempfile.mkdtemp()
+        dest_tmpdir = tempfile.mkdtemp()
+
+        try:
+            os.makedirs(os.path.join(tmpdir, 'testing', 'nested', 'dirs'))
+
+            with open(os.path.join(tmpdir, 'testing', 'nested', 'dirs', 'oci-layout'), 'wb') as file:
+                file.write('testing'.encode('UTF-8'))
+
+            self.assertTrue(bndl_oci.oci_image_unpack(dest_tmpdir, tmpdir, True))
+
+            self.assertTrue(os.path.exists(os.path.join(dest_tmpdir, 'oci-layout')))
+        finally:
+            shutil.rmtree(tmpdir)
+            shutil.rmtree(dest_tmpdir)
+
+    def test_oci_image_bundle_conf(self):
+        base_args = create_attributes_object({
+            'name': 'world',
+            'component_description': 'testing desc 1',
+            'tag': 'testing'
+        })
+
+        extended_args = create_attributes_object({
+            'name': 'world',
+            'component_description': 'testing desc 2',
+            'version': '4',
+            'compatibilityVersion': '5',
+            'system': 'myapp',
+            'systemVersion': '3',
+            'nrOfCpus': '8',
+            'memory': '65536',
+            'diskSpace': '16384',
+            'roles': ['web', 'backend'],
+            'tag': 'latest'
+        })
+
+        # test that config value is specified
+        simple_config = ConfigFactory.parse_string('')
+        bndl_utils.load_bundle_args_into_conf(simple_config, base_args)
+        self.assertEqual(simple_config.get('name'), 'world')
+
+        # test that config value is overwritten
+        name_config = ConfigFactory.parse_string('name = "hello"')
+        bndl_utils.load_bundle_args_into_conf(name_config, base_args)
+        self.assertEqual(name_config.get('name'), 'world')
+
+        # test that config value is retained
+        cpu_config = ConfigFactory.parse_string('nrOfCpus = 0.1')
+        bndl_utils.load_bundle_args_into_conf(cpu_config, base_args)
+        self.assertEqual(cpu_config.get('nrOfCpus'), 0.1)
+
+        config = ConfigFactory.parse_string('')
+        bndl_utils.load_bundle_args_into_conf(config, extended_args)
+
+        # test that various args are set correctly
+        self.assertEqual(config.get('name'), 'world')
+        self.assertEqual(config.get('version'), '4')
+        self.assertEqual(config.get('compatibilityVersion'), '5')
+        self.assertEqual(config.get('system'), 'myapp')
+        self.assertEqual(config.get('systemVersion'), '3')
+        self.assertEqual(config.get('nrOfCpus'), '8')
+        self.assertEqual(config.get('memory'), '65536')
+        self.assertEqual(config.get('diskSpace'), '16384')
+        self.assertEqual(config.get('roles'), ['web', 'backend'])
+        self.assertEqual(
+            bndl_oci.oci_image_bundle_conf(base_args, 'my-component'),
+            strip_margin('''|name = "world"
+                            |roles = []
+                            |components {
+                            |  my-component {
+                            |    description = "testing desc 1"
+                            |    file-system-type = "oci-image"
+                            |    start-command = [
+                            |      "ociImageTag"
+                            |      "testing"
+                            |    ]
+                            |    endpoints {}
+                            |  }
+                            |}''')
+        )
+
+        self.assertEqual(
+            bndl_oci.oci_image_bundle_conf(extended_args, 'my-other-component'),
+            strip_margin('''|name = "world"
+                            |version = "4"
+                            |compatibilityVersion = "5"
+                            |system = "myapp"
+                            |systemVersion = "3"
+                            |nrOfCpus = "8"
+                            |memory = "65536"
+                            |diskSpace = "16384"
+                            |roles = [
+                            |  "web"
+                            |  "backend"
+                            |]
+                            |components {
+                            |  my-other-component {
+                            |    description = "testing desc 2"
+                            |    file-system-type = "oci-image"
+                            |    start-command = [
+                            |      "ociImageTag"
+                            |      "latest"
+                            |    ]
+                            |    endpoints {}
+                            |  }
+                            |}''')
+        )

--- a/conductr_cli/test/test_bndl_utils.py
+++ b/conductr_cli/test/test_bndl_utils.py
@@ -1,0 +1,90 @@
+from conductr_cli import bndl_utils
+from conductr_cli.test.cli_test_case import CliTestCase
+from io import BytesIO
+import os
+import shutil
+import tempfile
+
+
+class TestBndlUtils(CliTestCase):
+    def test_detect_format_stream(self):
+        # empty stream is none
+        self.assertEqual(
+            bndl_utils.detect_format_stream(b''),
+            None
+        )
+
+        # unrelated stream is none
+        self.assertEqual(
+            bndl_utils.detect_format_stream(b'hello world this is a test'),
+            None
+        )
+
+        # docker save without tag starts with a hex digest tar dir entry
+        self.assertEqual(
+            bndl_utils.detect_format_stream(b'194853445611786369d26c17093e481cdc14c838375091037f780fe22aa760e7/'
+                                            b'\x00\x00\x00'),
+            'docker'
+        )
+
+        # docker save with a tag starts with a json tar file entry
+        self.assertEqual(
+            bndl_utils.detect_format_stream(b'4a415e3663882fbc554ee830889c68a33b3585503892cc718a4698e91ef2a526.json'
+                                            b'\x00\x00\x00'),
+            'docker'
+        )
+
+        # docker from a tar stream of a dir on disk, we just hope the order works out
+        self.assertEqual(
+            bndl_utils.detect_format_stream(b'\x00/manifest.json\x00\x00\x00/layer.tar\x00\x00\x00'),
+            'docker'
+        )
+
+        # oci image from a tar stream of a dir on disk, we just hope the order works out
+        self.assertEqual(
+            bndl_utils.detect_format_stream(b'\x00/oci-layout\x00\x00\x00/refs/\x00\x00\x00'),
+            'oci-image'
+        )
+
+    def test_detect_format_dir(self):
+        docker_dir = tempfile.mkdtemp()
+        oci_image_dir = tempfile.mkdtemp()
+        nothing_dir = tempfile.mkdtemp()
+
+        try:
+            os.mkdir(os.path.join(oci_image_dir, 'refs'))
+            os.mkdir(os.path.join(oci_image_dir, 'blobs'))
+
+            open(os.path.join(oci_image_dir, 'oci-layout'), 'a').close()
+            open(os.path.join(docker_dir, 'repositories'), 'a').close()
+            open(os.path.join(docker_dir, 'manifest.json'), 'a').close()
+            open(os.path.join(nothing_dir, 'hello'), 'a').close()
+
+            self.assertEqual(bndl_utils.detect_format_dir(oci_image_dir), 'oci-image')
+            self.assertEqual(bndl_utils.detect_format_dir(docker_dir), 'docker')
+            self.assertEqual(bndl_utils.detect_format_dir(nothing_dir), None)
+        finally:
+            shutil.rmtree(docker_dir)
+            shutil.rmtree(oci_image_dir)
+            shutil.rmtree(nothing_dir)
+
+    def test_digest_reader_writer(self):
+        data = b'some data'
+        digest = '1307990e6ba5ca145eb35e99182a9bec46531bc54ddf656a602c780fa0240dee'
+        digest_empty = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+
+        bytes_io = BytesIO(data)
+
+        reader = bndl_utils.DigestReaderWriter(bytes_io)
+        writer = bndl_utils.DigestReaderWriter(BytesIO())
+
+        shutil.copyfileobj(reader, writer)
+
+        self.assertEqual(reader.digest_in.hexdigest(), digest)
+        self.assertEqual(reader.digest_out.hexdigest(), digest_empty)
+        self.assertEqual(reader.size_in, 9)
+        self.assertEqual(reader.size_out, 0)
+        self.assertEqual(writer.digest_in.hexdigest(), digest_empty)
+        self.assertEqual(writer.digest_out.hexdigest(), digest)
+        self.assertEqual(writer.size_in, 0)
+        self.assertEqual(writer.size_out, 9)

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires = [
     'requests-toolbelt>=0.7.0',
     'argcomplete>=0.8.1',
     'psutil>=5.0.1, <6.0',
-    'pyhocon==0.2.1',
+    'pyhocon==0.3.35',
     'arrow>=0.6.0',
     'colorama>=0.3.7',
 
@@ -69,6 +69,7 @@ setup(
             'conduct = conductr_cli.conduct:run',
             'sandbox = conductr_cli.sandbox:run',
             'shazar = conductr_cli.shazar:run',
+            'bndl = conductr_cli.bndl:run',
         ],
     },
 


### PR DESCRIPTION
This PR implements `bndl`, a tool used to create and modify ConductR bundles. It currently handles input formats of `docker` and `oci-image` in both directory format (provided via `source` argument) and tar input stream (provided via `stdin` or `source` argument) It could fairly easily be extended in the future to support format `conductr`.

It auto-detects input based on some heuristics derived from `docker save` tar stream format as well as presence of certain files in the beginning of the stream or on disk. The format detection isn't bullet-proof but seems to work well enough for now. If it can't detect, a `-f` flag exists so you can explicitly tell it the format, but this shouldn't need to be used often. 

It uses the first `ref` or `tag` it comes across if the `--tag` argument isn't specified. This is typically `latest` for streams coming from `docker save`. If need be, a specific selection can be provided through that argument, i.e. `-t latest`.

If a `-o` argument is provided, output is written to the provided file. Otherwise, output is streamed to `stdout` similar to how `shazar` now operates.

Unless a `--no-shazar` argument is provided, `bndl` outputs in an already shazared format, thus allowing it to be piped directly to `conduct load`.

It currently uses a temporary directory to assemble the bundle and a temporary file to build a zip but conceptually this could be improved in the future to immediately start writing to stdout (ala streaming) if certain conditions are met.