### PR TITLE
Adjust `sandbox` run to set -Dconductr.agent.run.force-oci-docker

### DIFF
--- a/conductr_cli/sandbox_run_jvm.py
+++ b/conductr_cli/sandbox_run_jvm.py
@@ -624,6 +624,9 @@ def start_agent_instances(agent_extracted_dir, tmp_dir,
             '-Dconductr.agent.roles.{}={}'.format(j, role) for j, role in enumerate(agent_roles)
         ]
 
+        if not host.is_linux():
+            commands.append('-Dconductr.agent.run.force-oci-docker=on')
+
         if args:
             commands.extend(args)
         if args_agent:


### PR DESCRIPTION
This PR adjusts `sandbox run` to set `-Dconductr.agent.run.force-oci-docker=on` when running in non-linux environments. We do this so that ConductR doesn't need to be concerned about the OS it is running on -- only the CLI needs to specify this parameter. See https://github.com/typesafehub/conductr/pull/1714#issuecomment-289658448 for more information.

**Note**: If you're running on Linux and wish to enable this option, you can use the existing `--arg-agent`. For example: 

`sandbox run 2.0.5 --arg-agent='-Dconductr.agent.run.force-oci-docker=on'`