### PR TITLE
Conduct Info now support inspecting bundle

### DIFF
--- a/conductr_cli/conduct_acls.py
+++ b/conductr_cli/conduct_acls.py
@@ -26,77 +26,66 @@ def acls(args):
     if log.is_verbose_enabled():
         log.verbose(validation.pretty_json(response.text))
 
-    def is_started(bundle_executions):
-        for execution in bundle_executions:
-            if execution['isStarted']:
-                return 'Running'
-        return 'Starting'
-
-    all_acls = [
-        {
-            'acl': acl,
-            'bundle_id': bundle['bundleId'] if args.long_ids else bundle_utils.short_id(bundle['bundleId']),
-            'bundle_name': bundle['attributes']['bundleName'],
-            'status': is_started(bundle['bundleExecutions'])
-        }
-        for bundle in json.loads(response.text) if bundle['bundleExecutions']
-        for endpoint_name, endpoint in bundle['bundleConfig']['endpoints'].items() if 'acls' in endpoint
-        for acl in endpoint['acls']
-    ]
+    bundles = json.loads(response.text)
+    all_acls, http_acls, tcp_acls = get_acls_from_bundles(args, bundles)
 
     if args.protocol_family == 'http':
-        http_acls = [acl for acl in all_acls if 'http' in acl['acl']]
         display_http_acls(log, http_acls)
 
     elif args.protocol_family == 'tcp':
-        tcp_acls = [acl for acl in all_acls if 'tcp' in acl['acl']]
         display_tcp_acls(log, tcp_acls)
 
     return True
 
 
-def display_tcp_acls(log, tcp_acls):
+def display_tcp_acls(log, tcp_acls, display_bundle_id=True, display_bundle_name=True, display_status=True):
     def tcp_port_value(line):
         return int(line['tcp_port'])
 
     data = [
         {
             'tcp_port': 'TCP/PORT',
-            'bundle_id': 'BUNDLE ID',
-            'bundle_name': 'BUNDLE NAME',
-            'status': 'STATUS'
+            'bundle_id': 'BUNDLE ID' if display_bundle_id else '',
+            'bundle_name': 'BUNDLE NAME' if display_bundle_name else '',
+            'status': 'STATUS' if display_status else ''
         }
     ] + sorted([
         {
             'tcp_port': tcp_port,
-            'bundle_id': tcp_acl['bundle_id'],
-            'bundle_name': tcp_acl['bundle_name'],
-            'status': tcp_acl['status']
+            'bundle_id': tcp_acl['bundle_id'] if display_bundle_id else '',
+            'bundle_name': tcp_acl['bundle_name'] if display_bundle_name else '',
+            'status': tcp_acl['status'] if display_status else ''
         }
         for tcp_acl in tcp_acls
         for tcp_port in tcp_acl['acl']['tcp']['requests']
     ], key=tcp_port_value)
 
+    display_template = '{tcp_port: <{tcp_port_width}}{padding}'
+    if display_bundle_id:
+        display_template += '{bundle_id: <{bundle_id_width}}{padding}'
+
+    if display_bundle_name:
+        display_template += '{bundle_name: <{bundle_name_width}}{padding}'
+
+    if display_status:
+        display_template += '{status: <{status_width}}'
+
     padding = 2
     column_widths = dict(screen_utils.calc_column_widths(data), **{'padding': ' ' * padding})
     for row in data:
-        log.screen(
-            '{tcp_port: <{tcp_port_width}}{padding}'
-            '{bundle_id: <{bundle_id_width}}{padding}'
-            '{bundle_name: <{bundle_name_width}}{padding}'
-            '{status: <{status_width}}'.format(**dict(row, **column_widths)).rstrip())
+        log.screen(display_template.format(**dict(row, **column_widths)).rstrip())
 
 
-def display_http_acls(log, http_acls):
+def display_http_acls(log, http_acls, display_bundle_id=True, display_bundle_name=True, display_status=True):
     http_request_mappings = [
         {
             'http_method': http_request_mapping['method'] if 'method' in http_request_mapping else ALL_HTTP_METHOD,
             'http_rewrite': http_request_mapping['rewrite'] if 'rewrite' in http_request_mapping else '',
             'http_acl': get_http_acl(http_request_mapping),
             'http_acl_type': get_http_acl_type(http_request_mapping),
-            'bundle_id': http_acl['bundle_id'],
-            'bundle_name': http_acl['bundle_name'],
-            'status': http_acl['status']
+            'bundle_id': http_acl['bundle_id'] if display_bundle_id else '',
+            'bundle_name': http_acl['bundle_name'] if display_bundle_name else '',
+            'status': http_acl['status'] if display_status else ''
         }
         for http_acl in http_acls
         for http_request_mapping in http_acl['acl']['http']['requests']
@@ -127,21 +116,51 @@ def display_http_acls(log, http_acls):
         'http_method': 'METHOD',
         'http_acl': 'PATH',
         'http_rewrite': 'REWRITE',
-        'bundle_id': 'BUNDLE ID',
-        'bundle_name': 'BUNDLE NAME',
-        'status': 'STATUS'
+        'bundle_id': 'BUNDLE ID' if display_bundle_id else '',
+        'bundle_name': 'BUNDLE NAME' if display_bundle_name else '',
+        'status': 'STATUS' if display_status else ''
     }] + http_path_regex_sorted + http_path_beg_sorted + http_path_sorted
 
     padding = 2
     column_widths = dict(screen_utils.calc_column_widths(data), **{'padding': ' ' * padding})
+
+    display_template = '{http_method: <{http_method_width}}{padding}' \
+                       '{http_acl: <{http_acl_width}}{padding}' \
+                       '{http_rewrite: <{http_rewrite_width}}{padding}'
+    if display_bundle_id:
+        display_template += '{bundle_id: <{bundle_id_width}}{padding}'
+    if display_bundle_name:
+        display_template += '{bundle_name: <{bundle_name_width}}{padding}'
+    if display_status:
+        display_template += '{status: <{status_width}}'
+
     for row in data:
-        log.screen(
-            '{http_method: <{http_method_width}}{padding}'
-            '{http_acl: <{http_acl_width}}{padding}'
-            '{http_rewrite: <{http_rewrite_width}}{padding}'
-            '{bundle_id: <{bundle_id_width}}{padding}'
-            '{bundle_name: <{bundle_name_width}}{padding}'
-            '{status: <{status_width}}'.format(**dict(row, **column_widths)).rstrip())
+        log.screen(display_template.format(**dict(row, **column_widths)).rstrip())
+
+
+def get_acls_from_bundles(args, bundles):
+    def is_started(bundle_executions):
+        for execution in bundle_executions:
+            if execution['isStarted']:
+                return 'Running'
+        return 'Starting'
+
+    all_acls = [
+        {
+            'acl': acl,
+            'bundle_id': bundle['bundleId'] if args.long_ids else bundle_utils.short_id(bundle['bundleId']),
+            'bundle_name': bundle['attributes']['bundleName'],
+            'status': is_started(bundle['bundleExecutions'])
+        }
+        for bundle in bundles if bundle['bundleExecutions']
+        for endpoint_name, endpoint in bundle['bundleConfig']['endpoints'].items() if 'acls' in endpoint
+        for acl in endpoint['acls']
+    ]
+
+    http_acls = [acl for acl in all_acls if 'http' in acl['acl']]
+    tcp_acls = [acl for acl in all_acls if 'tcp' in acl['acl']]
+
+    return all_acls, http_acls, tcp_acls
 
 
 def get_http_acl(http_request_mapping):

--- a/conductr_cli/conduct_info.py
+++ b/conductr_cli/conduct_info.py
@@ -1,6 +1,5 @@
-from conductr_cli import bundle_utils, conduct_request, conduct_url, license, validation, screen_utils
+from conductr_cli import conduct_info_inspect, conduct_info_list, conduct_request, conduct_url, validation
 from conductr_cli.conduct_url import conductr_host
-from conductr_cli.license import UNLICENSED_DISPLAY_TEXT
 import json
 import logging
 from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
@@ -21,72 +20,7 @@ def info(args):
         log.verbose(validation.pretty_json(response.text))
 
     bundles = json.loads(response.text)
-    if args.quiet:
-        display_quiet(args, bundles)
+    if args.bundle:
+        return conduct_info_inspect.display_bundle(args, bundles, args.bundle)
     else:
-        is_license_success, conductr_license = license.get_license(args)
-        display_default(args, is_license_success, conductr_license, bundles)
-
-    return True
-
-
-def display_default(args, is_license_success, conductr_license, bundles):
-    log = logging.getLogger(__name__)
-
-    if is_license_success:
-        license_formatted = license.format_license(conductr_license)
-        license_to_display = license_formatted if conductr_license['isLicensed'] \
-            else '{}\n{}'.format(UNLICENSED_DISPLAY_TEXT, license_formatted)
-
-        log.screen('{}\n'.format(license_to_display))
-
-    data = [
-        {
-            'id': display_bundle_id(args, bundle),
-            'name': bundle['attributes']['bundleName'],
-            'compatibility_version': 'v{}'.format(bundle['attributes']['compatibilityVersion']),
-            'roles': ', '.join(sorted(bundle['attributes']['roles'])),
-            'replications': len(bundle['bundleInstallations']),
-            'starting': sum([not execution['isStarted'] for execution in bundle['bundleExecutions']]),
-            'executions': sum([execution['isStarted'] for execution in bundle['bundleExecutions']])
-        } for bundle in bundles
-    ]
-    data.insert(0, {
-        'id': 'ID',
-        'name': 'NAME',
-        'compatibility_version': 'VER',
-        'roles': 'ROLES',
-        'replications': '#REP',
-        'starting': '#STR',
-        'executions': '#RUN'
-    })
-
-    padding = 2
-    column_widths = dict(screen_utils.calc_column_widths(data), **{'padding': ' ' * padding})
-    has_error = False
-    for row in data:
-        has_error |= '!' in row['id']
-        log.screen('''\
-{id: <{id_width}}{padding}\
-{name: <{name_width}}{padding}\
-{compatibility_version: >{compatibility_version_width}}{padding}\
-{replications: >{replications_width}}{padding}\
-{starting: >{starting_width}}{padding}\
-{executions: >{executions_width}}{padding}\
-{roles: <{roles_width}}'''.format(**dict(row, **column_widths)).rstrip())
-
-    if has_error:
-        log.screen('There are errors: use `conduct events` or `conduct logs` for further information')
-
-
-def display_quiet(args, bundles):
-    log = logging.getLogger(__name__)
-
-    for bundle in bundles:
-        log.screen(display_bundle_id(args, bundle))
-
-
-def display_bundle_id(args, bundle):
-    bundle_id = bundle['bundleId'] if args.long_ids else bundle_utils.short_id(bundle['bundleId'])
-    has_error_display = '! ' if bundle.get('hasError', False) else ''
-    return '{}{}'.format(has_error_display, bundle_id)
+        return conduct_info_list.display_bundles(args, bundles)

--- a/conductr_cli/conduct_info_common.py
+++ b/conductr_cli/conduct_info_common.py
@@ -1,0 +1,9 @@
+from conductr_cli import bundle_utils
+
+DISPLAY_PADDING = 2
+
+
+def display_bundle_id(args, bundle):
+    bundle_id = bundle['bundleId'] if args.long_ids else bundle_utils.short_id(bundle['bundleId'])
+    has_error_display = '! ' if bundle.get('hasError', False) else ''
+    return '{}{}'.format(has_error_display, bundle_id)

--- a/conductr_cli/conduct_info_inspect.py
+++ b/conductr_cli/conduct_info_inspect.py
@@ -1,0 +1,239 @@
+from conductr_cli import screen_utils, conduct_acls, conduct_service_names
+from conductr_cli.conduct_info_common import DISPLAY_PADDING, display_bundle_id
+from urllib.parse import urlparse
+import json
+import logging
+
+
+def display_bundle(args, bundles, bundle_id_or_name):
+    log = logging.getLogger(__name__)
+
+    bundles = filter_bundles_by_id_or_name(bundles, bundle_id_or_name)
+    if bundles and len(bundles) == 1:
+        bundle = bundles[0]
+
+        if log.is_verbose_enabled():
+            log.verbose(json.dumps(bundle, sort_keys=True, indent=2, separators=(',', ': ')))
+
+        display_bundle_properties(args, bundle)
+
+        return True
+    elif bundles and len(bundles) > 1:
+        found_bundle_ids = [
+            display_bundle_id(args, bundle)
+            for bundle in bundles
+        ]
+        log.error('Specified Bundle ID/name: {} resulted in multiple Bundle IDs: {}'.format(bundle_id_or_name,
+                                                                                            found_bundle_ids))
+        return False
+    else:
+        log.error('Unable to find bundle {}'.format(bundle_id_or_name))
+        return False
+
+
+def display_bundle_properties(args, bundle):
+    display_bundle_attributes(args, bundle)
+    display_bundle_scale(bundle)
+    display_bundle_installations(bundle)
+    display_bundle_executions(bundle)
+    display_bundle_config(args, bundle)
+
+
+def display_bundle_attributes(args, bundle):
+    display_key_value_table_with_title('BUNDLE ATTRIBUTES', [
+        ('Bundle Id', display_bundle_id(args, bundle)),
+        ('Bundle Name', bundle['attributes']['bundleName']),
+        ('Compatibility Version', bundle['attributes']['compatibilityVersion']
+            if 'compatibilityVersion' in bundle['attributes'] else None),
+        ('System', bundle['attributes']['system']),
+        ('System Version', bundle['attributes']['systemVersion'] if 'systemVersion' in bundle['attributes'] else None),
+        ('Nr of CPUs', bundle['attributes']['nrOfCpus']),
+        ('Memory', bundle['attributes']['memory']),
+        ('Disk Space', bundle['attributes']['diskSpace']),
+        ('Roles', ', '.join(sorted(bundle['attributes']['roles']))),
+        ('Bundle Digest', bundle['bundleDigest']),
+        ('Configuration Digest', bundle['configurationDigest'] if 'configurationDigest' in bundle else None),
+        ('Error', 'Yes' if bundle['hasError'] else 'No'),
+    ])
+
+
+def display_bundle_config(args, bundle):
+    all_acls, http_acls, tcp_acls = conduct_acls.get_acls_from_bundles(args, [bundle])
+    display_http_acls(http_acls)
+    display_tcp_acls(tcp_acls)
+
+    data, duplicate_endpoints = conduct_service_names.get_service_names_from_bundles(args, [bundle])
+    display_service_names(data, duplicate_endpoints)
+
+
+def display_http_acls(http_acls):
+    log = logging.getLogger(__name__)
+    if http_acls:
+        display_title_table('HTTP ACLS')
+        conduct_acls.display_http_acls(log, http_acls,
+                                       display_bundle_id=False,
+                                       display_bundle_name=False,
+                                       display_status=True)
+        log.screen('')
+
+
+def display_tcp_acls(tcp_acls):
+    log = logging.getLogger(__name__)
+
+    if tcp_acls:
+        display_title_table('TCP ACLS')
+        conduct_acls.display_tcp_acls(log, tcp_acls,
+                                      display_bundle_id=False,
+                                      display_bundle_name=False,
+                                      display_status=True)
+        log.screen('')
+
+
+def display_service_names(service_names, duplicate_endpoints):
+    log = logging.getLogger(__name__)
+
+    if service_names:
+        display_title_table('SERVICE NAMES')
+        conduct_service_names.display_service_names(log, service_names, duplicate_endpoints,
+                                                    display_bundle_id=False,
+                                                    display_bundle_name=False,
+                                                    display_status=True)
+        log.screen('')
+
+
+def display_bundle_installations(bundle):
+    def host_from_akka_address(akka_address):
+        return akka_address.split('@')[1].split(':')[0]
+
+    def get_path(file_uri):
+        parse = urlparse(file_uri)
+        if parse.scheme == '' or parse.scheme == 'file':
+            return parse.path
+        else:
+            return file_uri
+
+    if 'bundleInstallations' in bundle:
+        installations = bundle['bundleInstallations']
+        if installations:
+            display_title_table('BUNDLE INSTALLATIONS')
+
+            for installation in installations:
+                display_key_value_table([
+                    ('Host', host_from_akka_address(installation['uniqueAddress']['address'])),
+                    ('Bundle', get_path(installation['bundleFile'])),
+                    ('Bundle configuration', get_path(installation['configurationFile'])
+                        if 'configurationFile' in installation else None),
+                ])
+
+
+def display_bundle_executions(bundle):
+    log = logging.getLogger(__name__)
+
+    if 'bundleExecutions' in bundle and bundle['bundleExecutions']:
+        rows = sorted([
+            {
+                'endpoint': endpoint_name,
+                'host': bundle_execution['host'],
+                'is_started': 'Yes' if bundle_execution['isStarted'] else 'No',
+                'bind_port': endpoint_details['bindPort'],
+                'host_port': endpoint_details['hostPort']
+            }
+            for bundle_execution in bundle['bundleExecutions']
+            for endpoint_name, endpoint_details in bundle_execution['endpoints'].items()
+        ], key=lambda v: v['endpoint'])
+
+        if rows:
+            display_title_table('BUNDLE EXECUTIONS')
+
+            rows.insert(0, {
+                'endpoint': 'ENDPOINT',
+                'host': 'HOST',
+                'is_started': 'STARTED',
+                'bind_port': 'BIND_PORT',
+                'host_port': 'HOST_PORT',
+            })
+            column_widths = dict(screen_utils.calc_column_widths(rows), **{'padding': ' ' * DISPLAY_PADDING})
+            for row in rows:
+                log.screen('{endpoint: <{endpoint_width}}{padding}'
+                           '{host: <{host_width}}{padding}'
+                           '{is_started: >{is_started_width}}{padding}'
+                           '{bind_port: >{bind_port_width}}{padding}'
+                           '{host_port: >{host_port_width}}'.format(**dict(row, **column_widths)).rstrip())
+
+            log.screen('')
+
+
+def display_bundle_scale(bundle):
+    if 'bundleScale' in bundle:
+        if isinstance(bundle['bundleScale'], int):
+            display_key_value_table_with_title('BUNDLE SCALE', [
+                ('Scale', bundle['bundleScale']),
+            ])
+        else:
+            display_key_value_table_with_title('BUNDLE SCALE', [
+                ('Nr of Reschedules', bundle['bundleScale']['nrOfReschedules']
+                    if 'nrOfReschedules' in bundle['bundleScale'] else None),
+                ('Scale', bundle['bundleScale']['scale']),
+            ])
+
+
+def display_key_value_table_with_title(title, entries):
+    display_title_table(title)
+    display_key_value_table(entries)
+
+
+def display_key_value_table(entries):
+    log = logging.getLogger(__name__)
+    rows = [{'key': key, 'value': value} for key, value in entries if value is not None]
+
+    column_widths = dict(screen_utils.calc_column_widths(rows), **{'padding': ' ' * DISPLAY_PADDING})
+    for row in rows:
+        log.screen('''\
+{key: <{key_width}}{padding}\
+{value: <{value_width}}'''.format(**dict(row, **column_widths)).rstrip())
+
+    log.screen('')
+
+
+def display_title_table(title):
+    log = logging.getLogger(__name__)
+    log.screen(title)
+    title_separator = ''.join(['-' for x in title])
+    log.screen(title_separator)
+
+
+def filter_bundles_by_id_or_name(bundles, bundle_id_or_name):
+    return [
+        bundle
+        for bundle in bundles
+        if has_bundle_name(bundle, bundle_id_or_name) or has_bundle_id(bundle, bundle_id_or_name)
+    ]
+
+
+def has_bundle_name(bundle, bundle_name):
+    actual_name = bundle['attributes']['bundleName']
+    return actual_name == bundle_name or actual_name.startswith(bundle_name)
+
+
+def has_bundle_id(bundle, bundle_id):
+    actual_bundle_id = bundle['bundleId']
+    if actual_bundle_id == bundle_id:
+        return True
+    else:
+        if '-' in actual_bundle_id and '-' in bundle_id:
+            actual_bundle_id_parts = actual_bundle_id.split('-')
+            actual_bundle_digest = actual_bundle_id_parts[0]
+            actual_config_digest = actual_bundle_id_parts[1]
+
+            bundle_id_parts = bundle_id.split('-')
+            bundle_digest = bundle_id_parts[0]
+            config_digest = bundle_id_parts[1]
+
+            bundle_digest_matches = actual_bundle_digest == bundle_digest or \
+                actual_bundle_digest.startswith(bundle_digest)
+            config_digest_matches = actual_config_digest == config_digest or \
+                actual_config_digest.startswith(config_digest)
+
+            return bundle_digest_matches and config_digest_matches
+        else:
+            return actual_bundle_id.startswith(bundle_id)

--- a/conductr_cli/conduct_info_list.py
+++ b/conductr_cli/conduct_info_list.py
@@ -1,0 +1,69 @@
+from conductr_cli import license, screen_utils
+from conductr_cli.conduct_info_common import DISPLAY_PADDING, display_bundle_id
+from conductr_cli.license import UNLICENSED_DISPLAY_TEXT
+import logging
+
+
+def display_bundles(args, bundles):
+    if args.quiet:
+        display_bundles_quiet(args, bundles)
+    else:
+        is_license_success, conductr_license = license.get_license(args)
+        display_bundles_default(args, is_license_success, conductr_license, bundles)
+
+    return True
+
+
+def display_bundles_default(args, is_license_success, conductr_license, bundles):
+    log = logging.getLogger(__name__)
+
+    if is_license_success:
+        license_formatted = license.format_license(conductr_license)
+        license_to_display = license_formatted if conductr_license['isLicensed'] \
+            else '{}\n{}'.format(UNLICENSED_DISPLAY_TEXT, license_formatted)
+
+        log.screen('{}\n'.format(license_to_display))
+
+    data = [
+        {
+            'id': display_bundle_id(args, bundle),
+            'name': bundle['attributes']['bundleName'],
+            'compatibility_version': 'v{}'.format(bundle['attributes']['compatibilityVersion']),
+            'roles': ', '.join(sorted(bundle['attributes']['roles'])),
+            'replications': len(bundle['bundleInstallations']),
+            'starting': sum([not execution['isStarted'] for execution in bundle['bundleExecutions']]),
+            'executions': sum([execution['isStarted'] for execution in bundle['bundleExecutions']])
+        } for bundle in bundles
+    ]
+    data.insert(0, {
+        'id': 'ID',
+        'name': 'NAME',
+        'compatibility_version': 'VER',
+        'roles': 'ROLES',
+        'replications': '#REP',
+        'starting': '#STR',
+        'executions': '#RUN'
+    })
+
+    column_widths = dict(screen_utils.calc_column_widths(data), **{'padding': ' ' * DISPLAY_PADDING})
+    has_error = False
+    for row in data:
+        has_error |= '!' in row['id']
+        log.screen('''\
+{id: <{id_width}}{padding}\
+{name: <{name_width}}{padding}\
+{compatibility_version: >{compatibility_version_width}}{padding}\
+{replications: >{replications_width}}{padding}\
+{starting: >{starting_width}}{padding}\
+{executions: >{executions_width}}{padding}\
+{roles: <{roles_width}}'''.format(**dict(row, **column_widths)).rstrip())
+
+    if has_error:
+        log.screen('There are errors: use `conduct events` or `conduct logs` for further information')
+
+
+def display_bundles_quiet(args, bundles):
+    log = logging.getLogger(__name__)
+
+    for bundle in bundles:
+        log.screen(display_bundle_id(args, bundle))

--- a/conductr_cli/conduct_main.py
+++ b/conductr_cli/conduct_main.py
@@ -224,6 +224,11 @@ def build_parser(dcos_mode):
                                         help='Print bundle information',
                                         formatter_class=argparse.RawTextHelpFormatter)
     add_default_arguments(info_parser, dcos_mode)
+    info_parser.add_argument('bundle',
+                             nargs='?',
+                             default=None,
+                             help='The optional id or name to the bundle.\n'
+                                  'When specified detailed information pertaining to the bundle is displayed')
     info_parser.set_defaults(func=conduct_info.info)
 
     # Sub-parser for `service-names` sub-command

--- a/conductr_cli/conduct_service_names.py
+++ b/conductr_cli/conduct_service_names.py
@@ -19,6 +19,13 @@ def service_names(args):
     if log.is_verbose_enabled():
         log.verbose(validation.pretty_json(response.text))
 
+    bundles = json.loads(response.text)
+    data, duplicate_endpoints = get_service_names_from_bundles(args, bundles)
+    display_service_names(log, data, duplicate_endpoints)
+    return True
+
+
+def get_service_names_from_bundles(args, bundles):
     def execution_status(bundle_executions):
         for execution in bundle_executions:
             if execution['isStarted']:
@@ -37,13 +44,12 @@ def service_names(args):
             {
                 'service_name': get_service_name_from_service_uri(service_uri),
                 'service_uri': service_uri,
-                'bundle_id': bundle['bundleId'] if args.long_ids else bundle_utils.short_id(
-                    bundle['bundleId']),
+                'bundle_id': bundle['bundleId'] if args.long_ids else bundle_utils.short_id(bundle['bundleId']),
                 'bundle_name': bundle['attributes']['bundleName'],
                 'status': execution_status(bundle['bundleExecutions'])
             }
         )
-        for bundle in json.loads(response.text) if bundle['bundleExecutions']
+        for bundle in bundles if bundle['bundleExecutions']
         for endpoint_name, endpoint in bundle['bundleConfig']['endpoints'].items() if 'services' in endpoint
         for service_uri in endpoint['services']
     ]
@@ -53,13 +59,12 @@ def service_names(args):
             {
                 'service_name': endpoint['serviceName'],
                 'service_uri': None,
-                'bundle_id': bundle['bundleId'] if args.long_ids else bundle_utils.short_id(
-                    bundle['bundleId']),
+                'bundle_id': bundle['bundleId'] if args.long_ids else bundle_utils.short_id(bundle['bundleId']),
                 'bundle_name': bundle['attributes']['bundleName'],
                 'status': execution_status(bundle['bundleExecutions'])
             }
         )
-        for bundle in json.loads(response.text) if bundle['bundleExecutions']
+        for bundle in bundles if bundle['bundleExecutions']
         for endpoint_name, endpoint in bundle['bundleConfig']['endpoints'].items() if 'serviceName' in endpoint
     ]
 
@@ -77,20 +82,33 @@ def service_names(args):
     duplicate_endpoints = [service for (service, endpoint) in service_endpoints.items() if len(endpoint) > 1] \
         if len(service_endpoints) > 0 else []
 
-    data.insert(0, {'service_name': 'SERVICE NAME', 'bundle_id': 'BUNDLE ID', 'bundle_name': 'BUNDLE NAME', 'status': 'STATUS'})
+    return data, duplicate_endpoints
+
+
+def display_service_names(log, data, duplicate_endpoints, display_bundle_id=True, display_bundle_name=True,
+                          display_status=True):
+    data.insert(0, {
+        'service_name': 'SERVICE NAME',
+        'bundle_id': 'BUNDLE ID' if display_bundle_id else '',
+        'bundle_name': 'BUNDLE NAME' if display_bundle_name else '',
+        'status': 'STATUS' if display_status else ''
+    })
 
     padding = 2
+
+    display_template = '{service_name: <{service_name_width}}{padding}'
+    if display_bundle_id:
+        display_template += '{bundle_id: <{bundle_id_width}}{padding}'
+    if display_bundle_name:
+        display_template += '{bundle_name: <{bundle_name_width}}{padding}'
+    if display_status:
+        display_template += '{status: <{status_width}}'
+
     column_widths = dict(screen_utils.calc_column_widths(data), **{'padding': ' ' * padding})
     for row in data:
-        log.screen(
-            '{service_name: <{service_name_width}}{padding}'
-            '{bundle_id: <{bundle_id_width}}{padding}'
-            '{bundle_name: <{bundle_name_width}}{padding}'
-            '{status: <{status_width}}'.format(**dict(row, **column_widths)).rstrip())
+        log.screen(display_template.format(**dict(row, **column_widths)).rstrip())
 
     if len(duplicate_endpoints) > 0:
         log.screen('')
         log.warning('Multiple endpoints found for the following services: {}'.format(', '.join(duplicate_endpoints)))
         log.warning('Service resolution for these services is undefined.')
-
-    return True

--- a/conductr_cli/test/data/conduct_info_inspect/bundle_with_acls.json
+++ b/conductr_cli/test/data/conduct_info_inspect/bundle_with_acls.json
@@ -1,0 +1,299 @@
+[
+    {
+        "bundleId": "3349b6bfbc09e8d88123fee5b33b2717",
+        "bundleDigest": "3349b6bfbc09e8d88123fee5b33b2717e07fb2a91de719c99e0403c9e4b28ea5",
+        "attributes": {
+            "system": "eslite",
+            "nrOfCpus": 0.1,
+            "memory": 402653184,
+            "diskSpace": 200000000,
+            "roles": [
+                "elasticsearch"
+            ],
+            "bundleName": "eslite",
+            "systemVersion": "1",
+            "compatibilityVersion": "1"
+        },
+        "bundleConfig": {
+            "endpoints": {
+                "akka-remote": {
+                    "bindProtocol": "tcp"
+                },
+                "es": {
+                    "bindProtocol": "http",
+                    "serviceName": "elastic-search"
+                }
+            }
+        },
+        "bundleScale": {
+            "scale": 1,
+            "nrOfReschedules": 0
+        },
+        "bundleExecutions": [
+            {
+                "host": "192.168.10.2",
+                "endpoints": {
+                    "akka-remote": {
+                        "bindPort": 10822,
+                        "hostPort": 10822
+                    },
+                    "es": {
+                        "bindPort": 10007,
+                        "hostPort": 10007
+                    }
+                },
+                "isStarted": true
+            }
+        ],
+        "bundleInstallations": [
+            {
+                "uniqueAddress": {
+                    "address": "akka.tcp://conductr@192.168.10.2:9004",
+                    "uid": 1480539637
+                },
+                "bundleFile": "file:///Users/felixsatyaputra/.conductr/images/tmp/conductr/192.168.10.2/bundles/3349b6bfbc09e8d88123fee5b33b2717e07fb2a91de719c99e0403c9e4b28ea5.zip"
+            },
+            {
+                "uniqueAddress": {
+                    "address": "akka.tcp://conductr@192.168.10.1:9004",
+                    "uid": -430464113
+                },
+                "bundleFile": "file:///Users/felixsatyaputra/.conductr/images/tmp/conductr/192.168.10.1/bundles/3349b6bfbc09e8d88123fee5b33b2717e07fb2a91de719c99e0403c9e4b28ea5.zip"
+            },
+            {
+                "uniqueAddress": {
+                    "address": "akka.tcp://conductr@192.168.10.3:9004",
+                    "uid": -2501706
+                },
+                "bundleFile": "file:///Users/felixsatyaputra/.conductr/images/tmp/conductr/192.168.10.3/bundles/3349b6bfbc09e8d88123fee5b33b2717e07fb2a91de719c99e0403c9e4b28ea5.zip"
+            }
+        ],
+        "hasError": false
+    },
+    {
+        "bundleId": "85dd2657bf86e5ed817c6cbe9d4c18e3",
+        "bundleDigest": "85dd2657bf86e5ed817c6cbe9d4c18e3a6c30eb3146383fc65357b65f11cb550",
+        "attributes": {
+            "system": "conductr-elasticsearch",
+            "nrOfCpus": 0.1,
+            "memory": 1572864000,
+            "diskSpace": 100000000,
+            "roles": [
+                "elasticsearch"
+            ],
+            "bundleName": "conductr-elasticsearch",
+            "systemVersion": "1",
+            "compatibilityVersion": "1"
+        },
+        "bundleExecutions": [],
+        "bundleInstallations": [
+            {
+                "uniqueAddress": {
+                    "address": "akka.tcp://conductr@192.168.10.2:9004",
+                    "uid": 1480539637
+                },
+                "bundleFile": "file:///Users/felixsatyaputra/.conductr/images/tmp/conductr/192.168.10.2/bundles/85dd2657bf86e5ed817c6cbe9d4c18e3a6c30eb3146383fc65357b65f11cb550.zip"
+            },
+            {
+                "uniqueAddress": {
+                    "address": "akka.tcp://conductr@192.168.10.1:9004",
+                    "uid": -430464113
+                },
+                "bundleFile": "file:///Users/felixsatyaputra/.conductr/images/tmp/conductr/192.168.10.1/bundles/85dd2657bf86e5ed817c6cbe9d4c18e3a6c30eb3146383fc65357b65f11cb550.zip"
+            },
+            {
+                "uniqueAddress": {
+                    "address": "akka.tcp://conductr@192.168.10.3:9004",
+                    "uid": -2501706
+                },
+                "bundleFile": "file:///Users/felixsatyaputra/.conductr/images/tmp/conductr/192.168.10.3/bundles/85dd2657bf86e5ed817c6cbe9d4c18e3a6c30eb3146383fc65357b65f11cb550.zip"
+            }
+        ],
+        "hasError": false
+    },
+    {
+        "bundleId": "bdfa43d7ade7456af30a95e9ef4bce86-e5f35046d59c27f4cfeebcc026f3e3b7",
+        "bundleDigest": "bdfa43d7ade7456af30a95e9ef4bce863d3029dc58b6824f5783881297d1983b",
+        "configurationDigest": "e5f35046d59c27f4cfeebcc026f3e3b76e027b15223a8961b59d728e559402e2",
+        "attributes": {
+            "system": "conductr-haproxy",
+            "nrOfCpus": 0.1,
+            "memory": 402653184,
+            "diskSpace": 35000000,
+            "roles": [
+                "haproxy"
+            ],
+            "bundleName": "conductr-haproxy",
+            "systemVersion": "2",
+            "compatibilityVersion": "2"
+        },
+        "bundleConfig": {
+            "endpoints": {
+                "status": {
+                    "bindProtocol": "http"
+                }
+            }
+        },
+        "bundleScale": {
+            "scale": 1,
+            "nrOfReschedules": 0
+        },
+        "bundleExecutions": [
+            {
+                "host": "192.168.10.2",
+                "endpoints": {
+                    "status": {
+                        "bindPort": 9009,
+                        "hostPort": 9009
+                    }
+                },
+                "isStarted": true
+            }
+        ],
+        "bundleInstallations": [
+            {
+                "uniqueAddress": {
+                    "address": "akka.tcp://conductr@192.168.10.2:9004",
+                    "uid": 1480539637
+                },
+                "bundleFile": "file:///Users/felixsatyaputra/.conductr/images/tmp/conductr/192.168.10.2/bundles/bdfa43d7ade7456af30a95e9ef4bce863d3029dc58b6824f5783881297d1983b.zip",
+                "configurationFile": "file:///Users/felixsatyaputra/.conductr/images/tmp/conductr/192.168.10.2/bundles/e5f35046d59c27f4cfeebcc026f3e3b76e027b15223a8961b59d728e559402e2.zip"
+            },
+            {
+                "uniqueAddress": {
+                    "address": "akka.tcp://conductr@192.168.10.1:9004",
+                    "uid": -430464113
+                },
+                "bundleFile": "file:///Users/felixsatyaputra/.conductr/images/tmp/conductr/192.168.10.1/bundles/bdfa43d7ade7456af30a95e9ef4bce863d3029dc58b6824f5783881297d1983b.zip",
+                "configurationFile": "file:///Users/felixsatyaputra/.conductr/images/tmp/conductr/192.168.10.1/bundles/e5f35046d59c27f4cfeebcc026f3e3b76e027b15223a8961b59d728e559402e2.zip"
+            },
+            {
+                "uniqueAddress": {
+                    "address": "akka.tcp://conductr@192.168.10.3:9004",
+                    "uid": -2501706
+                },
+                "bundleFile": "file:///Users/felixsatyaputra/.conductr/images/tmp/conductr/192.168.10.3/bundles/bdfa43d7ade7456af30a95e9ef4bce863d3029dc58b6824f5783881297d1983b.zip",
+                "configurationFile": "file:///Users/felixsatyaputra/.conductr/images/tmp/conductr/192.168.10.3/bundles/e5f35046d59c27f4cfeebcc026f3e3b76e027b15223a8961b59d728e559402e2.zip"
+            }
+        ],
+        "hasError": false
+    },
+    {
+        "bundleId": "cb96704f739ddfa36ddb9fabdfc42592",
+        "bundleDigest": "cb96704f739ddfa36ddb9fabdfc4259238a5b4d8f3d4bc8f1fd34bdcc8e1bcae",
+        "attributes": {
+            "system": "path-tester",
+            "nrOfCpus": 0.1,
+            "memory": 402653184,
+            "diskSpace": 200000000,
+            "roles": [
+                "ptester"
+            ],
+            "bundleName": "path-tester",
+            "systemVersion": "1",
+            "compatibilityVersion": "1"
+        },
+        "bundleConfig": {
+            "endpoints": {
+                "ptest": {
+                    "bindProtocol": "http",
+                    "serviceName": "path-tester",
+                    "acls": [
+                        {
+                            "http": {
+                                "requests": [
+                                    {
+                                        "pathBeg": "/bacon",
+                                        "method": "GET",
+                                        "rewrite": "/burger"
+                                    },
+                                    {
+                                        "pathBeg": "/tree",
+                                        "method": "GET"
+                                    },
+                                    {
+                                        "pathRegex": "^/fee/(.*)/fi/(.*)/fo/(.*)/fum$",
+                                        "method": "GET",
+                                        "rewrite": "/boom/\\1-\\2-\\3/box"
+                                    },
+                                    {
+                                        "pathRegex": "^/boom/(.*)/box$",
+                                        "method": "GET"
+                                    },
+                                    {
+                                        "path": "/foo",
+                                        "method": "GET",
+                                        "rewrite": "/baz"
+                                    },
+                                    {
+                                        "path": "/baz",
+                                        "method": "GET"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "ptunnel": {
+                    "bindProtocol": "tcp",
+                    "serviceName": "ptunnel",
+                    "acls": [
+                        {
+                            "tcp": {
+                                "requests": [
+                                    3303,
+                                    5601,
+                                    12101
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "bundleScale": {
+            "scale": 1,
+            "nrOfReschedules": 0
+        },
+        "bundleExecutions": [
+            {
+                "host": "192.168.10.1",
+                "endpoints": {
+                    "ptest": {
+                        "bindPort": 10822,
+                        "hostPort": 10822
+                    },
+                    "ptunnel": {
+                        "bindPort": 10007,
+                        "hostPort": 10007
+                    }
+                },
+                "isStarted": true
+            }
+        ],
+        "bundleInstallations": [
+            {
+                "uniqueAddress": {
+                    "address": "akka.tcp://conductr@192.168.10.3:9004",
+                    "uid": -2501706
+                },
+                "bundleFile": "file:///Users/felixsatyaputra/.conductr/images/tmp/conductr/192.168.10.3/bundles/cb96704f739ddfa36ddb9fabdfc4259238a5b4d8f3d4bc8f1fd34bdcc8e1bcae.zip"
+            },
+            {
+                "uniqueAddress": {
+                    "address": "akka.tcp://conductr@192.168.10.2:9004",
+                    "uid": 1480539637
+                },
+                "bundleFile": "file:///Users/felixsatyaputra/.conductr/images/tmp/conductr/192.168.10.2/bundles/cb96704f739ddfa36ddb9fabdfc4259238a5b4d8f3d4bc8f1fd34bdcc8e1bcae.zip"
+            },
+            {
+                "uniqueAddress": {
+                    "address": "akka.tcp://conductr@192.168.10.1:9004",
+                    "uid": -430464113
+                },
+                "bundleFile": "file:///Users/felixsatyaputra/.conductr/images/tmp/conductr/192.168.10.1/bundles/cb96704f739ddfa36ddb9fabdfc4259238a5b4d8f3d4bc8f1fd34bdcc8e1bcae.zip"
+            }
+        ],
+        "hasError": false
+    }
+]

--- a/conductr_cli/test/data/conduct_info_inspect/bundle_with_service_uris_v1.json
+++ b/conductr_cli/test/data/conduct_info_inspect/bundle_with_service_uris_v1.json
@@ -1,0 +1,105 @@
+[
+  {
+    "bundleId": "90b6082727c545b9534447f206cf98c5",
+    "bundleDigest": "90b6082727c545b9534447f206cf98c55f5e146456c6078b19d48fb34b309e91",
+    "attributes": {
+      "system": "visualizer",
+      "nrOfCpus": 1,
+      "memory": 67108864,
+      "diskSpace": 35000000,
+      "roles": [
+        "web"
+      ],
+      "bundleName": "visualizer"
+    },
+    "bundleConfig": {
+      "endpoints": {
+        "web": {
+          "bindProtocol": "http",
+          "services": [
+            "http://:9999"
+          ]
+        }
+      }
+    },
+    "bundleScale": 1,
+    "bundleExecutions": [
+      {
+        "host": "172.17.0.2",
+        "endpoints": {
+          "web": {
+            "bindPort": 10822,
+            "hostPort": 10822
+          }
+        },
+        "isStarted": true
+      }
+    ],
+    "bundleInstallations": [
+      {
+        "uniqueAddress": {
+          "address": "akka.tcp://conductr@172.17.0.2:9004",
+          "uid": 34777716
+        },
+        "bundleFile": "file:///tmp/90b6082727c545b9534447f206cf98c55f5e146456c6078b19d48fb34b309e91.zip"
+      }
+    ],
+    "hasError": false
+  },
+  {
+    "bundleId": "55436ba8468dad03313a2bfd6cdd7707",
+    "bundleDigest": "55436ba8468dad03313a2bfd6cdd77077a79d8046abb2944c922cfa9e9c5d0b6",
+    "attributes": {
+      "system": "eslite",
+      "nrOfCpus": 0.1,
+      "memory": 33554432,
+      "diskSpace": 200000000,
+      "roles": [
+        "elasticsearch"
+      ],
+      "bundleName": "eslite"
+    },
+    "bundleConfig": {
+      "endpoints": {
+        "akka-remote": {
+          "bindProtocol": "tcp",
+          "services": []
+        },
+        "elastic-search": {
+          "bindProtocol": "http",
+          "services": [
+            "http://127.0.0.1:9200",
+            "http://:9200/elastic-search"
+          ]
+        }
+      }
+    },
+    "bundleScale": 1,
+    "bundleExecutions": [
+      {
+        "host": "172.17.0.2",
+        "endpoints": {
+          "akka-remote": {
+            "bindPort": 10917,
+            "hostPort": 10917
+          },
+          "elastic-search": {
+            "bindPort": 10007,
+            "hostPort": 10007
+          }
+        },
+        "isStarted": true
+      }
+    ],
+    "bundleInstallations": [
+      {
+        "uniqueAddress": {
+          "address": "akka.tcp://conductr@172.17.0.2:9004",
+          "uid": 34777716
+        },
+        "bundleFile": "file:///tmp/55436ba8468dad03313a2bfd6cdd77077a79d8046abb2944c922cfa9e9c5d0b6.zip"
+      }
+    ],
+    "hasError": false
+  }
+]

--- a/conductr_cli/test/data/conduct_info_inspect/bundle_with_service_uris_v2.json
+++ b/conductr_cli/test/data/conduct_info_inspect/bundle_with_service_uris_v2.json
@@ -1,0 +1,113 @@
+[
+  {
+    "bundleId": "90b6082727c545b9534447f206cf98c5",
+    "bundleDigest": "90b6082727c545b9534447f206cf98c55f5e146456c6078b19d48fb34b309e91",
+    "attributes": {
+      "system": "visualizer",
+      "nrOfCpus": 1,
+      "memory": 67108864,
+      "diskSpace": 35000000,
+      "roles": [
+        "web"
+      ],
+      "bundleName": "visualizer",
+      "systemVersion": "1.1",
+      "compatibilityVersion": "1.1"
+    },
+    "bundleConfig": {
+      "endpoints": {
+        "web": {
+          "bindProtocol": "http",
+          "services": [
+            "http://:9999"
+          ]
+        }
+      }
+    },
+    "bundleScale": {
+      "scale": 1
+    },
+    "bundleExecutions": [
+      {
+        "host": "172.17.0.2",
+        "endpoints": {
+          "web": {
+            "bindPort": 10822,
+            "hostPort": 10822
+          }
+        },
+        "isStarted": true
+      }
+    ],
+    "bundleInstallations": [
+      {
+        "uniqueAddress": {
+          "address": "akka.tcp://conductr@172.17.0.2:9004",
+          "uid": 34777716
+        },
+        "bundleFile": "file:///tmp/90b6082727c545b9534447f206cf98c55f5e146456c6078b19d48fb34b309e91.zip"
+      }
+    ],
+    "hasError": false
+  },
+  {
+    "bundleId": "55436ba8468dad03313a2bfd6cdd7707",
+    "bundleDigest": "55436ba8468dad03313a2bfd6cdd77077a79d8046abb2944c922cfa9e9c5d0b6",
+    "attributes": {
+      "system": "eslite",
+      "nrOfCpus": 0.1,
+      "memory": 33554432,
+      "diskSpace": 200000000,
+      "roles": [
+        "elasticsearch"
+      ],
+      "bundleName": "eslite",
+      "systemVersion": "1",
+      "compatibilityVersion": "1"
+    },
+    "bundleConfig": {
+      "endpoints": {
+        "akka-remote": {
+          "bindProtocol": "tcp",
+          "services": []
+        },
+        "elastic-search": {
+          "bindProtocol": "http",
+          "services": [
+            "http://127.0.0.1:9200",
+            "http://:9200/elastic-search"
+          ]
+        }
+      }
+    },
+    "bundleScale": {
+      "scale": 1
+    },
+    "bundleExecutions": [
+      {
+        "host": "172.17.0.2",
+        "endpoints": {
+          "akka-remote": {
+            "bindPort": 10917,
+            "hostPort": 10917
+          },
+          "elastic-search": {
+            "bindPort": 10007,
+            "hostPort": 10007
+          }
+        },
+        "isStarted": true
+      }
+    ],
+    "bundleInstallations": [
+      {
+        "uniqueAddress": {
+          "address": "akka.tcp://conductr@172.17.0.2:9004",
+          "uid": 34777716
+        },
+        "bundleFile": "file:///tmp/55436ba8468dad03313a2bfd6cdd77077a79d8046abb2944c922cfa9e9c5d0b6.zip"
+      }
+    ],
+    "hasError": false
+  }
+]

--- a/conductr_cli/test/test_conduct_main.py
+++ b/conductr_cli/test/test_conduct_main.py
@@ -44,6 +44,19 @@ class TestConduct(TestCase):
         self.assertEqual(args.cli_settings_dir, '{}/.conductr'.format(os.path.expanduser('~')))
         self.assertEqual(args.verbose, False)
         self.assertEqual(args.long_ids, False)
+        self.assertEqual(args.bundle, None)
+
+    def test_parser_info_with_bundle(self):
+        args = self.parser.parse_args('info vis'.split())
+
+        self.assertEqual(args.func.__name__, 'info')
+        self.assertEqual(args.ip, None)
+        self.assertEqual(args.port, 9005)
+        self.assertEqual(args.api_version, '2')
+        self.assertEqual(args.cli_settings_dir, '{}/.conductr'.format(os.path.expanduser('~')))
+        self.assertEqual(args.verbose, False)
+        self.assertEqual(args.long_ids, False)
+        self.assertEqual(args.bundle, 'vis')
 
     def test_parser_services(self):
         args = self.parser.parse_args('service-names'.split())


### PR DESCRIPTION
When `conduct info <bundle_id_or_name>`, bundle with matching name or id will be filtered from the list of bundles returned from ConductR's bundle endpoint.

If a single matching bundle is found, the `bundle.conf` attributes, `bundleScale`, `bundleInstallations`, `bundleExecutions`, HTTP ACLs, TCP ACLs, and Service Names are displayed. Only when they are available, the optional properties `bundleScale`, `bundleExecutions`, HTTP ACLs, TCP ACLs, and Service Names will be displayed.
