### PR TITLE
Download license from Lightbend.com

### DIFF
--- a/conductr_cli/conduct_load_license.py
+++ b/conductr_cli/conduct_load_license.py
@@ -8,6 +8,7 @@ import os
 @validation.handle_connection_error
 @validation.handle_http_error
 @validation.handle_license_load_error
+@validation.handle_license_download_error
 def load_license(args):
     log = logging.getLogger(__name__)
 
@@ -24,7 +25,6 @@ def load_license(args):
         if args.offline_mode:
             log.info('Skipping downloading license from Lightbend.com')
         else:
-            log.info('Downloading license from Lightbend.com')
             license.download_license(args, save_to=license_file)
 
         if os.path.exists(license_file):

--- a/conductr_cli/conduct_main.py
+++ b/conductr_cli/conduct_main.py
@@ -8,7 +8,7 @@ from conductr_cli.constants import \
     DEFAULT_SCHEME, DEFAULT_PORT, DEFAULT_BASE_PATH, \
     DEFAULT_API_VERSION, DEFAULT_DCOS_SERVICE, DEFAULT_CLI_SETTINGS_DIR, \
     DEFAULT_CUSTOM_SETTINGS_FILE, DEFAULT_CUSTOM_PLUGINS_DIR, DEFAULT_BUNDLE_RESOLVE_CACHE_DIR, \
-    DEFAULT_CONFIGURATION_RESOLVE_CACHE_DIR, DEFAULT_WAIT_TIMEOUT, DEFAULT_OFFLINE_MODE
+    DEFAULT_CONFIGURATION_RESOLVE_CACHE_DIR, DEFAULT_WAIT_TIMEOUT, DEFAULT_OFFLINE_MODE, DEFAULT_LICENSE_DOWNLOAD_URL
 from dcos import config, constants
 
 from pathlib import Path
@@ -401,11 +401,16 @@ def build_parser(dcos_mode):
 
     add_dcos_mode_args(load_license_parser, dcos_mode)
     add_api_version(load_license_parser)
+    add_local_connection_flag(load_license_parser)
     add_offline_mode(load_license_parser)
     add_cli_settings_dir(load_license_parser)
     add_custom_settings_file(load_license_parser)
     add_custom_plugins_dir(load_license_parser)
     add_quiet_flag(load_license_parser)
+    load_license_parser.add_argument('--license-download-url',
+                                     dest='license_download_url',
+                                     help=argparse.SUPPRESS,
+                                     default=DEFAULT_LICENSE_DOWNLOAD_URL)
     load_license_parser.set_defaults(func=conduct_load_license.load_license)
 
     return parser

--- a/conductr_cli/constants.py
+++ b/conductr_cli/constants.py
@@ -33,8 +33,12 @@ DEFAULT_SANDBOX_PROXY_DIR = os.path.abspath(os.getenv('CONDUCTR_SANDBOX_PROXY_DI
 DEFAULT_SANDBOX_PROXY_CONTAINER_NAME = os.getenv('CONDUCTR_SANDBOX_PROXY_CONTAINER_NAME', 'sandbox-haproxy')
 DEFAULT_ERROR_LOG_FILE = os.path.abspath(os.getenv('CONDUCTR_CLI_ERROR_LOG',
                                                    '{}/errors.log'.format(DEFAULT_CLI_SETTINGS_DIR)))
+DEFAULT_LICENSE_DOWNLOAD_URL = os.getenv('CONDUCTR_LICENSE_DOWNLOAD_URL',
+                                         'https://www.lightbend.com/product/conductr/license')
 DEFAULT_LICENSE_FILE = os.path.abspath(os.getenv('CONDUCTR_LICENSE_FILE',
                                                  '{}/.lightbend/license'.format(os.path.expanduser('~'))))
+DEFAULT_AUTH_TOKEN_FILE = os.path.abspath(os.getenv('CONDUCTR_AUTH_TOKEN_FILE',
+                                                    '{}/.lightbend/auth-token'.format(os.path.expanduser('~'))))
 DEFAULT_WAIT_TIMEOUT = 60  # seconds
 
 # Must be able to hold the digest value, name of algorithm, and newline character

--- a/conductr_cli/exceptions.py
+++ b/conductr_cli/exceptions.py
@@ -189,3 +189,11 @@ class LicenseValidationError(Exception):
 
     def __str(self):
         return repr(os.linesep.join(self.messages))
+
+
+class LicenseDownloadError(Exception):
+    def __init__(self, messages):
+        self.messages = messages
+
+    def __str(self):
+        return repr(os.linesep.join(self.messages))

--- a/conductr_cli/license_auth.py
+++ b/conductr_cli/license_auth.py
@@ -1,0 +1,49 @@
+from conductr_cli.constants import DEFAULT_AUTH_TOKEN_FILE
+import os
+
+
+AUTH_TOKEN_PROMPT = 'An access token is required. Please visit https://www.lightbend.com/account/access-token to ' \
+                    'obtain your access token, and a free license or your commercial one.\n' \
+                    '\n' \
+                    'Please enter your access token: '
+
+
+def get_cached_auth_token():
+    """
+    Obtains cached token from local filesystem.
+    :return: cached token
+    """
+    if os.path.exists(DEFAULT_AUTH_TOKEN_FILE):
+        with open(DEFAULT_AUTH_TOKEN_FILE, 'r') as f:
+            auth_token = f.readline()
+    else:
+        auth_token = None
+
+    return auth_token
+
+
+def prompt_for_auth_token():
+    """
+    Prompts for cached token from the user. Reads the token stdin keyed in by the user
+    :return: cached token
+    """
+    print(AUTH_TOKEN_PROMPT, end='', flush=False)
+    auth_token = input()
+    return auth_token
+
+
+def remove_cached_auth_token():
+    """
+    Removes cached token from local filesystem.
+    """
+    if os.path.exists(DEFAULT_AUTH_TOKEN_FILE):
+        os.remove(DEFAULT_AUTH_TOKEN_FILE)
+
+
+def save_auth_token(auth_token):
+    """
+    Saves token into local filesystem.
+    :param auth_token: The auth token to be saved.
+    """
+    with open(DEFAULT_AUTH_TOKEN_FILE, 'w') as f:
+        f.write(auth_token)

--- a/conductr_cli/test/cli_test_case.py
+++ b/conductr_cli/test/cli_test_case.py
@@ -21,6 +21,8 @@ class CliTestCase(TestCase):
     def respond_with(status_code=200, text=''):
         reasons = {
             200: 'OK',
+            401: 'Unauthorized',
+            403: 'Forbidden',
             404: 'Not Found',
             500: 'Error',
             503: 'Service unavailable'

--- a/conductr_cli/test/test_conduct_main.py
+++ b/conductr_cli/test/test_conduct_main.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 from conductr_cli.conduct_main import build_parser, get_cli_parameters
+from conductr_cli.constants import DEFAULT_LICENSE_DOWNLOAD_URL
 from argparse import Namespace
 import os
 
@@ -108,7 +109,7 @@ class TestConduct(TestCase):
                 patch('sys.stderr.write', stderr):
             self.parser_tty.parse_args('load'.split())
 
-        self.assertEquals(print_usage_mock.call_count, 1)
+        self.assertEqual(print_usage_mock.call_count, 1)
         stderr.assert_called_once_with('conduct load: error: the following arguments are required: bundle\n')
         exit_mock.assert_called_with(2)
 
@@ -218,6 +219,8 @@ class TestConduct(TestCase):
         self.assertEqual(args.cli_settings_dir, '{}/.conductr'.format(os.path.expanduser('~')))
         self.assertEqual(args.custom_settings_file, '{}/.conductr/settings.conf'.format(os.path.expanduser('~')))
         self.assertEqual(args.custom_plugins_dir, '{}/.conductr/plugins'.format(os.path.expanduser('~')))
+        self.assertEqual(args.license_download_url, DEFAULT_LICENSE_DOWNLOAD_URL)
+        self.assertEqual(args.local_connection, True)
 
     def test_parser_load_license_custom_args(self):
         args = self.parser.parse_args('load-license '
@@ -227,7 +230,8 @@ class TestConduct(TestCase):
                                       '--api-version 1 '
                                       '--settings-dir /tmp '
                                       '--custom-settings-file /tmp/foo.conf '
-                                      '--custom-plugins-dir /tmp/plugins'.split())
+                                      '--custom-plugins-dir /tmp/plugins '
+                                      '--license-download-url http://example.org'.split())
 
         self.assertEqual(args.func.__name__, 'load_license')
         self.assertEqual(args.host, '127.0.0.1')
@@ -237,6 +241,8 @@ class TestConduct(TestCase):
         self.assertEqual(args.cli_settings_dir, '/tmp')
         self.assertEqual(args.custom_settings_file, '/tmp/foo.conf')
         self.assertEqual(args.custom_plugins_dir, '/tmp/plugins')
+        self.assertEqual(args.license_download_url, 'http://example.org')
+        self.assertEqual(args.local_connection, True)
 
     def test_default_with_dcos(self):
         dcos_parser = build_parser(True)

--- a/conductr_cli/test/test_license_auth.py
+++ b/conductr_cli/test/test_license_auth.py
@@ -1,0 +1,87 @@
+from conductr_cli import license_auth
+from conductr_cli.constants import DEFAULT_AUTH_TOKEN_FILE
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+import io
+import tempfile
+
+
+class TestGetCachedAuthToken(TestCase):
+    def test_cached_token_exists(self):
+        mock_exists = MagicMock(return_value=True)
+        cached_token = 'test cached token'
+        mock_open = MagicMock(return_value=io.StringIO(cached_token))
+
+        with patch('os.path.exists', mock_exists), \
+                patch('builtins.open', mock_open):
+            license_auth.get_cached_auth_token()
+
+        mock_exists.assert_called_once_with(DEFAULT_AUTH_TOKEN_FILE)
+        mock_open.assert_called_once_with(DEFAULT_AUTH_TOKEN_FILE, 'r')
+
+    def test_cached_token_missing(self):
+        mock_exists = MagicMock(return_value=False)
+        mock_open = MagicMock()
+
+        with patch('os.path.exists', mock_exists), \
+                patch('builtins.open', mock_open):
+            license_auth.get_cached_auth_token()
+
+        mock_exists.assert_called_once_with(DEFAULT_AUTH_TOKEN_FILE)
+        mock_open.assert_not_called()
+
+
+class TestPromptForAuthToken(TestCase):
+    def test_prompt_for_auth_token(self):
+        auth_token = 'test auth token'
+
+        mock_print = MagicMock()
+        mock_input = MagicMock(return_value=auth_token)
+
+        with patch('builtins.print', mock_print), \
+                patch('builtins.input', mock_input):
+            self.assertEqual(auth_token, license_auth.prompt_for_auth_token())
+
+        mock_print.assert_called_once_with(license_auth.AUTH_TOKEN_PROMPT, end='', flush=False)
+        mock_input.assert_called_once_with()
+
+
+class TestRemoveCachedAuthToken(TestCase):
+    def test_cached_token_exists(self):
+        mock_exists = MagicMock(return_value=True)
+        mock_remove = MagicMock()
+
+        with patch('os.path.exists', mock_exists), \
+                patch('os.remove', mock_remove):
+            license_auth.remove_cached_auth_token()
+
+        mock_exists.assert_called_once_with(DEFAULT_AUTH_TOKEN_FILE)
+        mock_remove.assert_called_once_with(DEFAULT_AUTH_TOKEN_FILE)
+
+    def test_cached_token_missing(self):
+        mock_exists = MagicMock(return_value=False)
+        mock_remove = MagicMock()
+
+        with patch('os.path.exists', mock_exists), \
+                patch('os.remove', mock_remove):
+            license_auth.remove_cached_auth_token()
+
+        mock_exists.assert_called_once_with(DEFAULT_AUTH_TOKEN_FILE)
+        mock_remove.assert_not_called()
+
+
+class TestSaveAuthToken(TestCase):
+    def test_save_auth_token(self):
+        with tempfile.NamedTemporaryFile() as f:
+            auth_token = 'test auth token'
+
+            open_temp_file = open(f.name, 'w')
+            mock_open = MagicMock(return_value=open_temp_file)
+
+            with patch('builtins.open', mock_open):
+                license_auth.save_auth_token(auth_token)
+
+            mock_open.assert_called_once_with(DEFAULT_AUTH_TOKEN_FILE, 'w')
+
+            with open(f.name, 'r') as d:
+                self.assertEqual([auth_token], d.readlines())

--- a/conductr_cli/validation.py
+++ b/conductr_cli/validation.py
@@ -16,7 +16,7 @@ from conductr_cli.exceptions import BindAddressNotFound, \
     WaitTimeoutError, InsecureFilePermissions, SandboxImageNotFoundError, JavaCallError, \
     JavaUnsupportedVendorError, JavaUnsupportedVersionError, JavaVersionParseError, DockerValidationError, \
     SandboxImageNotAvailableOfflineError, SandboxUnsupportedOsError, SandboxUnsupportedOsArchError, \
-    LicenseLoadError, LicenseValidationError, NOT_FOUND_ERROR
+    LicenseLoadError, LicenseValidationError, LicenseDownloadError, NOT_FOUND_ERROR
 
 
 def connection_error(log, err, args):
@@ -463,6 +463,24 @@ def handle_license_validation_error(func):
         except LicenseValidationError as e:
             log = get_logger_for_func(func)
             log.error('Unable to start ConductR due to license validation failure')
+            for message in e.messages:
+                log.error(message)
+            return False
+
+        # Do not change the wrapped function name,
+        # so argparse configuration can be tested.
+    handler.__name__ = func.__name__
+
+    return handler
+
+
+def handle_license_download_error(func):
+
+    def handler(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except LicenseDownloadError as e:
+            log = get_logger_for_func(func)
             for message in e.messages:
                 log.error(message)
             return False


### PR DESCRIPTION
Download license from Lightbend.com as part of `conduct load-license` command.

Cached auth token will be sent as OAuth2 Bearer token when requesting license from Lightbend.com.

If the cached auth token is not present, user will be prompted to enter the auth token along with the instruction on how to obtain the auth token. The entered token is cached for subsequent use.

If the token is expired or user has not accepted t&c, HTTP `401` and `403` is returned by the license download endpoint respectively. The response text from this endpoint will contain the instruction on how to proceed, and thus it will be presented to the user.

The command `conduct load-license` has additional switch `--license-download-url` to allow overriding the default download license endpoint URL. This option is not shown as part of help text however.