### PR TITLE
Add options to `bndl` to allow adjustment of docker image prior to conversion

### DIFF
--- a/conductr_cli/bndl_main.py
+++ b/conductr_cli/bndl_main.py
@@ -1,4 +1,4 @@
-from conductr_cli import logging_setup
+from conductr_cli import logging_setup, validation
 from conductr_cli.bndl_create import bndl_create
 from conductr_cli.bndl_utils import mappings
 import argcomplete
@@ -58,6 +58,21 @@ def build_parser():
                         default=True,
                         dest='use_shazar',
                         action='store_false')
+
+    parser.add_argument('--docker-cmd',
+                        help='When provided, explicitly overrides "Cmd". For use with docker format',
+                        type=validation.argparse_json,
+                        required=False)
+
+    parser.add_argument('--docker-entrypoint',
+                        help='When provided, explicitly overrides "Entrypoint". For use with docker format',
+                        type=validation.argparse_json,
+                        required=False)
+
+    parser.add_argument('--docker-env',
+                        help='When provided, explicitly overrides "Env". For use with docker format',
+                        type=validation.argparse_json,
+                        required=False)
 
     parser.add_argument('--component-description',
                         help='Description to use for the generated ConductR component',

--- a/conductr_cli/test/test_bndl_docker.py
+++ b/conductr_cli/test/test_bndl_docker.py
@@ -102,7 +102,10 @@ class TestBndlDocker(CliTestCase):
             sizes={'some digest': 1234},
             layers_to_digests={
                 '693bdf455e7bf0952f8a4539f9f96aa70c489ca239a7dbed0afb481c87cbe131/layer.tar': 'some digest'
-            }
+            },
+            docker_cmd=None,
+            docker_entrypoint=None,
+            docker_env=None
         )
 
         self.assertEqual(json.loads(data['config'].decode('UTF-8')), {
@@ -140,6 +143,76 @@ class TestBndlDocker(CliTestCase):
             'size': 307
         })
 
+    def test_docker_config_to_oci_image_overrides(self):
+        data = bndl_docker.docker_config_to_oci_image(
+            manifest={
+                'Config': '4a415e3663882fbc554ee830889c68a33b3585503892cc718a4698e91ef2a526.json',
+                'RepoTags': ['alpine:latest'],
+                'Layers': [
+                    '693bdf455e7bf0952f8a4539f9f96aa70c489ca239a7dbed0afb481c87cbe131/layer.tar'
+                ]
+            },
+            config={
+                'created': '2017-01-13T22:50:56.415736637Z',
+                'os': 'linux',
+                'architecture': 'amd64',
+                'history': [{'created': '2017-01-13T22:50:55.903893599Z', 'created_by': '/bin/sh'}],
+                'rootfs': {
+                    'type': 'layers',
+                    'diff_ids': [
+                        'sha256:98c944e98de8d35097100ff70a31083ec57704be0991a92c51700465e4544d08'
+                    ]
+                },
+                'config': {
+                    'Env': ['TEST=123'],
+                    'Cmd': ['/bin']
+                }
+            },
+            sizes={'some digest': 1234},
+            layers_to_digests={
+                '693bdf455e7bf0952f8a4539f9f96aa70c489ca239a7dbed0afb481c87cbe131/layer.tar': 'some digest'
+            },
+            docker_cmd=['/bin/sh', 'testing'],
+            docker_entrypoint=['/bin/bash', 'testing'],
+            docker_env=['ENV=/bin']
+        )
+
+        self.assertEqual(json.loads(data['config'].decode('UTF-8')), {
+            'rootfs': {
+                'type': 'layers',
+                'diff_ids': ['sha256:98c944e98de8d35097100ff70a31083ec57704be0991a92c51700465e4544d08']
+            },
+            'created': '2017-01-13T22:50:56.415736637Z',
+            'history': [{'created': '2017-01-13T22:50:55.903893599Z', 'created_by': '/bin/sh'}],
+            'config': {
+                'Cmd': ['/bin/sh', 'testing'],
+                'Env': ['ENV=/bin'],
+                'Entrypoint': ['/bin/bash', 'testing']
+            },
+            'os': 'linux',
+            'architecture': 'amd64'
+        })
+
+        self.assertEqual(json.loads(data['manifest'].decode('UTF-8')), {
+            'layers': [{
+                'digest': 'sha256:some digest',
+                'size': 1234,
+                'mediaType': 'application/vnd.oci.image.layer.v1.tar+gzip'
+            }],
+            'config': {
+                'digest': 'sha256:f6e13c6d7b63f73e7c9cf10b2b93374690eec8e151622f066d6d92a9b77eb7b2',
+                'size': 393,
+                'mediaType': 'application/vnd.oci.image.config.v1+json'
+            },
+            'schemaVersion': 2
+        })
+
+        self.assertEqual(json.loads(data['refs'].decode('UTF-8')), {
+            'digest': 'sha256:81107b157193a030f625a9db8dbe2ac6e1826ac0218db4e3df26c83a4912b795',
+            'mediaType': 'application/vnd.oci.image.manifest.v1+json',
+            'size': 307
+        })
+
     def test_docker_unpack_tar_wrong_format(self):
         file = tempfile.NamedTemporaryFile()
         dest_tmpdir = tempfile.mkdtemp()
@@ -151,7 +224,18 @@ class TestBndlDocker(CliTestCase):
             file.seek(0)
 
             with tarfile.open(fileobj=file, mode='r') as tar:
-                self.assertIsNone(bndl_docker.docker_unpack(dest_tmpdir, tar, False, None, None))
+                self.assertIsNone(
+                    bndl_docker.docker_unpack(
+                        dest_tmpdir,
+                        tar,
+                        False,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None
+                    )
+                )
         finally:
             shutil.rmtree(dest_tmpdir)
 
@@ -163,7 +247,18 @@ class TestBndlDocker(CliTestCase):
             with open(os.path.join(tmpdir, 'testing'), 'wb') as file:
                 file.write('hello'.encode('UTF-8'))
 
-            self.assertFalse(bndl_docker.docker_unpack(dest_tmpdir, tmpdir, True, None, None))
+            self.assertFalse(
+                bndl_docker.docker_unpack(
+                    dest_tmpdir,
+                    tmpdir,
+                    True,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None
+                )
+            )
         finally:
             shutil.rmtree(tmpdir)
             shutil.rmtree(dest_tmpdir)

--- a/conductr_cli/test/test_bndl_main.py
+++ b/conductr_cli/test/test_bndl_main.py
@@ -17,6 +17,9 @@ class TestBndl(CliTestCase):
         self.assertEqual(args.name, 'hello')
         self.assertEqual(args.tag, 'latest')
         self.assertTrue(args.use_shazar)
+        self.assertIsNone(args.docker_env)
+        self.assertIsNone(args.docker_entrypoint)
+        self.assertIsNone(args.docker_cmd)
 
     def test_parser_with_all_params(self):
         args = self.parser.parse_args([
@@ -46,7 +49,13 @@ class TestBndl(CliTestCase):
             '16384',
             '--roles',
             'web',
-            'backend'
+            'backend',
+            '--docker-env',
+            '["PATH=/bin"]',
+            '--docker-entrypoint',
+            '["/bin/sh", "test.sh"]',
+            '--docker-cmd',
+            '["/bin/bash", "test.sh"]'
         ])
 
         self.assertEqual(args.source, 'oci-image-dir')
@@ -64,6 +73,9 @@ class TestBndl(CliTestCase):
         self.assertEqual(args.memory, 65536)
         self.assertEqual(args.diskSpace, 16384)
         self.assertEqual(args.roles, ['web', 'backend'])
+        self.assertEqual(args.docker_env, ['PATH=/bin'])
+        self.assertEqual(args.docker_entrypoint, ['/bin/sh', 'test.sh'])
+        self.assertEqual(args.docker_cmd, ['/bin/bash', 'test.sh'])
 
     def test_parser_no_args(self):
         args = self.parser.parse_args([])

--- a/conductr_cli/test/test_validation.py
+++ b/conductr_cli/test/test_validation.py
@@ -1,32 +1,47 @@
 from argparse import ArgumentTypeError
-from conductr_cli.validation import argparse_version
+from conductr_cli.validation import argparse_json, argparse_version
 from conductr_cli.test.cli_test_case import CliTestCase
 
 
 class TestTerminal(CliTestCase):
     def test_argparse_version_number(self):
-        def expect_fail(value):
-            passed = False
+        self.assertEqual(argparse_version('1'), '1')
+        self.assertEqual(argparse_version('1.1'), '1.1')
+        self.assertEqual(argparse_version('1.1.0'), '1.1.0')
+        self.assertEqual(argparse_version('1.1.0-SNAPSHOT'), '1.1.0-SNAPSHOT')
+        self.assertEqual(argparse_version('1.2.3.4.5'), '1.2.3.4.5')
+        self.assertEqual(argparse_version('2'), '2')
+        self.assertEqual(argparse_version('2.0.0'), '2.0.0')
+        self.assertEqual(argparse_version('2.0.0-SNAPSHOT'), '2.0.0-SNAPSHOT')
 
-            try:
-                argparse_version(value)
-            except ArgumentTypeError:
-                passed = True
+        with self.assertRaises(ArgumentTypeError):
+            argparse_version('potato')
 
-            self.assertTrue(passed)
+        with self.assertRaises(ArgumentTypeError):
+            argparse_version('1.')
 
-        def expect_pass(value):
-            self.assertEqual(argparse_version(value), value)
+        with self.assertRaises(ArgumentTypeError):
+            argparse_version(' asdf 1 hello')
 
-        expect_pass('1')
-        expect_pass('1.1')
-        expect_pass('1.1.0')
-        expect_pass('1.1.0-SNAPSHOT')
-        expect_pass('1.2.3.4.5')
-        expect_pass('2')
-        expect_pass('2.0.0')
-        expect_pass('2.0.0-SNAPSHOT')
+    def test_argparse_json(self):
+        self.assertEqual(argparse_json('[]'), [])
+        self.assertEqual(argparse_json('{}'), {})
+        self.assertEqual(argparse_json('["hello", "there"]'), ['hello', 'there'])
+        self.assertEqual(argparse_json('[null]'), [None])
+        self.assertEqual(argparse_json('{"year":2000}'), {'year': 2000})
+        self.assertEqual(argparse_json('1'), 1)
+        self.assertTrue(argparse_json('true'))
+        self.assertFalse(argparse_json('false'))
+        self.assertEqual(argparse_json('0'), 0)
+        self.assertEqual(argparse_json('1.5'), 1.5)
+        self.assertEqual(argparse_json('""'), '')
+        self.assertEqual(argparse_json('null'), None)
 
-        expect_fail('potato')
-        expect_fail('1.')
-        expect_fail(' asdf 1 hello')
+        with self.assertRaises(ArgumentTypeError):
+            argparse_json('potato')
+
+        with self.assertRaises(ArgumentTypeError):
+            argparse_json('1.')
+
+        with self.assertRaises(ArgumentTypeError):
+            argparse_json("{ 'wrong': 'quotes'}")

--- a/conductr_cli/validation.py
+++ b/conductr_cli/validation.py
@@ -1,9 +1,11 @@
+import argparse
+import arrow
 import dcos
 import json
 import logging
-import urllib
-import arrow
 import platform
+import re
+import urllib
 
 from pyhocon.exceptions import ConfigException
 from requests import status_codes
@@ -523,10 +525,14 @@ def get_logger_for_func(func):
 
 
 def argparse_version(value):
-    import argparse
-    import re
-
     if re.match("^[0-9]+([.][0-9]+)*(\\-SNAPSHOT)?$", value):
         return value
 
-    raise argparse.ArgumentTypeError("'%s' is not a valid version number" % value)
+    raise argparse.ArgumentTypeError("'{}' is not a valid version number".format(value))
+
+
+def argparse_json(value):
+    try:
+        return json.loads(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError("'{}' is not valid JSON".format(value))


### PR DESCRIPTION
This commit adds a couple useful options to `bndl` to allow you to transform the docker image before it is turned into a bundle -- overwriting `Cmd`, `Entrypoint`, and `Env` is possible.

Because of how these values are used, they accept an argument in JSON format. Otherwise, there are ambiguities with argparse. For example, flags meant to be part of `Cmd` cannot easily be expressed.

**Manual Test:**

```bash
$ docker save wstest:latest | bndl --no-shazar --docker-cmd '["/hello/world"]' --docker-env '["PATH=/"]' --docker-entrypoint '["/bin/bash"]' | tar x 
-> 0

$ cat wstest/oci-image/blobs/sha256/14cc8e5430e5f7e30bee8f024e008f374d307879a5503b7ccf2d4f3a8336a841  | jsl-format-json 
{
    "architecture": "amd64",
    "config": {
        "Cmd": [
            "/hello/world"
        ],
        "Entrypoint": [
            "/bin/bash"
        ],
        "Env": [
            "PATH=/"
        ]
    },
   ...
}
