### PR TITLE
Improve proxy output

### DIFF
--- a/conductr_cli/sandbox_features.py
+++ b/conductr_cli/sandbox_features.py
@@ -102,22 +102,10 @@ class ProxyingFeature:
         if not self.enabled() or None in [self.host, self.proxy_bind_addr, self.bundle_http_port, self.proxy_ports]:
             return FeatureStartResult(False, [])
         else:
-            log = logging.getLogger(__name__)
-            log.info(h1('Starting proxying feature'))
-
             started = sandbox_proxy.start_proxy(proxy_bind_addr=self.proxy_bind_addr,
                                                 bundle_http_port=self.bundle_http_port,
                                                 proxy_ports=self.proxy_ports,
                                                 all_feature_ports=all_feature_ports())
-
-            if started:
-                log.info('HAProxy has been started')
-                log.info('Your Bundles are by default accessible on:')
-                log.info('  {}:{}'.format(self.host, self.bundle_http_port))
-            else:
-                log.info('HAProxy has not been started')
-                log.info('To enable proxying ensure Docker is running and restart the sandbox')
-
             return FeatureStartResult(started, [])
 
     @staticmethod

--- a/conductr_cli/sandbox_run_jvm.py
+++ b/conductr_cli/sandbox_run_jvm.py
@@ -148,6 +148,15 @@ def log_run_attempt(args, run_result, feature_results, feature_provided):
     log.info('ConductR service locator has been started on:')
     log.info('  {}:{}'.format(run_result.host, DEFAULT_SERVICE_LOCATOR_PORT))
 
+    log.info(h2('Proxy'))
+    if FEATURE_PROVIDE_PROXYING in feature_provided:
+        log.info('HAProxy has been started')
+        log.info('By default, your bundles are accessible on:')
+        log.info('  {}:{}'.format(run_result.host, args.bundle_http_port))
+    else:
+        log.info('HAProxy has not been started')
+        log.info('To enable proxying ensure Docker is running and restart the sandbox')
+
     if feature_results:
         log.info(h2('Features'))
         log.info('The following feature related bundles have been started:')

--- a/conductr_cli/test/test_sandbox_features.py
+++ b/conductr_cli/test/test_sandbox_features.py
@@ -5,7 +5,7 @@ from conductr_cli.sandbox_features import VisualizationFeature, LiteLoggingFeatu
     LoggingFeature, MonitoringFeature, ProxyingFeature, \
     calculate_features, collect_features, feature_conflicts, select_bintray_uri
 from conductr_cli.docker import DockerVmType
-from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
+from conductr_cli.test.cli_test_case import CliTestCase
 from conductr_cli.test.data.test_constants import LATEST_CONDUCTR_VERSION
 
 
@@ -140,14 +140,6 @@ class TestProxyingFeature(CliTestCase):
             self.assertFalse(feature.start().started)
 
         proxy_start.assert_called_once_with(proxy_bind_addr='192.168.100.1', bundle_http_port=9000, proxy_ports=[], all_feature_ports=[3000, 5601, 9200, 9999])
-        self.assertEqual(
-            strip_margin("""||------------------------------------------------|
-                            || Starting proxying feature                      |
-                            ||------------------------------------------------|
-                            |HAProxy has not been started
-                            |To enable proxying ensure Docker is running and restart the sandbox
-                            |"""),
-            self.output(stdout_mock))
 
     def test_start_v2_configured_with_docker(self):
         proxy_start = MagicMock(return_value=True)
@@ -180,15 +172,6 @@ class TestProxyingFeature(CliTestCase):
             self.assertTrue(feature.start().started)
 
         proxy_start.assert_called_once_with(proxy_bind_addr='192.168.100.1', bundle_http_port=9000, proxy_ports=[], all_feature_ports=[3000, 5601, 9200, 9999])
-        self.assertEqual(
-            strip_margin("""||------------------------------------------------|
-                            || Starting proxying feature                      |
-                            ||------------------------------------------------|
-                            |HAProxy has been started
-                            |Your Bundles are by default accessible on:
-                            |  192.168.100.1:9000
-                            |"""),
-            self.output(stdout_mock))
 
     def test_stop(self):
         proxy_stop = MagicMock(return_value=True)

--- a/conductr_cli/test/test_sandbox_run_jvm.py
+++ b/conductr_cli/test/test_sandbox_run_jvm.py
@@ -1196,7 +1196,9 @@ class TestLogRunAttempt(CliTestCase):
     def test_log_output(self):
         run_mock = MagicMock()
         stdout = MagicMock()
-        input_args = MagicMock(**{})
+        input_args = MagicMock(**{
+            'bundle_http_port': 9000
+        })
 
         with patch('conductr_cli.conduct_main.run', run_mock):
             logging_setup.configure_logging(input_args, stdout)
@@ -1220,6 +1222,12 @@ class TestLogRunAttempt(CliTestCase):
                                           |  agent instances on 192.168.1.1, 192.168.1.2, 192.168.1.3
                                           |ConductR service locator has been started on:
                                           |  192.168.1.1:9008
+                                          ||- - - - - - - - - - - - - - - - - - - - - - - - |
+                                          || Proxy                                          |
+                                          ||- - - - - - - - - - - - - - - - - - - - - - - - |
+                                          |HAProxy has been started
+                                          |By default, your bundles are accessible on:
+                                          |  192.168.1.1:9000
                                           ||- - - - - - - - - - - - - - - - - - - - - - - - |
                                           || Features                                       |
                                           ||- - - - - - - - - - - - - - - - - - - - - - - - |
@@ -1247,7 +1255,8 @@ class TestLogRunAttempt(CliTestCase):
         run_mock = MagicMock()
         stdout = MagicMock()
         input_args = MagicMock(**{
-            'no_wait': False
+            'no_wait': False,
+            'bundle_http_port': 9000
         })
 
         with patch('conductr_cli.conduct_main.run', run_mock):
@@ -1270,6 +1279,12 @@ class TestLogRunAttempt(CliTestCase):
                                           |  agent instance on 192.168.1.1
                                           |ConductR service locator has been started on:
                                           |  192.168.1.1:9008
+                                          ||- - - - - - - - - - - - - - - - - - - - - - - - |
+                                          || Proxy                                          |
+                                          ||- - - - - - - - - - - - - - - - - - - - - - - - |
+                                          |HAProxy has been started
+                                          |By default, your bundles are accessible on:
+                                          |  192.168.1.1:9000
                                           ||- - - - - - - - - - - - - - - - - - - - - - - - |
                                           || Features                                       |
                                           ||- - - - - - - - - - - - - - - - - - - - - - - - |
@@ -1312,6 +1327,11 @@ class TestLogRunAttempt(CliTestCase):
                                           |  agent instances on 192.168.1.1, 192.168.1.2, 192.168.1.3
                                           |ConductR service locator has been started on:
                                           |  192.168.1.1:9008
+                                          ||- - - - - - - - - - - - - - - - - - - - - - - - |
+                                          || Proxy                                          |
+                                          ||- - - - - - - - - - - - - - - - - - - - - - - - |
+                                          |HAProxy has not been started
+                                          |To enable proxying ensure Docker is running and restart the sandbox
                                           ||- - - - - - - - - - - - - - - - - - - - - - - - |
                                           || Features                                       |
                                           ||- - - - - - - - - - - - - - - - - - - - - - - - |


### PR DESCRIPTION
Since the HAProxy logic has moved to a feature, the summary of the Proxy is displayed when HAProxy is started and not in the summary section.

This PR, is changing the output logic so that the Proxy summary is again displayed in the summary section:

```
|- - - - - - - - - - - - - - - - - - - - - - - - |
| Proxy                                          |
|- - - - - - - - - - - - - - - - - - - - - - - - |
HAProxy has not been started
To enable proxying ensure Docker is running and restart the sandbox
```