### PR TITLE
Hostname lookup validation pre-check

### DIFF
--- a/conductr_cli/exceptions.py
+++ b/conductr_cli/exceptions.py
@@ -160,6 +160,14 @@ class JavaUnsupportedVersionError(Exception):
         return repr(self.jvm_version)
 
 
+class HostnameLookupError(Exception):
+    def __init__(self):
+        pass
+
+    def __str(self):
+        return repr(self)
+
+
 class DockerValidationError(Exception):
     def __init__(self, messages):
         self.messages = messages

--- a/conductr_cli/host.py
+++ b/conductr_cli/host.py
@@ -30,6 +30,10 @@ def resolve_host_from_env():
     return os.getenv(CONDUCTR_HOST, os.getenv(CONDUCTR_IP, None))
 
 
+def hostname():
+    return socket.gethostname()
+
+
 def loopback_device_name():
     return 'lo' if is_linux() else 'lo0'
 

--- a/conductr_cli/sandbox_run.py
+++ b/conductr_cli/sandbox_run.py
@@ -18,6 +18,7 @@ import sys
 @validation.handle_bintray_credentials_error
 @validation.handle_bintray_unreachable_error
 @validation.handle_jvm_validation_error
+@validation.handle_hostname_lookup_error
 @validation.handle_docker_validation_error
 @validation.handle_license_validation_error
 @validation.handle_conductr_startup_error

--- a/conductr_cli/validation.py
+++ b/conductr_cli/validation.py
@@ -13,7 +13,7 @@ from zipfile import BadZipFile
 from conductr_cli.exceptions import BindAddressNotFound, ConductrStartupError, \
     InstanceCountError, MalformedBundleError, \
     BintrayCredentialsNotFoundError, MalformedBintrayCredentialsError, BintrayUnreachableError, BundleResolutionError, \
-    WaitTimeoutError, InsecureFilePermissions, SandboxImageNotFoundError, JavaCallError, \
+    WaitTimeoutError, InsecureFilePermissions, SandboxImageNotFoundError, JavaCallError, HostnameLookupError, \
     JavaUnsupportedVendorError, JavaUnsupportedVersionError, JavaVersionParseError, DockerValidationError, \
     SandboxImageNotAvailableOfflineError, SandboxUnsupportedOsError, SandboxUnsupportedOsArchError, \
     LicenseLoadError, LicenseValidationError, LicenseDownloadError, NOT_FOUND_ERROR
@@ -433,6 +433,31 @@ def handle_jvm_validation_error(func):
 
         # Do not change the wrapped function name,
         # so argparse configuration can be tested.
+    handler.__name__ = func.__name__
+
+    return handler
+
+
+def handle_hostname_lookup_error(func):
+
+    def handler(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except HostnameLookupError:
+            log = get_logger_for_func(func)
+            log.error('Hostname lookup on your machine will take more than 5 seconds '
+                      'which will result in a ConductR startup failure')
+            log.error('This is known Java 8 issue on macOS: http://stackoverflow.com/questions/39636792/'
+                      'jvm-takes-a-long-time-to-resolve-ip-address-for-localhost')
+            log.error('To speed up the hostname lookup add your macOS hostname to /etc/hosts')
+            log.error('Resolves your hostname on the terminal with: hostname')
+            log.error('Sample /etc/hosts file:')
+            log.error('127.0.0.1   localhost mbpro.local')
+            log.error('::1         localhost mbpro.local')
+            return False
+
+            # Do not change the wrapped function name,
+            # so argparse configuration can be tested.
     handler.__name__ = func.__name__
 
     return handler


### PR DESCRIPTION
Adding additional check that the hostname lookup doesn’t take too long. This validation is necessary to check if ConductR would fail at startup given this issue with Java 8 on macOS: https://github.com/akka/akka/issues/22160

The validation is failing if the hostname is not part of the `/etc/hosts` file and if the operation system is macOS. In this case, we abort with this error:

```
$ sandbox run 2.0.5
Error: Hostname lookup on your machine will take more than 5 seconds which will result in a ConductR startup failure
Error: This is known Java 8 issue on macOS: http://stackoverflow.com/questions/39636792/jvm-takes-a-long-time-to-resolve-ip-address-for-localhost
Error: To speed up the hostname lookup add your macOS hostname to /etc/hosts
Error: Resolves your hostname on the terminal with: hostname
Error: Sample /etc/hosts file:
Error: 127.0.0.1   localhost mbpro.local
Error: ::1         localhost mbpro.local
```

We do not check for the Java version given that this error only occurs from Java 8 onwards and ConductR supports only Java 8 and onwards.

The check is only performed in sandbox JVM mode.