### PR TITLE
Validate bintray credentials on demand

### DIFF
--- a/conductr_cli/conduct_load.py
+++ b/conductr_cli/conduct_load.py
@@ -31,6 +31,7 @@ KEEP_BUNDLE_VERSIONS = 1
 @validation.handle_wait_timeout_error
 @validation.handle_conduct_load_read_timeout_error
 @validation.handle_insecure_file_permissions
+@validation.handle_bintray_resolution_error
 @validation.handle_bintray_credentials_error
 def load(args):
     if args.api_version == '1':

--- a/conductr_cli/exceptions.py
+++ b/conductr_cli/exceptions.py
@@ -38,11 +38,11 @@ class MalformedBundleUriError(Exception):
 
 
 class BintrayResolutionError(Exception):
-    def __init__(self, value):
-        self.value = value
+    def __init__(self, message):
+        self.message = message
 
     def __str__(self):
-        return repr(self.value)
+        return repr(self.message)
 
 
 class BintrayUnreachableError(Exception):

--- a/conductr_cli/sandbox_common.py
+++ b/conductr_cli/sandbox_common.py
@@ -115,7 +115,11 @@ def bundle_http_port():
 
 
 def major_version(version):
-    return int(version[0])
+    return version_parts(version)[0]
+
+
+def version_parts(version):
+    return tuple(map(int, version.split('.')))
 
 
 def resolve_conductr_roles_by_instance(user_conductr_roles, feature_conductr_roles, instance):

--- a/conductr_cli/sandbox_run.py
+++ b/conductr_cli/sandbox_run.py
@@ -15,6 +15,7 @@ import sys
 @validation.handle_sandbox_image_not_available_offline_error
 @validation.handle_sandbox_unsupported_os_error
 @validation.handle_sandbox_unsupported_os_arch_error
+@validation.handle_bintray_resolution_error
 @validation.handle_bintray_credentials_error
 @validation.handle_bintray_unreachable_error
 @validation.handle_jvm_validation_error

--- a/conductr_cli/test/test_sandbox_run_jvm.py
+++ b/conductr_cli/test/test_sandbox_run_jvm.py
@@ -4,7 +4,7 @@ from conductr_cli.constants import DEFAULT_LICENSE_FILE, FEATURE_PROVIDE_PROXYIN
 from conductr_cli.exceptions import BindAddressNotFound, InstanceCountError, BintrayUnreachableError, \
     SandboxImageNotFoundError, SandboxImageNotAvailableOfflineError, SandboxUnsupportedOsError, \
     SandboxUnsupportedOsArchError, JavaCallError, JavaUnsupportedVendorError, JavaUnsupportedVersionError, \
-    JavaVersionParseError, LicenseValidationError, HostnameLookupError
+    JavaVersionParseError, LicenseValidationError, HostnameLookupError, BintrayCredentialsNotFoundError
 from conductr_cli.sandbox_features import LoggingFeature
 from conductr_cli.sandbox_run_jvm import BIND_TEST_PORT
 from unittest.mock import call, patch, MagicMock
@@ -38,6 +38,7 @@ class TestRun(CliTestCase):
         mock_validate_jvm_support = MagicMock()
         mock_validate_hostname_lookup = MagicMock()
         mock_validate_64bit_support = MagicMock()
+        mock_validate_bintray_credentials = MagicMock()
         mock_cleanup_tmp_dir = MagicMock()
 
         bind_addr = MagicMock()
@@ -66,6 +67,7 @@ class TestRun(CliTestCase):
         with patch('conductr_cli.sandbox_run_jvm.validate_jvm_support', mock_validate_jvm_support), \
                 patch('conductr_cli.sandbox_run_jvm.validate_hostname_lookup', mock_validate_hostname_lookup), \
                 patch('conductr_cli.sandbox_run_jvm.validate_64bit_support', mock_validate_64bit_support), \
+                patch('conductr_cli.sandbox_run_jvm.validate_bintray_credentials', mock_validate_bintray_credentials), \
                 patch('conductr_cli.sandbox_run_jvm.cleanup_tmp_dir', mock_cleanup_tmp_dir), \
                 patch('conductr_cli.sandbox_run_jvm.find_bind_addrs', mock_find_bind_addrs), \
                 patch('conductr_cli.sandbox_run_jvm.obtain_sandbox_image', mock_obtain_sandbox_image), \
@@ -84,6 +86,7 @@ class TestRun(CliTestCase):
         mock_validate_jvm_support.assert_called_once_with()
         mock_validate_hostname_lookup.assert_called_once_with()
         mock_validate_64bit_support.assert_called_once_with()
+        mock_validate_bintray_credentials.assert_called_once_with('2.0.0', False)
         mock_cleanup_tmp_dir.assert_called_once_with(self.tmp_dir)
         mock_find_bind_addrs.assert_called_with(1, self.addr_range)
         mock_start_core_instances.assert_called_with(mock_core_extracted_dir,
@@ -115,6 +118,7 @@ class TestRun(CliTestCase):
         mock_validate_jvm_support = MagicMock()
         mock_validate_64bit_support = MagicMock()
         mock_validate_hostname_lookup = MagicMock()
+        mock_validate_bintray_credentials = MagicMock()
         mock_cleanup_tmp_dir = MagicMock()
 
         bind_addr1 = MagicMock()
@@ -149,6 +153,7 @@ class TestRun(CliTestCase):
         with patch('conductr_cli.sandbox_run_jvm.validate_jvm_support', mock_validate_jvm_support), \
                 patch('conductr_cli.sandbox_run_jvm.validate_hostname_lookup', mock_validate_hostname_lookup), \
                 patch('conductr_cli.sandbox_run_jvm.validate_64bit_support', mock_validate_64bit_support), \
+                patch('conductr_cli.sandbox_run_jvm.validate_bintray_credentials', mock_validate_bintray_credentials), \
                 patch('conductr_cli.sandbox_run_jvm.cleanup_tmp_dir', mock_cleanup_tmp_dir), \
                 patch('conductr_cli.sandbox_run_jvm.find_bind_addrs', mock_find_bind_addrs), \
                 patch('conductr_cli.sandbox_run_jvm.obtain_sandbox_image', mock_obtain_sandbox_image), \
@@ -167,6 +172,7 @@ class TestRun(CliTestCase):
         mock_validate_jvm_support.assert_called_once_with()
         mock_validate_hostname_lookup.assert_called_once_with()
         mock_validate_64bit_support.assert_called_once_with()
+        mock_validate_bintray_credentials.assert_called_once_with('2.0.0', False)
         mock_cleanup_tmp_dir.assert_called_once_with(self.tmp_dir)
         mock_find_bind_addrs.assert_called_with(3, self.addr_range)
         mock_start_core_instances.assert_called_with(mock_core_extracted_dir,
@@ -198,6 +204,7 @@ class TestRun(CliTestCase):
         mock_validate_jvm_support = MagicMock()
         mock_validate_hostname_lookup = MagicMock()
         mock_validate_64bit_support = MagicMock()
+        mock_validate_bintray_credentials = MagicMock()
 
         bind_addr1 = MagicMock()
         bind_addr2 = MagicMock()
@@ -244,6 +251,7 @@ class TestRun(CliTestCase):
         with patch('conductr_cli.sandbox_run_jvm.validate_jvm_support', mock_validate_jvm_support), \
                 patch('conductr_cli.sandbox_run_jvm.validate_hostname_lookup', mock_validate_hostname_lookup), \
                 patch('conductr_cli.sandbox_run_jvm.validate_64bit_support', mock_validate_64bit_support), \
+                patch('conductr_cli.sandbox_run_jvm.validate_bintray_credentials', mock_validate_bintray_credentials), \
                 patch('conductr_cli.sandbox_run_jvm.find_bind_addrs', mock_find_bind_addrs), \
                 patch('conductr_cli.sandbox_run_jvm.obtain_sandbox_image', mock_obtain_sandbox_image), \
                 patch('conductr_cli.sandbox_stop.stop', mock_sandbox_stop), \
@@ -261,6 +269,7 @@ class TestRun(CliTestCase):
         mock_validate_jvm_support.assert_called_once_with()
         mock_validate_hostname_lookup.assert_called_once_with()
         mock_validate_64bit_support.assert_called_once_with()
+        mock_validate_bintray_credentials.assert_called_once_with('2.0.0', False)
         mock_find_bind_addrs.assert_called_with(1, self.addr_range)
         mock_start_core_instances.assert_called_with(mock_core_extracted_dir,
                                                      self.tmp_dir,
@@ -291,6 +300,7 @@ class TestRun(CliTestCase):
         mock_validate_jvm_support = MagicMock()
         mock_validate_hostname_lookup = MagicMock()
         mock_validate_64bit_support = MagicMock()
+        mock_validate_bintray_credentials = MagicMock()
         mock_cleanup_tmp_dir = MagicMock()
 
         bind_addr = MagicMock()
@@ -324,6 +334,7 @@ class TestRun(CliTestCase):
         with patch('conductr_cli.sandbox_run_jvm.validate_jvm_support', mock_validate_jvm_support), \
                 patch('conductr_cli.sandbox_run_jvm.validate_hostname_lookup', mock_validate_hostname_lookup), \
                 patch('conductr_cli.sandbox_run_jvm.validate_64bit_support', mock_validate_64bit_support), \
+                patch('conductr_cli.sandbox_run_jvm.validate_bintray_credentials', mock_validate_bintray_credentials), \
                 patch('conductr_cli.sandbox_run_jvm.cleanup_tmp_dir', mock_cleanup_tmp_dir), \
                 patch('conductr_cli.sandbox_run_jvm.find_bind_addrs', mock_find_bind_addrs), \
                 patch('conductr_cli.sandbox_run_jvm.obtain_sandbox_image', mock_obtain_sandbox_image), \
@@ -342,6 +353,7 @@ class TestRun(CliTestCase):
         mock_validate_jvm_support.assert_called_once_with()
         mock_validate_hostname_lookup.assert_called_once_with()
         mock_validate_64bit_support.assert_called_once_with()
+        mock_validate_bintray_credentials.assert_called_once_with('2.0.0', False)
         mock_cleanup_tmp_dir.assert_called_once_with(self.tmp_dir)
         mock_find_bind_addrs.assert_called_with(1, self.addr_range)
         mock_start_core_instances.assert_called_with(mock_core_extracted_dir,
@@ -373,6 +385,7 @@ class TestRun(CliTestCase):
         mock_validate_jvm_support = MagicMock()
         mock_validate_hostname_lookup = MagicMock()
         mock_validate_64bit_support = MagicMock()
+        mock_validate_bintray_credentials = MagicMock()
         mock_cleanup_tmp_dir = MagicMock()
 
         bind_addr = MagicMock()
@@ -400,6 +413,7 @@ class TestRun(CliTestCase):
         with patch('conductr_cli.sandbox_run_jvm.validate_jvm_support', mock_validate_jvm_support), \
                 patch('conductr_cli.sandbox_run_jvm.validate_hostname_lookup', mock_validate_hostname_lookup), \
                 patch('conductr_cli.sandbox_run_jvm.validate_64bit_support', mock_validate_64bit_support), \
+                patch('conductr_cli.sandbox_run_jvm.validate_bintray_credentials', mock_validate_bintray_credentials), \
                 patch('conductr_cli.sandbox_run_jvm.cleanup_tmp_dir', mock_cleanup_tmp_dir), \
                 patch('conductr_cli.sandbox_run_jvm.find_bind_addrs', mock_find_bind_addrs), \
                 patch('conductr_cli.sandbox_run_jvm.obtain_sandbox_image', mock_obtain_sandbox_image), \
@@ -413,6 +427,7 @@ class TestRun(CliTestCase):
         mock_validate_jvm_support.assert_called_once_with()
         mock_validate_hostname_lookup.assert_called_once_with()
         mock_validate_64bit_support.assert_called_once_with()
+        mock_validate_bintray_credentials.assert_called_once_with('2.0.0', False)
         mock_cleanup_tmp_dir.assert_called_once_with(self.tmp_dir)
         mock_find_bind_addrs.assert_called_with(1, self.addr_range)
         mock_start_core_instances.assert_called_with(mock_core_extracted_dir,
@@ -1503,6 +1518,41 @@ class TestValidate64BitSupport(CliTestCase):
                               sandbox_run_jvm.validate_64bit_support)
 
 
+class TestValidateBintrayCredentials(CliTestCase):
+    def test_check_passed(self):
+        mock_load_bintray_credentials = MagicMock()
+
+        with patch('conductr_cli.resolvers.bintray_resolver.load_bintray_credentials', mock_load_bintray_credentials):
+            sandbox_run_jvm.validate_bintray_credentials('2.0.0', offline_mode=False)
+
+        mock_load_bintray_credentials.assert_called_once_with(disable_instructions=True, raise_error=True)
+
+    def test_check_failed(self):
+        mock_load_bintray_credentials = MagicMock(side_effect=BintrayCredentialsNotFoundError('test only'))
+
+        with patch('conductr_cli.resolvers.bintray_resolver.load_bintray_credentials', mock_load_bintray_credentials):
+            self.assertRaises(BintrayCredentialsNotFoundError,
+                              sandbox_run_jvm.validate_bintray_credentials, '2.0.0', offline_mode=False)
+
+        mock_load_bintray_credentials.assert_called_once_with(disable_instructions=True, raise_error=True)
+
+    def test_no_check_offline_mode(self):
+        mock_load_bintray_credentials = MagicMock()
+
+        with patch('conductr_cli.resolvers.bintray_resolver.load_bintray_credentials', mock_load_bintray_credentials):
+            sandbox_run_jvm.validate_bintray_credentials('2.0.0', offline_mode=True)
+
+        mock_load_bintray_credentials.assert_not_called()
+
+    def test_no_check_conductr_version(self):
+        mock_load_bintray_credentials = MagicMock()
+
+        with patch('conductr_cli.resolvers.bintray_resolver.load_bintray_credentials', mock_load_bintray_credentials):
+            sandbox_run_jvm.validate_bintray_credentials('2.1.0', offline_mode=False)
+
+        mock_load_bintray_credentials.assert_not_called()
+
+
 class TestDownloadSandboxImage(CliTestCase):
     bintray_auth = ('Bintray', 'username', 'password')
 
@@ -1586,7 +1636,7 @@ class TestDownloadSandboxImage(CliTestCase):
                                                                     self.core_artefact_type,
                                                                     self.image_version))
 
-        mock_load_bintray_credentials.assert_called_once_with()
+        mock_load_bintray_credentials.assert_called_once_with(raise_error=False)
         mock_bintray_artefacts_by_version.assert_called_once_with(self.bintray_auth,
                                                                   'lightbend',
                                                                   'commercial-releases',
@@ -1620,7 +1670,7 @@ class TestDownloadSandboxImage(CliTestCase):
                                                                     self.agent_artefact_type,
                                                                     self.image_version))
 
-        mock_load_bintray_credentials.assert_called_once_with()
+        mock_load_bintray_credentials.assert_called_once_with(raise_error=False)
         mock_bintray_artefacts_by_version.assert_called_once_with(self.bintray_auth,
                                                                   'lightbend',
                                                                   'commercial-releases',
@@ -1645,7 +1695,7 @@ class TestDownloadSandboxImage(CliTestCase):
                               self.core_artefact_type,
                               self.image_version)
 
-        mock_load_bintray_credentials.assert_called_once_with()
+        mock_load_bintray_credentials.assert_called_once_with(raise_error=False)
         mock_bintray_artefacts_by_version.assert_called_once_with(self.bintray_auth,
                                                                   'lightbend',
                                                                   'commercial-releases',
@@ -1667,7 +1717,7 @@ class TestDownloadSandboxImage(CliTestCase):
                               self.core_artefact_type,
                               self.image_version)
 
-        mock_load_bintray_credentials.assert_called_once_with()
+        mock_load_bintray_credentials.assert_called_once_with(raise_error=False)
         mock_bintray_artefacts_by_version.assert_called_once_with(self.bintray_auth,
                                                                   'lightbend',
                                                                   'commercial-releases',
@@ -1692,7 +1742,7 @@ class TestDownloadSandboxImage(CliTestCase):
                               self.core_artefact_type,
                               self.image_version)
 
-        mock_load_bintray_credentials.assert_called_once_with()
+        mock_load_bintray_credentials.assert_called_once_with(raise_error=False)
         mock_bintray_artefacts_by_version.assert_called_once_with(self.bintray_auth,
                                                                   'lightbend',
                                                                   'commercial-releases',
@@ -1721,7 +1771,7 @@ class TestDownloadSandboxImage(CliTestCase):
                               self.core_artefact_type,
                               self.image_version)
 
-        mock_load_bintray_credentials.assert_called_once_with()
+        mock_load_bintray_credentials.assert_called_once_with(raise_error=False)
         mock_bintray_artefacts_by_version.assert_called_once_with(self.bintray_auth,
                                                                   'lightbend',
                                                                   'commercial-releases',

--- a/conductr_cli/validation.py
+++ b/conductr_cli/validation.py
@@ -12,11 +12,12 @@ from urllib.error import URLError
 from zipfile import BadZipFile
 from conductr_cli.exceptions import BindAddressNotFound, ConductrStartupError, \
     InstanceCountError, MalformedBundleError, \
-    BintrayCredentialsNotFoundError, MalformedBintrayCredentialsError, BintrayUnreachableError, BundleResolutionError, \
-    WaitTimeoutError, InsecureFilePermissions, SandboxImageNotFoundError, JavaCallError, HostnameLookupError, \
-    JavaUnsupportedVendorError, JavaUnsupportedVersionError, JavaVersionParseError, DockerValidationError, \
-    SandboxImageNotAvailableOfflineError, SandboxUnsupportedOsError, SandboxUnsupportedOsArchError, \
-    LicenseLoadError, LicenseValidationError, LicenseDownloadError, NOT_FOUND_ERROR
+    BintrayCredentialsNotFoundError, MalformedBintrayCredentialsError, BintrayResolutionError, \
+    BintrayUnreachableError, BundleResolutionError, WaitTimeoutError, InsecureFilePermissions, \
+    SandboxImageNotFoundError, JavaCallError, HostnameLookupError, JavaUnsupportedVendorError, \
+    JavaUnsupportedVersionError, JavaVersionParseError, DockerValidationError, SandboxImageNotAvailableOfflineError, \
+    SandboxUnsupportedOsError, SandboxUnsupportedOsArchError, LicenseLoadError, LicenseValidationError, \
+    LicenseDownloadError, NOT_FOUND_ERROR
 
 
 def connection_error(log, err, args):
@@ -358,6 +359,23 @@ def handle_sandbox_restart_error(func):
     return handler
 
 
+def handle_bintray_resolution_error(func):
+
+    def handler(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except BintrayResolutionError as e:
+            log = get_logger_for_func(func)
+            log.error(e.message)
+            return False
+
+            # Do not change the wrapped function name,
+            # so argparse configuration can be tested.
+    handler.__name__ = func.__name__
+
+    return handler
+
+
 def handle_bintray_unreachable_error(func):
 
     def handler(*args, **kwargs):
@@ -384,7 +402,7 @@ def handle_bintray_credentials_error(func):
             return func(*args, **kwargs)
         except BintrayCredentialsNotFoundError as e:
             log = get_logger_for_func(func)
-            log.error('Nearly there! The ConductR artifacts and bundles are hosted on Bintray.')
+            log.error('Nearly there! The ConductR artifacts are hosted on private Bintray repository.')
             log.error('It is therefore necessary to create a Bintray credentials file at {}'
                       .format(e.credential_file_path))
             log.error('For more information how to setup the Lightbend Bintray credentials please follow:')


### PR DESCRIPTION
So far have checked for valid Bintray credentials every time the sandbox has been started or a bundle has been loaded from Bintray.

Due to the fact that the ConductR artifacts are available on a public Bintray repository, we don’t need to perform this check every time. Also, every bundle is hosted on a public Bintray repository, including the monitoring bundles (https://bintray.com/lightbend/commercial-monitoring is also public). As a result, the user doesn’t need to setup Bintray credentials anymore from onwards ConductR 2.1.0.

This PR is:
- Adding a new validation to `sandbox_run_jvm` that checks based on the ConductR version if Bintray credentials are needed. If Bintray credentials are needed and the credential file is not created or malformed then the `sandbox run` command will abort before starting ConductR
- Changing the Bintray resolver so that no exception is thrown anymore if the credentials could not be loaded. Instead, we now try to download the artifacts without credentials. If a `404 Not Found` with the response text `Repo my-repo was not found` then we will catch this error and abort with the message:

    ```
    $ conduct load lightbend/commercial-releases/ConductR-Agent-Debian
    Retrieving bundle..
    Loading bundle from cache lightbend/commercial-releases/ConductR-Agent-Debian
    Error: Unable to find Bintray repository lightbend/commercial-releases. If this is a private repository make sure to setup the Bintray credentials at /Users/mj/.lightbend/commercial.credentials
    ```

Note that this message is only thrown for private Bintray repositories and after our `sandbox run` validation check. So for all ConductR artificats hosted on Bintray this error should never occur. The error should only occur in case the user wants to load bundles from a custom private repository.