### PR TITLE
Introduce a script to build, package, and validate native executables

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -289,12 +289,41 @@ For Linux:
 For Windows:
 - Windows 7
 - Python version ``3.5``.
+- 7Zip executable from http://www.7-zip.org/download.html required to build zip file on the command line. When installing 7Zip, ensure the 7z.exe is available on the Windows ``%PATH%``.
 
 Pyinstaller version ``3.2.1`` or above is required. Please visit http://www.pyinstaller.org/ to obtain instructions on how to install it.
 
 Ensure the native executables are built from tagged release commit.
 
-To build native packages follow the form:
+Continue to build native packages.
+
+For MacOS and Linux:
+
+.. code:: bash
+
+    sh package-native-zip.sh [release-version-number]
+
+
+For Windows perform the following steps.
+
+Open a DOS prompt, and then execute the following command.
+
+.. code:: bash
+
+    set CONDUCTR_HOST=192.168.10.1
+
+For those using Windows VM, the local sandbox address ``192.168.10.1`` can be used - ensure the sandbox on the host machine has been started before proceeding further. This will allow the CLI on the Windows VM to connect to the ConductR running on the host machine.
+
+If you wish to use ConductR running from a different host, replace ``192.168.10.1`` accordingly.
+
+.. code:: bash
+
+    package-native-zip.bat [release-version-number]
+
+
+The ``package-native-zip.sh`` and ``package-native-zip.bat`` follow performs the following steps.
+
+First it builds the native executables.
 
 .. code:: bash
 
@@ -304,7 +333,7 @@ To build native packages follow the form:
     
 This will result in standalone images for your current environment being created in a ``dist`` folder.
 
-Ensure correct versions are built.
+It will ensure correct versions are built. This is done by comparing the version number from the output of the commands below with the input to the script. If there's a mismatch, the script will exit with failure.
 
 .. code:: bash
 
@@ -323,7 +352,7 @@ For Windows, perform the following since the ``sandbox`` command is not supporte
 
 .. code:: bash
 
-    ./dist/conduct info --host [host of some running ConductR]
+    ./dist/conduct info
     ./dist/shazar -h
 
 

--- a/package-native-zip.bat
+++ b/package-native-zip.bat
@@ -1,0 +1,82 @@
+echo off
+SETLOCAL
+
+set PACKAGE_VERSION_NUMBER=%1
+
+if [%PACKAGE_VERSION_NUMBER%] == [] (
+    echo "ERROR: Package version number must be specified"
+    goto EndWithError
+)
+
+del /q dist\*
+
+set PACKAGE_OS_NAME=Win32
+set PACKAGE_NAME=conductr-cli-%PACKAGE_VERSION_NUMBER%-%PACKAGE_OS_NAME%.zip
+
+echo.
+echo Building %PACKAGE_NAME%
+echo.
+
+echo ------------------------------------------------
+echo Creating single executable for 'conduct' command
+echo ------------------------------------------------
+echo.
+pyinstaller --onefile conductr_cli/conduct.py
+
+echo ------------------------------------------------
+echo Creating single executable for 'shazar' command
+echo ------------------------------------------------
+echo.
+pyinstaller --onefile conductr_cli/shazar.py
+
+echo ------------------------------------------------
+echo Creating single executable for 'sandbox' command
+echo ------------------------------------------------
+echo.
+pyinstaller --hidden-import psutil --onefile conductr_cli/sandbox.py
+
+echo ------------------------------------------------
+echo Validating version for 'conduct' command
+echo ------------------------------------------------
+echo.
+del c:\temp\conduct-version.txt
+conduct version > c:\temp\conduct-version.txt
+set /p CONDUCT_VERSION=< c:\temp\conduct-version.txt
+
+if %CONDUCT_VERSION% NEQ %PACKAGE_VERSION_NUMBER% (
+    echo ERROR: Mismatched version number for 'conduct' command
+    echo ERROR: 'conduct' command version: %CONDUCT_VERSION%
+    echo ERROR: Package version: %PACKAGE_VERSION_NUMBER%
+    goto EndWithError
+)
+
+echo ------------------------------------------------
+echo Checking 'conduct' command is working as expected
+echo ------------------------------------------------
+echo.
+conduct info
+
+echo ------------------------------------------------
+echo Checking 'shazar' command is working as expected
+echo ------------------------------------------------
+echo.
+shazar -h
+
+
+echo ------------------------------------------------
+echo Building zip archive for %PACKAGE_NAME%
+echo ------------------------------------------------
+echo.
+cd dist
+7z a %PACKAGE_NAME% conduct.exe shazar.exe sandbox.exe
+cd ..
+
+echo ------------------------------------------------
+echo Success
+echo ------------------------------------------------
+echo Created archive in dist/%PACKAGE_NAME%
+echo.
+echo.
+
+:EndWithError
+echo.

--- a/package-native-zip.sh
+++ b/package-native-zip.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+set -e
+
+CURRENT_DIR=`pwd`
+PACKAGE_VERSION_NUMBER="$1"
+
+if [ -z "$PACKAGE_VERSION_NUMBER" ]; then
+    echo "ERROR: Package version number must be specified"
+    exit 1
+fi
+
+UNAME_VALUE=`uname`
+
+if [ "$UNAME_VALUE" = "Darwin" ]; then
+    PACKAGE_OS_NAME="Mac_OS_X-x86_64"
+elif [ "$UNAME_VALUE" = "Linux" ]; then
+    PACKAGE_OS_NAME="Linux-amd64"
+else
+    echo "ERROR: Unable to build package for $UNAME_VALUE"
+    exit 1
+fi
+
+PACKAGE_NAME="conductr-cli-$PACKAGE_VERSION_NUMBER-$PACKAGE_OS_NAME.zip"
+
+echo ""
+echo "Building $PACKAGE_NAME"
+echo ""
+
+rm -f dist/*
+
+echo "------------------------------------------------"
+echo "Creating single executable for 'conduct' command"
+echo "------------------------------------------------"
+echo ""
+pyinstaller --onefile conductr_cli/conduct.py
+
+echo "------------------------------------------------"
+echo "Creating single executable for 'shazar' command"
+echo "------------------------------------------------"
+echo ""
+pyinstaller --onefile conductr_cli/shazar.py
+
+echo "------------------------------------------------"
+echo "Creating single executable for 'sandbox' command"
+echo "------------------------------------------------"
+echo ""
+pyinstaller --hidden-import psutil --onefile conductr_cli/sandbox.py
+
+
+echo "------------------------------------------------"
+echo "Validating version for 'conduct' command"
+echo "------------------------------------------------"
+echo ""
+# Do not use `head -n 1` to trim the first line of the output as this will result in broken pipe error in Linux.
+CONDUCT_VERSION=$(dist/conduct version)
+CONDUCT_VERSION=$(echo $CONDUCT_VERSION | awk '{print $1}')
+
+if [ "$CONDUCT_VERSION" != "$PACKAGE_VERSION_NUMBER" ]; then
+    echo "ERROR: Mismatched version number for 'conduct' command"
+    echo "ERROR: 'conduct' command version: $CONDUCT_VERSION"
+    echo "ERROR: Package version: $PACKAGE_VERSION_NUMBER"
+    exit 1
+fi
+
+echo "------------------------------------------------"
+echo "Validating version for 'sandbox' command"
+echo "------------------------------------------------"
+echo ""
+# Do not use `head -n 1` to trim the first line of the output as this will result in broken pipe error in Linux.
+SANDBOX_VERSION=$(dist/sandbox version)
+SANDBOX_VERSION=$(echo $SANDBOX_VERSION | awk '{print $1}')
+
+if [ "$SANDBOX_VERSION" != "$PACKAGE_VERSION_NUMBER" ]; then
+    echo "ERROR: Mismatched version number for 'sandbox' command"
+    echo "ERROR: 'sandbox' command version: $SANDBOX_VERSION"
+    echo "ERROR: Package version: $PACKAGE_VERSION_NUMBER"
+    exit 1
+fi
+
+echo "------------------------------------------------"
+echo "Checking 'sandbox' and 'conduct' command is working as expected"
+echo "------------------------------------------------"
+echo ""
+
+dist/sandbox run 2.0.0 -f visualization
+echo "Checking Visualizer"
+curl http://192.168.10.1:9008/services/visualizer
+echo ""
+conduct info
+dist/sandbox stop
+
+echo "------------------------------------------------"
+echo "Checking 'shazar' command is working as expected"
+echo "------------------------------------------------"
+echo ""
+
+dist/shazar -h
+
+echo "------------------------------------------------"
+echo "Building zip archive for $PACKAGE_NAME"
+echo "------------------------------------------------"
+echo ""
+zip -j dist/$PACKAGE_NAME dist/conduct dist/sandbox dist/shazar
+
+echo "------------------------------------------------"
+echo "Success"
+echo "------------------------------------------------"
+echo "Created archive in dist/$PACKAGE_NAME"
+echo ""
+echo ""
+


### PR DESCRIPTION
- The script `package-native-zip.sh` is for MacOS and Linux.
- The script `package-native-zip.bat` is for Windows.

README is updated accordingly.