### PR TITLE
Update Bintray Webhook header

### DIFF
--- a/conductr_cli/conduct_deploy.py
+++ b/conductr_cli/conduct_deploy.py
@@ -52,7 +52,7 @@ def deploy(args):
     # HTTP headers required for deployment request
     hmac_digest = bundle_deploy.generate_hmac_signature(bintray_webhook_secret, resolved_version['package_name'])
     headers = {
-        'X-Bintray-WebHook-Hmac': hmac_digest
+        'X-Bintray-Hook-Hmac': hmac_digest
     }
 
     response = conduct_request.post(args.dcos_mode, conductr_host(args), url,

--- a/conductr_cli/test/test_conduct_deploy.py
+++ b/conductr_cli/test/test_conduct_deploy.py
@@ -67,7 +67,7 @@ class TestConductDeploy(CliTestCase):
                                          'package': 'cassandra',
                                          'version': 'v1-abcabc'
                                      },
-                                     headers={'X-Bintray-WebHook-Hmac': self.hmac_mock},
+                                     headers={'X-Bintray-Hook-Hmac': self.hmac_mock},
                                      auth=self.conductr_auth,
                                      verify=self.server_verification_file)
         wait_for_deployment_complete_mock.assert_called_with(self.deployment_id, self.resolved_version, input_args)
@@ -114,7 +114,7 @@ class TestConductDeploy(CliTestCase):
                                          'package': 'cassandra',
                                          'version': 'v1-abcabc'
                                      },
-                                     headers={'X-Bintray-WebHook-Hmac': self.hmac_mock},
+                                     headers={'X-Bintray-Hook-Hmac': self.hmac_mock},
                                      auth=self.conductr_auth,
                                      verify=self.server_verification_file)
         wait_for_deployment_complete_mock.assert_not_called()
@@ -161,7 +161,7 @@ class TestConductDeploy(CliTestCase):
                                          'package': 'cassandra',
                                          'version': 'v1-abcabc'
                                      },
-                                     headers={'X-Bintray-WebHook-Hmac': self.hmac_mock},
+                                     headers={'X-Bintray-Hook-Hmac': self.hmac_mock},
                                      auth=self.conductr_auth,
                                      verify=self.server_verification_file)
         wait_for_deployment_complete_mock.assert_called_with(self.deployment_id, self.resolved_version, input_args)
@@ -364,7 +364,7 @@ class TestConductDeploy(CliTestCase):
                                          'package': 'cassandra',
                                          'version': 'v1-abcabc'
                                      },
-                                     headers={'X-Bintray-WebHook-Hmac': self.hmac_mock},
+                                     headers={'X-Bintray-Hook-Hmac': self.hmac_mock},
                                      auth=self.conductr_auth,
                                      verify=self.server_verification_file)
         wait_for_deployment_complete_mock.assert_not_called()


### PR DESCRIPTION
This is to match Bintray's change to the webhook header name. The webhook header is now called `X-Bintray-Hook-Hmac`.