### PR TITLE
Support "start" as an alias for "run"

### DIFF
--- a/conductr_cli/conduct_main.py
+++ b/conductr_cli/conduct_main.py
@@ -268,6 +268,7 @@ def build_parser(dcos_mode):
 
     # Sub-parser for `run` sub-command
     run_parser = subparsers.add_parser('run',
+                                       aliases=['start'],
                                        help='Run a bundle',
                                        formatter_class=argparse.RawTextHelpFormatter)
     run_parser.add_argument('--scale',

--- a/conductr_cli/sandbox_main.py
+++ b/conductr_cli/sandbox_main.py
@@ -26,6 +26,7 @@ def build_parser():
 
     # Sub-parser for `run` sub-command
     run_parser = subparsers.add_parser('run',
+                                       aliases=['start'],
                                        help='Run ConductR sandbox cluster',
                                        usage='%(prog)s IMAGE_VERSION [ARGS]',
                                        formatter_class=argparse.RawTextHelpFormatter)


### PR DESCRIPTION
User feedback shows that it is natural to use "start" as well as "run".