### PR TITLE
Export the stats port

### DIFF
--- a/conductr_cli/sandbox_proxy.py
+++ b/conductr_cli/sandbox_proxy.py
@@ -12,7 +12,7 @@ HAPROXY_DOCKER_IMAGE = 'haproxy:{}'.format(HAPROXY_VERSION)
 
 HAPROXY_CFG_DIR = '{}/haproxy'.format(DEFAULT_SANDBOX_PROXY_DIR)
 HAPROXY_CFG_PATH = '{}/haproxy.cfg'.format(HAPROXY_CFG_DIR)
-DEFAULT_PROXY_PORTS = [80, 443]  # These are the ports which will be opened by default to the proxy.
+DEFAULT_PROXY_PORTS = [80, 443, 8999]  # These are the ports which will be opened by default to the proxy.
 
 # This is the default config which will be supplied so HAProxy instance within Docker can be started.
 DEFAULT_HAPROXY_CFG_ENTRIES = 'defaults\n' \

--- a/conductr_cli/test/test_sandbox_proxy.py
+++ b/conductr_cli/test/test_sandbox_proxy.py
@@ -234,6 +234,7 @@ class TestStartDockerInstance(CliTestCase):
              '-p', '192.168.1.1:80:80',
              '-p', '192.168.1.1:443:443',
              '-p', '192.168.1.1:3003:3003',
+             '-p', '192.168.1.1:8999:8999',
              '-p', '192.168.1.1:9000:9000',
              '-p', '192.168.1.1:19001:19001',
              '-v', '{}:/usr/local/etc/haproxy:ro'.format(sandbox_proxy.HAPROXY_CFG_DIR)],
@@ -244,7 +245,7 @@ class TestStartDockerInstance(CliTestCase):
         expected_output = strip_margin("""||------------------------------------------------|
                                           || Starting HAProxy                               |
                                           ||------------------------------------------------|
-                                          |Exposing the following ports [80, 443, 3003, 9000, 19001]
+                                          |Exposing the following ports [80, 443, 3003, 8999, 9000, 19001]
                                           |""")
         self.assertEqual(expected_output, self.output(stdout))
 
@@ -272,6 +273,7 @@ class TestStartDockerInstance(CliTestCase):
              '-p', '192.168.1.1:443:443',
              '-p', '192.168.1.1:3000:3000',
              '-p', '192.168.1.1:3003:3003',
+             '-p', '192.168.1.1:8999:8999',
              '-p', '192.168.1.1:9000:9000',
              '-p', '192.168.1.1:19001:19001',
              '-v', '{}:/usr/local/etc/haproxy:ro'.format(sandbox_proxy.HAPROXY_CFG_DIR)],
@@ -282,7 +284,7 @@ class TestStartDockerInstance(CliTestCase):
         expected_output = strip_margin("""||------------------------------------------------|
                                           || Starting HAProxy                               |
                                           ||------------------------------------------------|
-                                          |Exposing the following ports [80, 443, 3000, 3003, 9000, 19001]
+                                          |Exposing the following ports [80, 443, 3000, 3003, 8999, 9000, 19001]
                                           |""")
         self.assertEqual(expected_output, self.output(stdout))
 
@@ -309,6 +311,7 @@ class TestStartDockerInstance(CliTestCase):
              '-p', '192.168.1.1:80:80',
              '-p', '192.168.1.1:443:443',
              '-p', '192.168.1.1:3003:3003',
+             '-p', '192.168.1.1:8999:8999',
              '-p', '192.168.1.1:9000:9000',
              '-p', '192.168.1.1:19001:19001',
              '-v', '{}:/usr/local/etc/haproxy:ro'.format(sandbox_proxy.HAPROXY_CFG_DIR)],
@@ -320,7 +323,7 @@ class TestStartDockerInstance(CliTestCase):
                                           || Starting HAProxy                               |
                                           ||------------------------------------------------|
                                           |Pulling docker image haproxy:1.5
-                                          |Exposing the following ports [80, 443, 3003, 9000, 19001]
+                                          |Exposing the following ports [80, 443, 3003, 8999, 9000, 19001]
                                           |""")
         self.assertEqual(expected_output, self.output(stdout))
 


### PR DESCRIPTION
As of ConductR 2.1, the stats port also requires exposure so that we can enable the HAProxy instrumentation.