### PR TITLE
Output conduct info bundle-id command

### DIFF
--- a/conductr_cli/conduct_load.py
+++ b/conductr_cli/conduct_load.py
@@ -105,9 +105,10 @@ def load_v1(args):
 
     log.info('Bundle loaded.')
     if not args.disable_instructions:
-        log.info('Start bundle with: {} run{} {}'.format(args.command, args.cli_parameters, bundle_id))
-        log.info('Unload bundle with: {} unload{} {}'.format(args.command, args.cli_parameters, bundle_id))
+        log.info('Start bundle with:        {} run{} {}'.format(args.command, args.cli_parameters, bundle_id))
+        log.info('Unload bundle with:       {} unload{} {}'.format(args.command, args.cli_parameters, bundle_id))
         log.info('Print ConductR info with: {} info{}'.format(args.command, args.cli_parameters))
+        log.info('Print bundle info with:   {} info{} {}'.format(args.command, args.cli_parameters, bundle_id))
 
     if not log.is_info_enabled() and log.is_quiet_enabled():
         log.quiet(response_json['bundleId'])
@@ -220,9 +221,10 @@ def load_v2(args):
 
     log.info('Bundle loaded.')
     if not args.disable_instructions:
-        log.info('Start bundle with: {} run{} {}'.format(args.command, args.cli_parameters, bundle_id))
-        log.info('Unload bundle with: {} unload{} {}'.format(args.command, args.cli_parameters, bundle_id))
+        log.info('Start bundle with:        {} run{} {}'.format(args.command, args.cli_parameters, bundle_id))
+        log.info('Unload bundle with:       {} unload{} {}'.format(args.command, args.cli_parameters, bundle_id))
         log.info('Print ConductR info with: {} info{}'.format(args.command, args.cli_parameters))
+        log.info('Print bundle info with:   {} info{} {}'.format(args.command, args.cli_parameters, bundle_id))
 
     if not log.is_info_enabled() and log.is_quiet_enabled():
         log.quiet(response_json['bundleId'])

--- a/conductr_cli/conduct_run.py
+++ b/conductr_cli/conduct_run.py
@@ -37,7 +37,8 @@ def run(args):
         bundle_scale.wait_for_scale(response_json['bundleId'], args.scale, args)
 
     if not args.disable_instructions:
-        log.info('Stop bundle with: {} stop{} {}'.format(args.command, args.cli_parameters, bundle_id))
+        log.info('Stop bundle with:         {} stop{} {}'.format(args.command, args.cli_parameters, bundle_id))
         log.info('Print ConductR info with: {} info{}'.format(args.command, args.cli_parameters))
+        log.info('Print bundle info with:   {} info{} {}'.format(args.command, args.cli_parameters, bundle_id))
 
     return True

--- a/conductr_cli/conduct_stop.py
+++ b/conductr_cli/conduct_stop.py
@@ -30,7 +30,8 @@ def stop(args):
         bundle_scale.wait_for_scale(response_json['bundleId'], 0, args)
 
     if not args.disable_instructions:
-        log.info('Unload bundle with: {} unload{} {}'.format(args.command, args.cli_parameters, bundle_id))
+        log.info('Unload bundle with:       {} unload{} {}'.format(args.command, args.cli_parameters, bundle_id))
         log.info('Print ConductR info with: {} info{}'.format(args.command, args.cli_parameters))
+        log.info('Print bundle info with:   {} info{} {}'.format(args.command, args.cli_parameters, bundle_id))
 
     return True

--- a/conductr_cli/test/conduct_load_test_base.py
+++ b/conductr_cli/test/conduct_load_test_base.py
@@ -11,9 +11,10 @@ class ConductLoadTestBase(CliTestCase):
     output_template = """|Retrieving bundle..
                          |{downloading_configuration}Loading bundle to ConductR..
                          |{verbose}Bundle loaded.
-                         |Start bundle with: {command} run{params} {bundle_id}
-                         |Unload bundle with: {command} unload{params} {bundle_id}
+                         |Start bundle with:        {command} run{params} {bundle_id}
+                         |Unload bundle with:       {command} unload{params} {bundle_id}
                          |Print ConductR info with: {command} info{params}
+                         |Print bundle info with:   {command} info{params} {bundle_id}
                          |"""
 
     def __init__(self, method_name):

--- a/conductr_cli/test/test_conduct_run_v1.py
+++ b/conductr_cli/test/test_conduct_run_v1.py
@@ -35,8 +35,9 @@ class TestConductRunCommand(ConductRunTestBase):
         self.default_url = 'http://127.0.0.1:9005/bundles/45e0c477d3e5ea92aa8d85c0d8f3e25c?scale=3'
 
         self.output_template = """|Bundle run request sent.
-                                  |Stop bundle with: conduct stop{params} {bundle_id}
+                                  |Stop bundle with:         conduct stop{params} {bundle_id}
                                   |Print ConductR info with: conduct info{params}
+                                  |Print bundle info with:   conduct info{params} {bundle_id}
                                   |"""
 
     def test_success(self):

--- a/conductr_cli/test/test_conduct_run_v2.py
+++ b/conductr_cli/test/test_conduct_run_v2.py
@@ -34,8 +34,9 @@ class TestConductRunCommand(ConductRunTestBase):
         self.default_url = 'http://127.0.0.1:9005/v2/bundles/45e0c477d3e5ea92aa8d85c0d8f3e25c?scale=3'
 
         self.output_template = """|Bundle run request sent.
-                                  |Stop bundle with: conduct stop{params} {bundle_id}
+                                  |Stop bundle with:         conduct stop{params} {bundle_id}
                                   |Print ConductR info with: conduct info{params}
+                                  |Print bundle info with:   conduct info{params} {bundle_id}
                                   |"""
 
     def test_success(self):

--- a/conductr_cli/test/test_conduct_stop.py
+++ b/conductr_cli/test/test_conduct_stop.py
@@ -41,8 +41,9 @@ class TestConductStopCommand(CliTestCase):
     default_url = 'http://127.0.0.1:9005/bundles/45e0c477d3e5ea92aa8d85c0d8f3e25c?scale=0'
 
     output_template = """|Bundle stop request sent.
-                         |Unload bundle with: conduct unload{params} {bundle_id}
+                         |Unload bundle with:       conduct unload{params} {bundle_id}
                          |Print ConductR info with: conduct info{params}
+                         |Print bundle info with:   conduct info{params} {bundle_id}
                          |"""
 
     def default_output(self, params='', bundle_id='45e0c47'):


### PR DESCRIPTION
After each conduct command we print out useful commands to continue with. e.g.

```
$ conduct run testing-signals
Bundle run request sent.
Bundle 7e08c7f10f68995a0f370d8b3ce68207 waiting to reach expected scale 1
Bundle 7e08c7f10f68995a0f370d8b3ce68207 has scale 0, expected 1
Bundle 7e08c7f10f68995a0f370d8b3ce68207 expected scale 1 is met
Stop bundle with: conduct stop 7e08c7f
Print ConductR info with: conduct info
```

This PR is adding the `conduct info bundle-id` command to print the bundle status. It also formats the lines so that each command is better visible:

```
$ conduct run testing-signals
Bundle run request sent.
Bundle 7e08c7f10f68995a0f370d8b3ce68207 waiting to reach expected scale 1
Bundle 7e08c7f10f68995a0f370d8b3ce68207 has scale 0, expected 1
Bundle 7e08c7f10f68995a0f370d8b3ce68207 expected scale 1 is met
Stop bundle with:         conduct stop 7e08c7f
Print ConductR info with: conduct info
Print bundle info with:   conduct info 7e08c7f
```