### PR TITLE
Fix tests failing with `python3 -m unittest`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ install:
   - pip install virtualenv
   - pip install tox
 script:
+  - pip3 install -e .
   - tox
+  - python3 -m unittest
 deploy:
   provider: pypi
   user: typesafehub

--- a/conductr_cli/test/test_bndl_create.py
+++ b/conductr_cli/test/test_bndl_create.py
@@ -23,7 +23,7 @@ class TestBndlCreate(CliTestCase):
 
         with \
                 patch('sys.stdin', MagicMock(**{'buffer': BytesIO(b'')})), \
-                patch('sys.stdout.buffer', stdout_mock):
+                patch('sys.stdout.buffer.write', stdout_mock):
             bndl_create.bndl_create(attributes)
 
         self.assertEqual(
@@ -49,7 +49,7 @@ class TestBndlCreate(CliTestCase):
 
         with \
                 patch('sys.stdin', MagicMock(**{'buffer': BytesIO(b'')})), \
-                patch('sys.stdout.buffer', stdout_mock):
+                patch('sys.stdout.buffer.write', stdout_mock):
             bndl_create.bndl_create(attributes)
 
         self.assertEqual(
@@ -78,7 +78,7 @@ class TestBndlCreate(CliTestCase):
 
         with \
                 patch('sys.stdin', MagicMock(**{'buffer': BytesIO(b'')})), \
-                patch('sys.stdout.buffer', stdout_mock):
+                patch('sys.stdout.buffer.write', stdout_mock):
             bndl_create.bndl_create(attributes)
 
         self.assertEqual(
@@ -108,7 +108,7 @@ class TestBndlCreate(CliTestCase):
 
             with \
                     patch('sys.stdin', MagicMock(**{'buffer': BytesIO(b'')})), \
-                    patch('sys.stdout.buffer', stdout_mock):
+                    patch('sys.stdout.buffer.write', stdout_mock):
                 self.assertEqual(bndl_create.bndl_create(attributes), 0)
 
             self.assertTrue(zipfile.is_zipfile(tmpfile))
@@ -137,7 +137,7 @@ class TestBndlCreate(CliTestCase):
 
             with \
                     patch('sys.stdin', MagicMock(**{'buffer': BytesIO(b'')})), \
-                    patch('sys.stdout.buffer', stdout_mock):
+                    patch('sys.stdout.buffer.write', stdout_mock):
                 self.assertEqual(bndl_create.bndl_create(attributes), 0)
 
             self.assertFalse(zipfile.is_zipfile(tmpfile))

--- a/conductr_cli/test/test_bndl_main.py
+++ b/conductr_cli/test/test_bndl_main.py
@@ -77,6 +77,8 @@ class TestBndl(CliTestCase):
 
         with \
                 patch('conductr_cli.bndl_main.bndl', bndl_mock), \
+                patch('sys.stdout.isatty', lambda: False), \
+                patch('sys.stdin.isatty', lambda: False), \
                 patch('sys.exit', exit_mock):
             bndl_main.run(['-o', '-', '-'])
 


### PR DESCRIPTION
It seems `tox` and `python3 -m unittest` are slightly different. `tox` will be okay with tests that mock `sys.stdout.buffer` but `python3 -m unittest` will fail saying it's a readonly attribute. This PR adjusts travis to run tests both ways and fixes those that were failing.

This PR also included manually testing travis by only updating `travis.yml`. When I did that, I was able to verify that the tests were indeed failing. Then, I pushed another commit to get them running correctly and squashed commits, so this is ready for merge upon approval.