### PR TITLE
Ensure `bndl` sets defaults for `bundle.conf` as appropriate

### DIFF
--- a/conductr_cli/bndl_utils.py
+++ b/conductr_cli/bndl_utils.py
@@ -1,4 +1,11 @@
 from collections import OrderedDict
+from conductr_cli.constants import \
+    BNDL_DEFAULT_COMPATIBILITY_VERSION, \
+    BNDL_DEFAULT_DISK_SPACE, \
+    BNDL_DEFAULT_MEMORY, \
+    BNDL_DEFAULT_NR_OF_CPUS, \
+    BNDL_DEFAULT_ROLES, \
+    BNDL_DEFAULT_VERSION
 import hashlib
 import os
 import re
@@ -81,7 +88,25 @@ def load_bundle_args_into_conf(config, args):
             config.put(bundle_key, value)
 
     if 'roles' not in config:
-        config.put('roles', [])
+        config.put('roles', BNDL_DEFAULT_ROLES)
+
+    if 'compatibilityVersion' not in config:
+        config.put('compatibilityVersion', BNDL_DEFAULT_COMPATIBILITY_VERSION)
+
+    if 'diskSpace' not in config:
+        config.put('diskSpace', BNDL_DEFAULT_DISK_SPACE)
+
+    if 'memory' not in config:
+        config.put('memory', BNDL_DEFAULT_MEMORY)
+
+    if 'nrOfCpus' not in config:
+        config.put('nrOfCpus', BNDL_DEFAULT_NR_OF_CPUS)
+
+    if 'system' not in config:
+        config.put('system', config.get('name'))
+
+    if 'version' not in config:
+        config.put('version', BNDL_DEFAULT_VERSION)
 
 
 def file_write_bytes(path, bs):

--- a/conductr_cli/constants.py
+++ b/conductr_cli/constants.py
@@ -3,6 +3,14 @@ import os
 # Preload this much data in the bndl tool to determine input type of a stream
 BNDL_PEEK_SIZE = 16384
 
+# Defaults for creating bundles without specifying params
+BNDL_DEFAULT_COMPATIBILITY_VERSION = 0
+BNDL_DEFAULT_DISK_SPACE = 1073741824
+BNDL_DEFAULT_MEMORY = 402653184
+BNDL_DEFAULT_NR_OF_CPUS = 0.1
+BNDL_DEFAULT_ROLES = []
+BNDL_DEFAULT_VERSION = 1
+
 CONDUCTR_SCHEME = 'CONDUCTR_SCHEME'
 
 DEFAULT_SCHEME = os.getenv(CONDUCTR_SCHEME, 'http')

--- a/conductr_cli/test/test_bndl_oci.py
+++ b/conductr_cli/test/test_bndl_oci.py
@@ -1,7 +1,6 @@
-from conductr_cli import bndl_utils, bndl_oci
+from conductr_cli import bndl_oci
 from conductr_cli.test.cli_test_case import CliTestCase, create_attributes_object, strip_margin
 from io import BytesIO
-from pyhocon import ConfigFactory
 import os
 import shutil
 import tarfile
@@ -124,38 +123,16 @@ class TestBndlOci(CliTestCase):
             'tag': 'latest'
         })
 
-        # test that config value is specified
-        simple_config = ConfigFactory.parse_string('')
-        bndl_utils.load_bundle_args_into_conf(simple_config, base_args)
-        self.assertEqual(simple_config.get('name'), 'world')
-
-        # test that config value is overwritten
-        name_config = ConfigFactory.parse_string('name = "hello"')
-        bndl_utils.load_bundle_args_into_conf(name_config, base_args)
-        self.assertEqual(name_config.get('name'), 'world')
-
-        # test that config value is retained
-        cpu_config = ConfigFactory.parse_string('nrOfCpus = 0.1')
-        bndl_utils.load_bundle_args_into_conf(cpu_config, base_args)
-        self.assertEqual(cpu_config.get('nrOfCpus'), 0.1)
-
-        config = ConfigFactory.parse_string('')
-        bndl_utils.load_bundle_args_into_conf(config, extended_args)
-
-        # test that various args are set correctly
-        self.assertEqual(config.get('name'), 'world')
-        self.assertEqual(config.get('version'), '4')
-        self.assertEqual(config.get('compatibilityVersion'), '5')
-        self.assertEqual(config.get('system'), 'myapp')
-        self.assertEqual(config.get('systemVersion'), '3')
-        self.assertEqual(config.get('nrOfCpus'), '8')
-        self.assertEqual(config.get('memory'), '65536')
-        self.assertEqual(config.get('diskSpace'), '16384')
-        self.assertEqual(config.get('roles'), ['web', 'backend'])
         self.assertEqual(
             bndl_oci.oci_image_bundle_conf(base_args, 'my-component'),
             strip_margin('''|name = "world"
                             |roles = []
+                            |compatibilityVersion = 0
+                            |diskSpace = 1073741824
+                            |memory = 402653184
+                            |nrOfCpus = 0.1
+                            |system = "world"
+                            |version = 1
                             |components {
                             |  my-component {
                             |    description = "testing desc 1"

--- a/conductr_cli/test/test_bndl_utils.py
+++ b/conductr_cli/test/test_bndl_utils.py
@@ -1,6 +1,14 @@
 from conductr_cli import bndl_utils
-from conductr_cli.test.cli_test_case import CliTestCase
+from conductr_cli.constants import \
+    BNDL_DEFAULT_COMPATIBILITY_VERSION, \
+    BNDL_DEFAULT_DISK_SPACE, \
+    BNDL_DEFAULT_MEMORY, \
+    BNDL_DEFAULT_NR_OF_CPUS, \
+    BNDL_DEFAULT_ROLES, \
+    BNDL_DEFAULT_VERSION
+from conductr_cli.test.cli_test_case import CliTestCase, create_attributes_object
 from io import BytesIO
+from pyhocon import ConfigFactory
 import os
 import shutil
 import tempfile
@@ -88,3 +96,60 @@ class TestBndlUtils(CliTestCase):
         self.assertEqual(writer.digest_out.hexdigest(), digest)
         self.assertEqual(writer.size_in, 0)
         self.assertEqual(writer.size_out, 9)
+
+    def test_load_bundle_args_into_conf(self):
+        base_args = create_attributes_object({
+            'name': 'world',
+            'component_description': 'testing desc 1',
+            'tag': 'testing'
+        })
+
+        extended_args = create_attributes_object({
+            'name': 'world',
+            'component_description': 'testing desc 2',
+            'version': '4',
+            'compatibilityVersion': '5',
+            'system': 'myapp',
+            'systemVersion': '3',
+            'nrOfCpus': '8',
+            'memory': '65536',
+            'diskSpace': '16384',
+            'roles': ['web', 'backend'],
+            'tag': 'latest'
+        })
+
+        # test that config value is specified, with defaults etc
+        simple_config = ConfigFactory.parse_string('')
+        bndl_utils.load_bundle_args_into_conf(simple_config, base_args)
+        self.assertEqual(simple_config.get('name'), 'world')
+        self.assertEqual(simple_config.get('compatibilityVersion'), BNDL_DEFAULT_COMPATIBILITY_VERSION)
+        self.assertEqual(simple_config.get('diskSpace'), BNDL_DEFAULT_DISK_SPACE)
+        self.assertEqual(simple_config.get('memory'), BNDL_DEFAULT_MEMORY)
+        self.assertEqual(simple_config.get('nrOfCpus'), BNDL_DEFAULT_NR_OF_CPUS)
+        self.assertEqual(simple_config.get('roles'), BNDL_DEFAULT_ROLES)
+        self.assertEqual(simple_config.get('system'), 'world')
+        self.assertEqual(simple_config.get('version'), BNDL_DEFAULT_VERSION)
+
+        # test that config value is overwritten
+        name_config = ConfigFactory.parse_string('name = "hello"')
+        bndl_utils.load_bundle_args_into_conf(name_config, base_args)
+        self.assertEqual(name_config.get('name'), 'world')
+
+        # test that config value is retained
+        cpu_config = ConfigFactory.parse_string('nrOfCpus = 0.1')
+        bndl_utils.load_bundle_args_into_conf(cpu_config, base_args)
+        self.assertEqual(cpu_config.get('nrOfCpus'), 0.1)
+
+        config = ConfigFactory.parse_string('')
+        bndl_utils.load_bundle_args_into_conf(config, extended_args)
+
+        # test that various args are set correctly
+        self.assertEqual(config.get('name'), 'world')
+        self.assertEqual(config.get('version'), '4')
+        self.assertEqual(config.get('compatibilityVersion'), '5')
+        self.assertEqual(config.get('system'), 'myapp')
+        self.assertEqual(config.get('systemVersion'), '3')
+        self.assertEqual(config.get('nrOfCpus'), '8')
+        self.assertEqual(config.get('memory'), '65536')
+        self.assertEqual(config.get('diskSpace'), '16384')
+        self.assertEqual(config.get('roles'), ['web', 'backend'])


### PR DESCRIPTION
This PR adds default values for `bndl` for required `bundle.conf` values.

Manual test showing successful loading:

```
$ docker save wstest | bndl | conduct load
Retrieving bundle..
Loading bundle from cache typesafe/bundle/-
Bintray credentials loaded from /home/longshorej/.lightbend/commercial.credentials
Loading bundle to ConductR..
[#################################################] 100%
Bundle 83f770f35099c542a1ca8ba5cdedc547 is installed
Bundle loaded.
Start bundle with: conduct run 83f770f
Unload bundle with: conduct unload 83f770f
Print ConductR info with: conduct info
-> 0
```