### PR TITLE
bndl expanded to parse OCI `ExposedPorts`

### DIFF
--- a/conductr_cli/bndl_create.py
+++ b/conductr_cli/bndl_create.py
@@ -1,4 +1,4 @@
-from conductr_cli.bndl_oci import oci_image_bundle_conf, oci_image_unpack
+from conductr_cli.bndl_oci import oci_image_bundle_conf, oci_image_extract_config, oci_image_unpack
 from conductr_cli.bndl_docker import docker_unpack
 from conductr_cli.bndl_utils import detect_format_dir, detect_format_stream
 from conductr_cli.constants import BNDL_PEEK_SIZE, IO_CHUNK_SIZE
@@ -100,7 +100,8 @@ def bndl_create(args):
 
             return 2
 
-        bundle_conf = oci_image_bundle_conf(args, component_name)
+        oci_config = oci_image_extract_config(oci_image_dir, args.tag)
+        bundle_conf = oci_image_bundle_conf(args, component_name, oci_config)
         bundle_conf_name = os.path.join(args.name, 'bundle.conf')
         bundle_conf_data = bundle_conf.encode('UTF-8')
 

--- a/conductr_cli/bndl_main.py
+++ b/conductr_cli/bndl_main.py
@@ -59,6 +59,18 @@ def build_parser():
                         dest='use_shazar',
                         action='store_false')
 
+    parser.add_argument('--no-default-endpoints',
+                        help='If enabled, a bundle will not contain endpoints for ExposedPorts. '
+                             'For use with docker and oci-image formats.',
+                        default=True,
+                        dest='use_default_endpoints',
+                        action='store_false')
+
+    parser.add_argument('--with-check',
+                        help='If enabled, a "check" component will be added to the bundle"',
+                        default=False,
+                        action='store_true')
+
     parser.add_argument('--component-description',
                         help='Description to use for the generated ConductR component',
                         default='')

--- a/conductr_cli/bndl_oci.py
+++ b/conductr_cli/bndl_oci.py
@@ -1,26 +1,86 @@
 from pyhocon import HOCONConverter, ConfigFactory, ConfigTree
 from conductr_cli.bndl_utils import load_bundle_args_into_conf
+import json
 import os
+import re
 import shutil
 import tempfile
 
 
-def oci_image_bundle_conf(args, component_name):
+def oci_image_bundle_conf(args, component_name, oci_config):
     conf = ConfigFactory.parse_string('')
     load_bundle_args_into_conf(conf, args)
+
+    endpoints_tree = ConfigTree()
 
     oci_tree = ConfigTree()
     oci_tree.put('description', args.component_description)
     oci_tree.put('file-system-type', 'oci-image')
     oci_tree.put('start-command', ['ociImageTag', args.tag])
-    oci_tree.put('endpoints', {})
+    oci_tree.put('endpoints', endpoints_tree)
 
     components_tree = ConfigTree()
     components_tree.put(component_name, oci_tree)
 
+    if args.use_default_endpoints and 'config' in oci_config and 'ExposedPorts' in oci_config['config']:
+        check_arguments = []
+
+        for exposed_port in sorted(oci_config['config']['ExposedPorts']):
+            type_parts = exposed_port.split('/', 1)
+
+            port = int(type_parts[0])
+            protocol = type_parts[1] if len(type_parts) > 1 else 'tcp'
+            name = '{}-{}-{}'.format(component_name, protocol, port)
+            check_arguments.append('${}_HOST'.format(re.sub('\\W', '_', name.upper())))
+
+            entry_tree = ConfigTree()
+            entry_tree.put('bind-protocol', protocol)
+            entry_tree.put('bind-port', port)
+            entry_tree.put('service-name', name)
+
+            endpoints_tree.put(name, entry_tree)
+
+        if len(check_arguments) > 0:
+            oci_check_tree = ConfigTree()
+            oci_check_tree.put('description', 'Status check for oci-image component')
+            oci_check_tree.put('file-system-type', 'universal')
+            oci_check_tree.put('start-command', ['check'] + check_arguments)
+            oci_check_tree.put('endpoints', {})
+
+            components_tree = ConfigTree()
+            components_tree.put(component_name, oci_tree)
+            components_tree.put('{}-status'.format(component_name), oci_check_tree)
+
     conf.put('components', components_tree)
 
     return HOCONConverter.to_hocon(conf)
+
+
+def oci_image_extract_config(dir, tag):
+    refs_path = os.path.join(dir, 'refs', tag)
+
+    if os.path.isfile(refs_path):
+        with open(refs_path, 'r') as refs_file:
+            refs_json = json.load(refs_file)
+
+        if 'digest' in refs_json:
+            manifest_parts = refs_json['digest'].split(':', 1)
+            manifest_path = os.path.join(dir, 'blobs', manifest_parts[0], manifest_parts[1])
+
+            if os.path.isfile(manifest_path):
+                with open(manifest_path, 'r') as manifest_file:
+                    manifest_json = json.load(manifest_file)
+
+                if 'config' in manifest_json and 'digest' in manifest_json['config']:
+                    config_parts = manifest_json['config']['digest'].split(':', 1)
+
+                    config_path = os.path.join(dir, 'blobs', config_parts[0], config_parts[1])
+
+                    if os.path.isfile(config_path):
+                        with open(config_path, 'r') as config_file:
+                            return json.load(config_file)
+
+    return {}
 
 
 def oci_image_unpack(destination, data, is_dir):

--- a/conductr_cli/test/test_bndl_create.py
+++ b/conductr_cli/test/test_bndl_create.py
@@ -99,12 +99,15 @@ class TestBndlCreate(CliTestCase):
                 'tag': 'latest',
                 'output': tmpfile,
                 'component_description': '',
-                'use_shazar': True
+                'use_shazar': True,
+                'use_default_endpoints': True
             })
 
             os.mkdir(os.path.join(tmpdir, 'refs'))
             open(os.path.join(tmpdir, 'oci-layout'), 'w').close()
-            open(os.path.join(tmpdir, 'refs/latest'), 'w').close()
+            refs = open(os.path.join(tmpdir, 'refs/latest'), 'w')
+            refs.write('{}')
+            refs.close()
 
             with \
                     patch('sys.stdin', MagicMock(**{'buffer': BytesIO(b'')})), \
@@ -117,6 +120,7 @@ class TestBndlCreate(CliTestCase):
 
     def test_without_shazar(self):
         stdout_mock = MagicMock()
+        extract_config_mock = MagicMock()
         tmpdir = tempfile.mkdtemp()
         tmpfile = os.path.join(tmpdir, 'output')
 
@@ -128,14 +132,18 @@ class TestBndlCreate(CliTestCase):
                 'tag': 'latest',
                 'output': tmpfile,
                 'component_description': '',
-                'use_shazar': False
+                'use_shazar': False,
+                'use_default_endpoints': True
             })
 
             os.mkdir(os.path.join(tmpdir, 'refs'))
             open(os.path.join(tmpdir, 'oci-layout'), 'w').close()
-            open(os.path.join(tmpdir, 'refs/latest'), 'w').close()
+            refs = open(os.path.join(tmpdir, 'refs/latest'), 'w')
+            refs.write('{}')
+            refs.close()
 
             with \
+                    patch('conductr_cli.bndl_oci.oci_image_extract_config', extract_config_mock), \
                     patch('sys.stdin', MagicMock(**{'buffer': BytesIO(b'')})), \
                     patch('sys.stdout.buffer.write', stdout_mock):
                 self.assertEqual(bndl_create.bndl_create(attributes), 0)

--- a/conductr_cli/test/test_bndl_docker.py
+++ b/conductr_cli/test/test_bndl_docker.py
@@ -96,7 +96,8 @@ class TestBndlDocker(CliTestCase):
                 },
                 'config': {
                     'Env': ['TEST=123'],
-                    'Cmd': ['/bin']
+                    'Cmd': ['/bin'],
+                    'ExposedPorts': {'80/tcp': {}}
                 }
             },
             sizes={'some digest': 1234},
@@ -114,7 +115,8 @@ class TestBndlDocker(CliTestCase):
             'history': [{'created': '2017-01-13T22:50:55.903893599Z', 'created_by': '/bin/sh'}],
             'config': {
                 'Cmd': ['/bin'],
-                'Env': ['TEST=123']
+                'Env': ['TEST=123'],
+                'ExposedPorts': {'80/tcp': {}}
             },
             'os': 'linux',
             'architecture': 'amd64'
@@ -127,15 +129,15 @@ class TestBndlDocker(CliTestCase):
                 'mediaType': 'application/vnd.oci.image.layer.v1.tar+gzip'
             }],
             'config': {
-                'digest': 'sha256:d1cbc4434ff3dc404a0fe22c7c2d232edb3bf39ced50952144924570878ea043',
-                'size': 339,
+                'digest': 'sha256:45d013d0948874b395f6ec383a30000dea8acf6f57705c5de5ad470c6169ef96',
+                'size': 371,
                 'mediaType': 'application/vnd.oci.image.config.v1+json'
             },
             'schemaVersion': 2
         })
 
         self.assertEqual(json.loads(data['refs'].decode('UTF-8')), {
-            'digest': 'sha256:9dadab903288242e1732b4a4f038d5a9ce57c1e0a9e1398093e7ba1ddd13357d',
+            'digest': 'sha256:94e34dd9b48fd022968081c489b105d55ef9a1a23d29c194f75d7e55ae8ec1ce',
             'mediaType': 'application/vnd.oci.image.manifest.v1+json',
             'size': 307
         })

--- a/conductr_cli/test/test_bndl_main.py
+++ b/conductr_cli/test/test_bndl_main.py
@@ -17,6 +17,7 @@ class TestBndl(CliTestCase):
         self.assertEqual(args.name, 'hello')
         self.assertEqual(args.tag, 'latest')
         self.assertTrue(args.use_shazar)
+        self.assertTrue(args.use_default_endpoints)
 
     def test_parser_with_all_params(self):
         args = self.parser.parse_args([
@@ -46,7 +47,9 @@ class TestBndl(CliTestCase):
             '16384',
             '--roles',
             'web',
-            'backend'
+            'backend',
+            '--with-check',
+            '--no-default-endpoints'
         ])
 
         self.assertEqual(args.source, 'oci-image-dir')
@@ -64,6 +67,7 @@ class TestBndl(CliTestCase):
         self.assertEqual(args.memory, 65536)
         self.assertEqual(args.diskSpace, 16384)
         self.assertEqual(args.roles, ['web', 'backend'])
+        self.assertFalse(args.use_default_endpoints)
 
     def test_parser_no_args(self):
         args = self.parser.parse_args([])


### PR DESCRIPTION
**Updated 2017-03-27 11:17 PM UTC**

This PR modifies `bndl` so that it creates `endpoint` entries in `bundle.conf` for OCI Image bundles that contain `ExposedPorts` declarations. It also creates a status component that runs `check` on the appropriate addresses. Lastly, it fixes an issue where layers that were symlinks weren't resolved properly.

A user can disable this behavior with the `--no-default-endpoints` flag but I think it's reasonable and indeed expected to be enabled by default.

### Manual Tests

```bash
$ docker save tutum/hello-world | bndl --no-shazar | tar x
-> 0

$ cat hello-world/bundle.conf 
name = "hello-world"
roles = []
compatibilityVersion = 0
diskSpace = 1073741824
memory = 402653184
nrOfCpus = 0.1
system = "hello-world"
version = 1
components {
  oci-image {
    description = ""
    file-system-type = "oci-image"
    start-command = [
      "ociImageTag"
      "latest"
    ]
    endpoints {
      oci-image-tcp-80 {
        bind-protocol = "tcp"
        bind-port = 80
        service-name = "oci-image-tcp-80"
      }
    }
  }
  oci-image-status {
    description = "Status check for oci-image component"
    file-system-type = "universal"
    start-command = [
      "check"
      "$OCI_IMAGE_TCP_80_HOST"
    ]
    endpoints {}
  }
}-> 0



docker save tutum/hello-world | bndl --no-default-endpoints --no-shazar | tar x
-> 0

cat hello-world/bundle.conf 
name = "hello-world"
roles = []
compatibilityVersion = 0
diskSpace = 1073741824
memory = 402653184
nrOfCpus = 0.1
system = "hello-world"
version = 1
components {
  oci-image {
    description = ""
    file-system-type = "oci-image"
    start-command = [
      "ociImageTag"
      "latest"
    ]
    endpoints {}
  }
}-> 0
```