### PR TITLE
Handle ConductR startup errors

### DIFF
--- a/conductr_cli/exceptions.py
+++ b/conductr_cli/exceptions.py
@@ -4,6 +4,15 @@ import os
 NOT_FOUND_ERROR = getattr(__builtins__, 'FileNotFoundError', OSError)
 
 
+class ConductrStartupError(Exception):
+    def __init__(self, wait_timeout, error_log_file):
+        self.timeout = wait_timeout
+        self.error_log_file = error_log_file
+
+    def __str__(self):
+        return repr('{} {}'.format(self.wait_timeout, self.error_log_file))
+
+
 class MalformedBundleError(Exception):
     def __init__(self, value):
         self.value = value

--- a/conductr_cli/license_validation.py
+++ b/conductr_cli/license_validation.py
@@ -1,4 +1,4 @@
-from conductr_cli import license, sandbox_common
+from conductr_cli import license
 from conductr_cli.constants import DEFAULT_SCHEME, DEFAULT_PORT, DEFAULT_BASE_PATH, DEFAULT_API_VERSION
 from conductr_cli.exceptions import LicenseValidationError
 import os
@@ -54,7 +54,6 @@ def validate_license(conductr_version, core_addr, nr_of_agent_instances, license
     """
 
     args = LicenseArgs(core_addr)
-    sandbox_common.wait_for_start(args, log_output=False)
 
     has_license_support, license_existing = license.get_license(args)
     if has_license_support:

--- a/conductr_cli/sandbox_run.py
+++ b/conductr_cli/sandbox_run.py
@@ -20,6 +20,7 @@ import sys
 @validation.handle_jvm_validation_error
 @validation.handle_docker_validation_error
 @validation.handle_license_validation_error
+@validation.handle_conductr_startup_error
 def run(args):
     """`sandbox run` command"""
     write_run_command()
@@ -29,22 +30,22 @@ def run(args):
 
     run_result = sandbox.run(args, features)
 
-    is_conductr_started, wait_timeout = sandbox_common.wait_for_start(run_result)
+    if run_result.wait_for_conductr:
+        sandbox_common.wait_for_start(run_result)
 
     feature_results = []
     feature_provided = []
 
-    if is_conductr_started:
-        for feature in features:
-            feature.conductr_post_start(args, run_result)
-            result = feature.start()
-            feature_results += result.bundle_results
+    for feature in features:
+        feature.conductr_post_start(args, run_result)
+        result = feature.start()
+        feature_results += result.bundle_results
 
-            if result.started:
-                for provided in feature.provides:
-                    feature_provided.append(provided)
+        if result.started:
+            for provided in feature.provides:
+                feature_provided.append(provided)
 
-    sandbox.log_run_attempt(args, run_result, feature_results, is_conductr_started, feature_provided, wait_timeout)
+    sandbox.log_run_attempt(args, run_result, feature_results, feature_provided)
 
     return True
 

--- a/conductr_cli/sandbox_run_docker.py
+++ b/conductr_cli/sandbox_run_docker.py
@@ -9,9 +9,10 @@ import os
 
 
 class SandboxRunResult:
-    def __init__(self, container_names, conductr_host):
+    def __init__(self, container_names, conductr_host, wait_for_conductr):
         self.container_names = container_names
         self.host = conductr_host
+        self.wait_for_conductr = wait_for_conductr
 
     scheme = DEFAULT_SCHEME
     port = DEFAULT_PORT
@@ -26,25 +27,20 @@ def run(args, features):
     nr_of_containers = instance_count(args.image_version, args.nr_of_instances)
     pull_image(args)
     container_names = scale_cluster(args, nr_of_containers, features)
-    return SandboxRunResult(container_names, host.DOCKER_IP)
+    return SandboxRunResult(container_names, host.DOCKER_IP, wait_for_conductr=True)
 
 
-def log_run_attempt(args, run_result, feature_results, is_conductr_started, feature_provided, wait_timeout):
+def log_run_attempt(args, run_result, feature_results, feature_provided):
     log = logging.getLogger(__name__)
     container_names = run_result.container_names
-    if is_conductr_started:
-        log.info(h1('Summary'))
-        log.info('ConductR has been started')
-        plural_string = 's' if len(container_names) > 1 else ''
-        log.info('Check resource consumption of Docker container{} that run the ConductR node{} with:'
-                 .format(plural_string, plural_string))
-        log.info('  docker stats {}'.format(' '.join(container_names)))
-        log.info('Check current bundle status with:')
-        log.info('  conduct info')
-    else:
-        log.info(h1('Summary'))
-        log.error('ConductR has not been started within {} seconds.'.format(wait_timeout))
-        log.error('Set the env CONDUCTR_SANDBOX_WAIT_RETRY_INTERVAL to increase the wait timeout.')
+    log.info(h1('Summary'))
+    log.info('ConductR has been started')
+    plural_string = 's' if len(container_names) > 1 else ''
+    log.info('Check resource consumption of Docker container{} that run the ConductR node{} with:'
+             .format(plural_string, plural_string))
+    log.info('  docker stats {}'.format(' '.join(container_names)))
+    log.info('Check current bundle status with:')
+    log.info('  conduct info')
 
 
 def instance_count(image_version, nr_of_containers):

--- a/conductr_cli/test/test_license_validation.py
+++ b/conductr_cli/test/test_license_validation.py
@@ -24,7 +24,6 @@ class TestValidateLicense(TestCase):
     license_file = DEFAULT_LICENSE_FILE
 
     def test_validate_posted_license(self):
-        mock_wait_for_start = MagicMock()
         mock_get_license = MagicMock(side_effect=[
             (True, None),
             (True, self.license),
@@ -33,8 +32,7 @@ class TestValidateLicense(TestCase):
         mock_post_license = MagicMock()
         mock_validate_license_data = MagicMock()
 
-        with patch('conductr_cli.sandbox_common.wait_for_start', mock_wait_for_start), \
-                patch('conductr_cli.license.get_license', mock_get_license), \
+        with patch('conductr_cli.license.get_license', mock_get_license), \
                 patch('os.path.exists', mock_exists), \
                 patch('conductr_cli.license.post_license', mock_post_license), \
                 patch('conductr_cli.license_validation.validate_license_data', mock_validate_license_data):
@@ -42,8 +40,6 @@ class TestValidateLicense(TestCase):
                                                 self.nr_of_agent_instances, self.license_file)
 
         expected_args = license_validation.LicenseArgs(self.core_addr)
-
-        mock_wait_for_start.assert_called_once_with(expected_args, log_output=False)
 
         self.assertEqual([
             call(expected_args),
@@ -58,7 +54,6 @@ class TestValidateLicense(TestCase):
                                                            self.license)
 
     def test_no_license_file(self):
-        mock_wait_for_start = MagicMock()
         mock_get_license = MagicMock(side_effect=[
             (True, None),
             (True, None),
@@ -67,8 +62,7 @@ class TestValidateLicense(TestCase):
         mock_post_license = MagicMock()
         mock_validate_license_data = MagicMock()
 
-        with patch('conductr_cli.sandbox_common.wait_for_start', mock_wait_for_start), \
-                patch('conductr_cli.license.get_license', mock_get_license), \
+        with patch('conductr_cli.license.get_license', mock_get_license), \
                 patch('os.path.exists', mock_exists), \
                 patch('conductr_cli.license.post_license', mock_post_license), \
                 patch('conductr_cli.license_validation.validate_license_data', mock_validate_license_data):
@@ -76,8 +70,6 @@ class TestValidateLicense(TestCase):
                                                 self.nr_of_agent_instances, self.license_file)
 
         expected_args = license_validation.LicenseArgs(self.core_addr)
-
-        mock_wait_for_start.assert_called_once_with(expected_args, log_output=False)
 
         self.assertEqual([
             call(expected_args),
@@ -92,14 +84,12 @@ class TestValidateLicense(TestCase):
                                                            None)
 
     def test_no_license_support(self):
-        mock_wait_for_start = MagicMock()
         mock_get_license = MagicMock(return_value=(False, None))
         mock_exists = MagicMock()
         mock_post_license = MagicMock()
         mock_validate_license_data = MagicMock()
 
-        with patch('conductr_cli.sandbox_common.wait_for_start', mock_wait_for_start), \
-                patch('conductr_cli.license.get_license', mock_get_license), \
+        with patch('conductr_cli.license.get_license', mock_get_license), \
                 patch('os.path.exists', mock_exists), \
                 patch('conductr_cli.license.post_license', mock_post_license), \
                 patch('conductr_cli.license_validation.validate_license_data', mock_validate_license_data):
@@ -107,8 +97,6 @@ class TestValidateLicense(TestCase):
                                                 self.nr_of_agent_instances, self.license_file)
 
         expected_args = license_validation.LicenseArgs(self.core_addr)
-
-        mock_wait_for_start.assert_called_once_with(expected_args, log_output=False)
 
         mock_get_license.assert_called_once_with(expected_args)
 

--- a/conductr_cli/test/test_sandbox_common.py
+++ b/conductr_cli/test/test_sandbox_common.py
@@ -1,6 +1,7 @@
 from conductr_cli.test.cli_test_case import CliTestCase
 from conductr_cli import logging_setup, sandbox_common
 from conductr_cli.sandbox_common import DEFAULT_WAIT_RETRIES, DEFAULT_WAIT_RETRY_INTERVAL
+from conductr_cli.exceptions import ConductrStartupError
 from unittest.mock import call, patch, MagicMock
 from requests.exceptions import ConnectionError
 
@@ -120,7 +121,7 @@ class TestWaitForStart(CliTestCase):
                 'host': '10.0.0.1'
             })
             result = sandbox_common.wait_for_start(run_result)
-            self.assertEqual((True, 1.0), result)
+            self.assertEqual(True, result)
 
         self.assertEqual([
             call('CONDUCTR_SANDBOX_WAIT_RETRIES', DEFAULT_WAIT_RETRIES),
@@ -161,8 +162,7 @@ class TestWaitForStart(CliTestCase):
             run_result = MagicMock(**{
                 'host': '10.0.0.1'
             })
-            result = sandbox_common.wait_for_start(run_result)
-            self.assertEqual((False, 1.0), result)
+            self.assertRaises(ConductrStartupError, sandbox_common.wait_for_start, run_result)
 
         self.assertEqual([
             call('CONDUCTR_SANDBOX_WAIT_RETRIES', DEFAULT_WAIT_RETRIES),

--- a/conductr_cli/test/test_sandbox_run.py
+++ b/conductr_cli/test/test_sandbox_run.py
@@ -47,7 +47,8 @@ class TestSandboxRunCommand(CliTestCase):
         features = [mock_feature]
         mock_collect_features = MagicMock(return_value=features)
 
-        sandbox_run_result = sandbox_run_docker.SandboxRunResult(self.container_names, '192.168.99.100')
+        sandbox_run_result = sandbox_run_docker.SandboxRunResult(self.container_names, '192.168.99.100',
+                                                                 wait_for_conductr=True)
         mock_sandbox_run_docker = MagicMock(return_value=sandbox_run_result)
         mock_wait_for_conductr = MagicMock(return_value=True)
         mock_log_run_attempt = MagicMock()
@@ -68,9 +69,9 @@ class TestSandboxRunCommand(CliTestCase):
         mock_sandbox_run_docker.assert_called_once_with(input_args, features)
 
         mock_wait_for_conductr.assert_called_once_with(sandbox_run_result, 0, DEFAULT_WAIT_RETRIES,
-                                                       DEFAULT_WAIT_RETRY_INTERVAL, log_output=True)
+                                                       DEFAULT_WAIT_RETRY_INTERVAL)
 
-        mock_log_run_attempt.assert_called_with(input_args, sandbox_run_result, bundle_start_result, True, [], 60)
+        mock_log_run_attempt.assert_called_with(input_args, sandbox_run_result, bundle_start_result, [])
 
         mock_feature.assert_not_called()
 
@@ -87,7 +88,8 @@ class TestSandboxRunCommand(CliTestCase):
         features = [mock_feature]
         mock_collect_features = MagicMock(return_value=features)
 
-        sandbox_run_result = sandbox_run_jvm.SandboxRunResult([1001], ['192.168.1.1'], [1002], ['192.168.1.1'])
+        sandbox_run_result = sandbox_run_jvm.SandboxRunResult([1001], ['192.168.1.1'], [1002], ['192.168.1.1'],
+                                                              wait_for_conductr=True)
         mock_sandbox_run_jvm = MagicMock(return_value=sandbox_run_result)
         mock_wait_for_conductr = MagicMock(return_value=True)
         mock_log_run_attempt = MagicMock()
@@ -108,9 +110,9 @@ class TestSandboxRunCommand(CliTestCase):
         mock_sandbox_run_jvm.assert_called_once_with(input_args, features)
 
         mock_wait_for_conductr.assert_called_once_with(sandbox_run_result, 0, DEFAULT_WAIT_RETRIES,
-                                                       DEFAULT_WAIT_RETRY_INTERVAL, log_output=True)
+                                                       DEFAULT_WAIT_RETRY_INTERVAL)
 
-        mock_log_run_attempt.assert_called_with(input_args, sandbox_run_result, bundle_start_result, True, [], 60)
+        mock_log_run_attempt.assert_called_with(input_args, sandbox_run_result, bundle_start_result, [])
 
     def test_docker_sandbox_instance_count_error(self):
         conductr_version = '1.1.11'

--- a/conductr_cli/test/test_sandbox_run_docker.py
+++ b/conductr_cli/test/test_sandbox_run_docker.py
@@ -1,4 +1,4 @@
-from conductr_cli.test.cli_test_case import CliTestCase, strip_margin, as_error
+from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
 from conductr_cli import sandbox_run_docker, logging_setup
 from conductr_cli.constants import FEATURE_PROVIDE_PROXYING
 from conductr_cli.docker import DockerVmType
@@ -331,7 +331,7 @@ class TestLogRunAttempt(CliTestCase):
     wait_timeout = 60
     container_names = ['cond-0', 'cond-1', 'cond-2']
     hostname = '10.0.0.1'
-    run_result = sandbox_run_docker.SandboxRunResult(container_names, hostname)
+    run_result = sandbox_run_docker.SandboxRunResult(container_names, hostname, wait_for_conductr=False)
     feature_results = []
 
     def test_log_output(self):
@@ -343,9 +343,7 @@ class TestLogRunAttempt(CliTestCase):
             input_args,
             run_result=self.run_result,
             feature_results=self.feature_results,
-            is_conductr_started=True,
-            feature_provided=[FEATURE_PROVIDE_PROXYING],
-            wait_timeout=self.wait_timeout
+            feature_provided=[FEATURE_PROVIDE_PROXYING]
         )
 
         expected_stdout = strip_margin("""||------------------------------------------------|
@@ -366,11 +364,9 @@ class TestLogRunAttempt(CliTestCase):
         logging_setup.configure_logging(input_args, stdout)
         sandbox_run_docker.log_run_attempt(
             input_args,
-            run_result=sandbox_run_docker.SandboxRunResult(['cond-0'], self.hostname),
+            run_result=sandbox_run_docker.SandboxRunResult(['cond-0'], self.hostname, wait_for_conductr=False),
             feature_results=self.feature_results,
-            is_conductr_started=True,
-            feature_provided=[FEATURE_PROVIDE_PROXYING],
-            wait_timeout=self.wait_timeout
+            feature_provided=[FEATURE_PROVIDE_PROXYING]
         )
 
         expected_stdout = strip_margin("""||------------------------------------------------|
@@ -383,29 +379,3 @@ class TestLogRunAttempt(CliTestCase):
                                           |  conduct info
                                           |""")
         self.assertEqual(expected_stdout, self.output(stdout))
-
-    def test_log_output_not_started(self):
-        stdout = MagicMock()
-        stderr = MagicMock()
-        input_args = MagicMock(**{})
-
-        logging_setup.configure_logging(input_args, stdout, stderr)
-        sandbox_run_docker.log_run_attempt(
-            input_args,
-            run_result=self.run_result,
-            feature_results=self.feature_results,
-            is_conductr_started=False,
-            feature_provided=[],
-            wait_timeout=self.wait_timeout
-        )
-
-        expected_stdout = strip_margin("""||------------------------------------------------|
-                                          || Summary                                        |
-                                          ||------------------------------------------------|
-                                          |""")
-        self.assertEqual(expected_stdout, self.output(stdout))
-
-        expected_stderr = strip_margin(as_error("""|Error: ConductR has not been started within 60 seconds.
-                                                   |Error: Set the env CONDUCTR_SANDBOX_WAIT_RETRY_INTERVAL to increase the wait timeout.
-                                                   |"""))
-        self.assertEqual(expected_stderr, self.output(stderr))

--- a/conductr_cli/test/test_sandbox_run_jvm.py
+++ b/conductr_cli/test/test_sandbox_run_jvm.py
@@ -51,6 +51,8 @@ class TestRun(CliTestCase):
         mock_core_pids = MagicMock()
         mock_start_core_instances = MagicMock(return_value=mock_core_pids)
 
+        mock_wait_for_start = MagicMock()
+
         mock_validate_license = MagicMock()
 
         mock_agent_pids = MagicMock()
@@ -66,11 +68,13 @@ class TestRun(CliTestCase):
                 patch('conductr_cli.sandbox_run_jvm.obtain_sandbox_image', mock_obtain_sandbox_image), \
                 patch('conductr_cli.sandbox_stop.stop', mock_sandbox_stop), \
                 patch('conductr_cli.sandbox_run_jvm.start_core_instances', mock_start_core_instances), \
+                patch('conductr_cli.sandbox_common.wait_for_start', mock_wait_for_start), \
                 patch('conductr_cli.license_validation.validate_license', mock_validate_license), \
                 patch('conductr_cli.sandbox_run_jvm.start_agent_instances', mock_start_agent_instances):
             result = sandbox_run_jvm.run(input_args, features)
             expected_result = sandbox_run_jvm.SandboxRunResult(mock_core_pids, bind_addrs,
-                                                               mock_agent_pids, bind_addrs)
+                                                               mock_agent_pids, bind_addrs,
+                                                               wait_for_conductr=False)
             self.assertEqual(expected_result, result)
 
         mock_sandbox_stop.assert_called_once_with(input_args)
@@ -88,6 +92,8 @@ class TestRun(CliTestCase):
                                                      [],
                                                      features,
                                                      'info')
+        expected_args = sandbox_run_jvm.WaitForConductrArgs(bind_addr)
+        mock_wait_for_start.assert_called_once_with(expected_args)
         mock_validate_license.assert_called_once_with('2.0.0', bind_addr, 1, DEFAULT_LICENSE_FILE)
         mock_start_agent_instances.assert_called_with(mock_agent_extracted_dir,
                                                       self.tmp_dir,
@@ -121,6 +127,8 @@ class TestRun(CliTestCase):
         mock_core_pids = MagicMock()
         mock_start_core_instances = MagicMock(return_value=mock_core_pids)
 
+        mock_wait_for_start = MagicMock()
+
         mock_validate_license = MagicMock()
 
         mock_agent_pids = MagicMock()
@@ -140,11 +148,13 @@ class TestRun(CliTestCase):
                 patch('conductr_cli.sandbox_run_jvm.obtain_sandbox_image', mock_obtain_sandbox_image), \
                 patch('conductr_cli.sandbox_stop.stop', mock_sandbox_stop), \
                 patch('conductr_cli.sandbox_run_jvm.start_core_instances', mock_start_core_instances), \
+                patch('conductr_cli.sandbox_common.wait_for_start', mock_wait_for_start), \
                 patch('conductr_cli.license_validation.validate_license', mock_validate_license), \
                 patch('conductr_cli.sandbox_run_jvm.start_agent_instances', mock_start_agent_instances):
             result = sandbox_run_jvm.run(input_args, features)
             expected_result = sandbox_run_jvm.SandboxRunResult(mock_core_pids, [bind_addr1],
-                                                               mock_agent_pids, [bind_addr1, bind_addr2, bind_addr3])
+                                                               mock_agent_pids, [bind_addr1, bind_addr2, bind_addr3],
+                                                               wait_for_conductr=False)
             self.assertEqual(expected_result, result)
 
         mock_sandbox_stop.assert_called_once_with(input_args)
@@ -162,6 +172,8 @@ class TestRun(CliTestCase):
                                                      [],
                                                      features,
                                                      'info')
+        expected_args = sandbox_run_jvm.WaitForConductrArgs(bind_addr1)
+        mock_wait_for_start.assert_called_once_with(expected_args)
         mock_validate_license.assert_called_once_with('2.0.0', bind_addr1, 3, DEFAULT_LICENSE_FILE)
         mock_start_agent_instances.assert_called_with(mock_agent_extracted_dir,
                                                       self.tmp_dir,
@@ -194,6 +206,8 @@ class TestRun(CliTestCase):
         mock_core_pids = MagicMock()
         mock_start_core_instances = MagicMock(return_value=mock_core_pids)
 
+        mock_wait_for_start = MagicMock()
+
         mock_validate_license = MagicMock()
 
         mock_agent_pids = MagicMock()
@@ -225,11 +239,13 @@ class TestRun(CliTestCase):
                 patch('conductr_cli.sandbox_run_jvm.obtain_sandbox_image', mock_obtain_sandbox_image), \
                 patch('conductr_cli.sandbox_stop.stop', mock_sandbox_stop), \
                 patch('conductr_cli.sandbox_run_jvm.start_core_instances', mock_start_core_instances), \
+                patch('conductr_cli.sandbox_common.wait_for_start', mock_wait_for_start), \
                 patch('conductr_cli.license_validation.validate_license', mock_validate_license), \
                 patch('conductr_cli.sandbox_run_jvm.start_agent_instances', mock_start_agent_instances):
             result = sandbox_run_jvm.run(input_args, features)
             expected_result = sandbox_run_jvm.SandboxRunResult(mock_core_pids, [bind_addr1],
-                                                               mock_agent_pids, [bind_addr1])
+                                                               mock_agent_pids, [bind_addr1],
+                                                               wait_for_conductr=False)
             self.assertEqual(expected_result, result)
 
         mock_sandbox_stop.assert_called_once_with(input_args)
@@ -246,6 +262,8 @@ class TestRun(CliTestCase):
                                                      [],
                                                      features,
                                                      'info')
+        expected_args = sandbox_run_jvm.WaitForConductrArgs(bind_addr1)
+        mock_wait_for_start.assert_called_once_with(expected_args)
         mock_validate_license.assert_called_once_with('2.0.0', bind_addr1, 1, DEFAULT_LICENSE_FILE)
         mock_start_agent_instances.assert_called_with(mock_agent_extracted_dir,
                                                       self.tmp_dir,
@@ -276,6 +294,7 @@ class TestRun(CliTestCase):
 
         mock_core_pids = MagicMock()
         mock_start_core_instances = MagicMock(return_value=mock_core_pids)
+        mock_wait_for_start = MagicMock()
 
         mock_validate_license = MagicMock()
 
@@ -298,11 +317,13 @@ class TestRun(CliTestCase):
                 patch('conductr_cli.sandbox_run_jvm.obtain_sandbox_image', mock_obtain_sandbox_image), \
                 patch('conductr_cli.sandbox_stop.stop', mock_sandbox_stop), \
                 patch('conductr_cli.sandbox_run_jvm.start_core_instances', mock_start_core_instances), \
+                patch('conductr_cli.sandbox_common.wait_for_start', mock_wait_for_start), \
                 patch('conductr_cli.license_validation.validate_license', mock_validate_license), \
                 patch('conductr_cli.sandbox_run_jvm.start_agent_instances', mock_start_agent_instances):
             result = sandbox_run_jvm.run(input_args, features)
             expected_result = sandbox_run_jvm.SandboxRunResult(mock_core_pids, bind_addrs,
-                                                               mock_agent_pids, bind_addrs)
+                                                               mock_agent_pids, bind_addrs,
+                                                               wait_for_conductr=False)
             self.assertEqual(expected_result, result)
 
         mock_sandbox_stop.assert_called_once_with(input_args)
@@ -320,6 +341,8 @@ class TestRun(CliTestCase):
                                                      [['role1', 'role2'], ['role3']],
                                                      features,
                                                      'info')
+        expected_args = sandbox_run_jvm.WaitForConductrArgs(bind_addrs[0])
+        mock_wait_for_start.assert_called_once_with(expected_args)
         mock_validate_license.assert_called_once_with('2.0.0', bind_addr, 1, DEFAULT_LICENSE_FILE)
         mock_start_agent_instances.assert_called_with(mock_agent_extracted_dir,
                                                       self.tmp_dir,
@@ -345,6 +368,7 @@ class TestRun(CliTestCase):
         mock_core_extracted_dir = MagicMock()
         mock_agent_extracted_dir = MagicMock()
         mock_obtain_sandbox_image = MagicMock(return_value=(mock_core_extracted_dir, mock_agent_extracted_dir))
+        mock_wait_for_start = MagicMock()
 
         mock_sandbox_stop = MagicMock()
 
@@ -364,6 +388,7 @@ class TestRun(CliTestCase):
                 patch('conductr_cli.sandbox_run_jvm.cleanup_tmp_dir', mock_cleanup_tmp_dir), \
                 patch('conductr_cli.sandbox_run_jvm.find_bind_addrs', mock_find_bind_addrs), \
                 patch('conductr_cli.sandbox_run_jvm.obtain_sandbox_image', mock_obtain_sandbox_image), \
+                patch('conductr_cli.sandbox_common.wait_for_start', mock_wait_for_start), \
                 patch('conductr_cli.sandbox_stop.stop', mock_sandbox_stop), \
                 patch('conductr_cli.sandbox_run_jvm.start_core_instances', mock_start_core_instances), \
                 patch('conductr_cli.license_validation.validate_license', mock_validate_license), \
@@ -384,6 +409,8 @@ class TestRun(CliTestCase):
                                                      [],
                                                      features,
                                                      'info')
+        expected_args = sandbox_run_jvm.WaitForConductrArgs(bind_addr)
+        mock_wait_for_start.assert_called_once_with(expected_args)
         mock_validate_license.assert_called_once_with('2.0.0', bind_addr, 1, DEFAULT_LICENSE_FILE)
         mock_start_agent_instances.assert_not_called()
         self.assertEqual([
@@ -1077,7 +1104,8 @@ class TestLogRunAttempt(CliTestCase):
         [1001, 1002, 1003],
         [ipaddress.ip_address('192.168.1.1'), ipaddress.ip_address('192.168.1.2'), ipaddress.ip_address('192.168.1.3')],
         [2001, 2002, 2003],
-        [ipaddress.ip_address('192.168.1.1'), ipaddress.ip_address('192.168.1.2'), ipaddress.ip_address('192.168.1.3')]
+        [ipaddress.ip_address('192.168.1.1'), ipaddress.ip_address('192.168.1.2'), ipaddress.ip_address('192.168.1.3')],
+        wait_for_conductr=True
     )
     feature_results = [sandbox_features.BundleStartResult('bundle-a', 1001),
                        sandbox_features.BundleStartResult('bundle-b', 1002)]
@@ -1093,9 +1121,7 @@ class TestLogRunAttempt(CliTestCase):
                 input_args,
                 run_result=self.run_result,
                 feature_results=self.feature_results,
-                is_conductr_started=True,
-                feature_provided=[FEATURE_PROVIDE_PROXYING],
-                wait_timeout=self.wait_timeout
+                feature_provided=[FEATURE_PROVIDE_PROXYING]
             )
 
         run_mock.assert_called_with(['info', '--host', '192.168.1.1'], configure_logging=False)
@@ -1131,7 +1157,8 @@ class TestLogRunAttempt(CliTestCase):
             [1001],
             [ipaddress.ip_address('192.168.1.1')],
             [2001],
-            [ipaddress.ip_address('192.168.1.1')]
+            [ipaddress.ip_address('192.168.1.1')],
+            wait_for_conductr=False
         )
 
         run_mock = MagicMock()
@@ -1146,9 +1173,7 @@ class TestLogRunAttempt(CliTestCase):
                 input_args,
                 run_result=run_result,
                 feature_results=self.feature_results,
-                is_conductr_started=True,
-                feature_provided=[FEATURE_PROVIDE_PROXYING],
-                wait_timeout=self.wait_timeout
+                feature_provided=[FEATURE_PROVIDE_PROXYING]
             )
 
         expected_stdout = strip_margin("""||------------------------------------------------|
@@ -1190,9 +1215,7 @@ class TestLogRunAttempt(CliTestCase):
                 input_args,
                 run_result=self.run_result,
                 feature_results=self.feature_results,
-                is_conductr_started=True,
-                feature_provided=[],
-                wait_timeout=self.wait_timeout
+                feature_provided=[]
             )
 
         expected_stdout = strip_margin("""||------------------------------------------------|


### PR DESCRIPTION
If ConductR has not been started within the 60 seconds then the `sandbox run` command will abort and display an improved error message:

```
$ sandbox run 2.0.2
|------------------------------------------------|
| Starting ConductR                              |
|------------------------------------------------|
Extracting ConductR core to /Users/mj/.conductr/images/core
Extracting ConductR agent to /Users/mj/.conductr/images/agent
Starting ConductR core instance on 192.168.10.1..
Waiting for ConductR to start.....
Error: ConductR has not been started within 10.0 seconds
Error: Set the env CONDUCTR_SANDBOX_WAIT_RETRIES to increase the wait timeout
Error: For more information check the ConductR log file at: /Users/mj/.conductr/images/core/logs/conductr.log
```

The error message got improved by adding the location of the log file (JVM mode only).

Prior to this PR, we have displayed an HTTP Connection error saying that the license could not be uploaded successfully. This was the case because we loaded the license on `sandbox run` and did not handled the ConductR startup error.