### PR TITLE
Small UX improvements for `load-license`

### DIFF
--- a/conductr_cli/conduct_main.py
+++ b/conductr_cli/conduct_main.py
@@ -413,6 +413,7 @@ def build_parser(dcos_mode):
     add_custom_settings_file(load_license_parser)
     add_custom_plugins_dir(load_license_parser)
     add_quiet_flag(load_license_parser)
+    add_verbose(load_license_parser)
     load_license_parser.add_argument('--license-download-url',
                                      dest='license_download_url',
                                      help=argparse.SUPPRESS,

--- a/conductr_cli/license_auth.py
+++ b/conductr_cli/license_auth.py
@@ -1,5 +1,6 @@
 from conductr_cli.constants import DEFAULT_AUTH_TOKEN_FILE
 import os
+import readline
 
 
 AUTH_TOKEN_PROMPT = '\nAn access token is required. Please visit https://www.lightbend.com/account/access-token to \n' \
@@ -27,9 +28,12 @@ def prompt_for_auth_token():
     Prompts for cached token from the user. Reads the token stdin keyed in by the user
     :return: cached token
     """
-    print(AUTH_TOKEN_PROMPT, end='', flush=False)
-    auth_token = input()
-    return auth_token
+    readline.clear_history()
+
+    try:
+        return input(AUTH_TOKEN_PROMPT).strip()
+    except EOFError:
+        return ''
 
 
 def remove_cached_auth_token():
@@ -45,5 +49,7 @@ def save_auth_token(auth_token):
     Saves token into local filesystem.
     :param auth_token: The auth token to be saved.
     """
+    os.makedirs(os.path.dirname(DEFAULT_AUTH_TOKEN_FILE), exist_ok=True)
+
     with open(DEFAULT_AUTH_TOKEN_FILE, 'w') as f:
         f.write(auth_token)

--- a/conductr_cli/test/test_license_auth.py
+++ b/conductr_cli/test/test_license_auth.py
@@ -42,8 +42,7 @@ class TestPromptForAuthToken(TestCase):
                 patch('builtins.input', mock_input):
             self.assertEqual(auth_token, license_auth.prompt_for_auth_token())
 
-        mock_print.assert_called_once_with(license_auth.AUTH_TOKEN_PROMPT, end='', flush=False)
-        mock_input.assert_called_once_with()
+        mock_input.assert_called_once_with(license_auth.AUTH_TOKEN_PROMPT)
 
 
 class TestRemoveCachedAuthToken(TestCase):


### PR DESCRIPTION
This PR improves a few things around `load-license`:

* input now trimmed so whitespace is ignored
* `readline` is now used so the user can delete input, plus use `CTRL-A`, `CTRL-D`, etc
* directories initialized with `os.makedirs` if not existing
* 303 considered auth error as well, but we may improve this after today's standup