### PR TITLE
Remove duplicate lines from output

### DIFF
--- a/conductr_cli/sandbox_logs.py
+++ b/conductr_cli/sandbox_logs.py
@@ -78,7 +78,6 @@ def tail(paths, follow, print_file, read_size_kb, follow_sleep_seconds):
                 for i, line in enumerate(lines):
                     if ends_on_line or i < num_lines - 1:
                         print(line, file=print_file)
-                        print(line)
 
                 if ends_on_line:
                     f['buffer'] = ''


### PR DESCRIPTION
Prior to this commit `sandbox logs` outputted two lines for every line to output. This commit fixes that by removing what I suspect to have been a print statement left in for debugging.