### PR TITLE
Encapsulating ConductR version validation

### DIFF
--- a/conductr_cli/sandbox_common.py
+++ b/conductr_cli/sandbox_common.py
@@ -114,14 +114,6 @@ def bundle_http_port():
     return int(os.getenv('BUNDLE_HTTP_PORT', 9000))
 
 
-def major_version(version):
-    return version_parts(version)[0]
-
-
-def version_parts(version):
-    return tuple(map(int, version.split('.')))
-
-
 def resolve_conductr_roles_by_instance(user_conductr_roles, feature_conductr_roles, instance):
     if not user_conductr_roles:
         # No ConductR roles have been specified => Return an empty list

--- a/conductr_cli/sandbox_main.py
+++ b/conductr_cli/sandbox_main.py
@@ -3,7 +3,8 @@ import argparse
 import ipaddress
 import re
 import sys
-from conductr_cli.sandbox_common import CONDUCTR_DEV_IMAGE, major_version
+from conductr_cli.sandbox_common import CONDUCTR_DEV_IMAGE
+from conductr_cli.sandbox_version import is_sandbox_docker_based
 from conductr_cli.sandbox_features import feature_conflicts, feature_names
 from conductr_cli.constants import DEFAULT_SANDBOX_ADDR_RANGE, DEFAULT_SANDBOX_IMAGE_DIR, DEFAULT_SANDBOX_TMP_DIR, \
     DEFAULT_OFFLINE_MODE
@@ -294,7 +295,7 @@ def run(_args=[], configure_logging=True):
 
         # Docker VM validation
         args.vm_type = docker.vm_type()
-        if vars(args).get('func').__name__ == 'run' and major_version(args.image_version) == 1:
+        if vars(args).get('func').__name__ == 'run' and is_sandbox_docker_based(args.image_version):
             docker.validate_docker_vm(args.vm_type)
 
         result = args.func(args)

--- a/conductr_cli/sandbox_run.py
+++ b/conductr_cli/sandbox_run.py
@@ -1,7 +1,8 @@
 from conductr_cli import validation, sandbox_common, sandbox_features, \
     sandbox_run_docker, sandbox_run_jvm
 from conductr_cli.constants import DEFAULT_CLI_TMP_DIR
-from conductr_cli.sandbox_common import major_version, LATEST_SANDBOX_RUN_ARGS_FILE
+from conductr_cli.sandbox_common import LATEST_SANDBOX_RUN_ARGS_FILE
+from conductr_cli.sandbox_version import is_sandbox_docker_based
 
 import os
 import sys
@@ -26,9 +27,8 @@ import sys
 def run(args):
     """`sandbox run` command"""
     write_run_command()
-    is_conductr_v1 = major_version(args.image_version) == 1
     features = sandbox_features.collect_features(args.features, args.no_default_features, args.image_version, args.offline_mode)
-    sandbox = sandbox_run_docker if is_conductr_v1 else sandbox_run_jvm
+    sandbox = sandbox_run_docker if is_sandbox_docker_based(args.image_version) else sandbox_run_jvm
 
     run_result = sandbox.run(args, features)
 

--- a/conductr_cli/sandbox_run_jvm.py
+++ b/conductr_cli/sandbox_run_jvm.py
@@ -7,7 +7,8 @@ from conductr_cli.exceptions import BindAddressNotFound, BintrayUnreachableError
     JavaVersionParseError, HostnameLookupError, LicenseValidationError
 from conductr_cli.resolvers import bintray_resolver
 from conductr_cli.resolvers.bintray_resolver import BINTRAY_LIGHTBEND_ORG, BINTRAY_CONDUCTR_REPO
-from conductr_cli.sandbox_common import flatten, version_parts
+from conductr_cli.sandbox_common import flatten
+from conductr_cli.sandbox_version import is_conductr_on_private_bintray
 from conductr_cli.screen_utils import h1, h2
 from requests.exceptions import HTTPError, ConnectionError
 from subprocess import CalledProcessError
@@ -277,10 +278,8 @@ def validate_bintray_credentials(image_version, offline_mode):
     :param image_version: the ConductR image version
     :param offline_mode: the offline mode flag
     """
-    if not offline_mode:
-        major_version, minor_version, _ = version_parts(image_version)
-        if major_version == 2 and minor_version == 0:
-            bintray_resolver.load_bintray_credentials(raise_error=True, disable_instructions=True)
+    if not offline_mode and is_conductr_on_private_bintray(image_version):
+        bintray_resolver.load_bintray_credentials(raise_error=True, disable_instructions=True)
 
 
 def cleanup_tmp_dir(tmp_dir):

--- a/conductr_cli/sandbox_version.py
+++ b/conductr_cli/sandbox_version.py
@@ -1,0 +1,24 @@
+
+def is_sandbox_docker_based(version):
+    return major_version(version) == 1
+
+
+def is_conductr_on_private_bintray(version):
+    major, minor, _ = version_parts(version)
+    return major == 1 or (major == 2 and minor == 0)
+
+
+def is_conductr_supportive_of_features(version):
+    return major_version(version) != 1
+
+
+def is_cinnamon_grafana_docker_based(version):
+    return major_version(version) != 1
+
+
+def version_parts(version):
+    return tuple(map(int, version.split('.')))
+
+
+def major_version(version):
+    return version_parts(version)[0]


### PR DESCRIPTION
Based on a given ConductR version, the `sandbox run` command performed certain validations, e.g. run ConductR in JVM or Docker mode, run certain features, check Bintray credentials, etc.

So far each version check was directly made in the corresponding function. With this PR, we enscapsulate the version checks to a python module `sandbox_version`. This module offers functions to check for certain capabilities, e.g. `is_docker_mode`, `check_bintray_credentials`. Each function will return either True or False based on the given ConductR version.

Manual tests that cover all the different scenarios have been performed.