### PR TITLE
Use tags in conduct info

### DIFF
--- a/conductr_cli/bundle_deploy.py
+++ b/conductr_cli/bundle_deploy.py
@@ -91,9 +91,9 @@ def wait_for_deployment_complete(deployment_id, resolved_version, args):
         return display_deployment_event(latest_event)
 
     package_name = resolved_version['package_name']
-    compatibility_version = resolved_version['compatibility_version']
+    tag = resolved_version['tag']
     bundle_id = display_bundle_id(resolved_version['digest'])
-    bundle_shorthand = '{}:{}-{}'.format(package_name, compatibility_version, bundle_id)
+    bundle_shorthand = '{}:{}-{}'.format(package_name, tag, bundle_id)
 
     log.info('Deploying {}'.format(bundle_shorthand))
 

--- a/conductr_cli/bundle_shorthand.py
+++ b/conductr_cli/bundle_shorthand.py
@@ -9,15 +9,15 @@ DEFAULT_REPO_BUNDLE_CONFIGURATION = 'bundle-configuration'
 def parse_bundle(uri):
     urn, rest = split_to_urn_and_rest(uri)
     org, repo, package = split_to_org_repo_package(rest, default_repo=DEFAULT_REPO_BUNDLE)
-    package_name, compatiblity_version, digest = split_package_to_parts(package)
-    return urn, org, repo, package_name, compatiblity_version, digest
+    package_name, tag, digest = split_package_to_parts(package)
+    return urn, org, repo, package_name, tag, digest
 
 
 def parse_bundle_configuration(uri):
     urn, rest = split_to_urn_and_rest(uri)
     org, repo, package = split_to_org_repo_package(rest, default_repo=DEFAULT_REPO_BUNDLE_CONFIGURATION)
-    package_name, compatiblity_version, digest = split_package_to_parts(package)
-    return urn, org, repo, package_name, compatiblity_version, digest
+    package_name, tag, digest = split_package_to_parts(package)
+    return urn, org, repo, package_name, tag, digest
 
 
 def split_to_urn_and_rest(uri):
@@ -46,8 +46,8 @@ def split_package_to_parts(package):
     if ':' in package:
         package_name, version = package.split(':')
         if '-' in version:
-            compatiblity_version, digest = version.split('-')
-            return package_name, compatiblity_version, digest
+            tag, digest = version.rsplit('-', 1)
+            return package_name, tag, digest
         else:
             return package_name, version, None
     else:

--- a/conductr_cli/conduct_deploy.py
+++ b/conductr_cli/conduct_deploy.py
@@ -46,7 +46,7 @@ def deploy(args):
     # JSON Payload for deployment request
     payload = {
         'package': resolved_version['package_name'],
-        'version': '{}-{}'.format(resolved_version['compatibility_version'], resolved_version['digest'])
+        'version': '{}-{}'.format(resolved_version['tag'], resolved_version['digest'])
     }
 
     # HTTP headers required for deployment request
@@ -77,7 +77,7 @@ def deploy(args):
 def request_deploy_confirmation(resolved_version, args):
     bundle_id = resolved_version['digest'] if args.long_ids else bundle_utils.short_id(resolved_version['digest'])
     user_input = input('Deploy {}:{}-{}? [Y/n]: '.format(resolved_version['package_name'],
-                                                         resolved_version['compatibility_version'],
+                                                         resolved_version['tag'],
                                                          bundle_id))
     confirmation = (user_input if user_input else 'y').lower().strip()
     return confirmation == 'y' or confirmation == 'yes'

--- a/conductr_cli/conduct_info_inspect.py
+++ b/conductr_cli/conduct_info_inspect.py
@@ -47,6 +47,7 @@ def display_bundle_attributes(args, bundle):
             if 'compatibilityVersion' in bundle['attributes'] else None),
         ('System', bundle['attributes']['system']),
         ('System Version', bundle['attributes']['systemVersion'] if 'systemVersion' in bundle['attributes'] else None),
+        ('Tags', ', '.join(bundle['attributes']['tags']) if 'tags' in bundle['attributes'] else None),
         ('Nr of CPUs', bundle['attributes']['nrOfCpus']),
         ('Memory', bundle['attributes']['memory']),
         ('Disk Space', bundle['attributes']['diskSpace']),

--- a/conductr_cli/conduct_info_list.py
+++ b/conductr_cli/conduct_info_list.py
@@ -54,7 +54,7 @@ def display_bundles_default(args, is_license_success, conductr_license, bundles)
         log.screen('''\
 {id: <{id_width}}{padding}\
 {name: <{name_width}}{padding}\
-{tag: <{tag_width}}{padding}\
+{tag: >{tag_width}}{padding}\
 {replications: >{replications_width}}{padding}\
 {starting: >{starting_width}}{padding}\
 {executions: >{executions_width}}{padding}\

--- a/conductr_cli/conduct_info_list.py
+++ b/conductr_cli/conduct_info_list.py
@@ -24,11 +24,13 @@ def display_bundles_default(args, is_license_success, conductr_license, bundles)
 
         log.screen('{}\n'.format(license_to_display))
 
+    has_tags_key = all('tags' in bundle['attributes'] for bundle in bundles)
+
     data = [
         {
             'id': display_bundle_id(args, bundle),
             'name': bundle['attributes']['bundleName'],
-            'compatibility_version': 'v{}'.format(bundle['attributes']['compatibilityVersion']),
+            'tag': display_tag_or_compatibility_version(bundle, has_tags_key),
             'roles': ', '.join(sorted(bundle['attributes']['roles'])),
             'replications': len(bundle['bundleInstallations']),
             'starting': sum([not execution['isStarted'] for execution in bundle['bundleExecutions']]),
@@ -38,7 +40,7 @@ def display_bundles_default(args, is_license_success, conductr_license, bundles)
     data.insert(0, {
         'id': 'ID',
         'name': 'NAME',
-        'compatibility_version': 'VER',
+        'tag': 'TAG' if has_tags_key else 'VER',
         'roles': 'ROLES',
         'replications': '#REP',
         'starting': '#STR',
@@ -52,7 +54,7 @@ def display_bundles_default(args, is_license_success, conductr_license, bundles)
         log.screen('''\
 {id: <{id_width}}{padding}\
 {name: <{name_width}}{padding}\
-{compatibility_version: >{compatibility_version_width}}{padding}\
+{tag: <{tag_width}}{padding}\
 {replications: >{replications_width}}{padding}\
 {starting: >{starting_width}}{padding}\
 {executions: >{executions_width}}{padding}\
@@ -60,6 +62,13 @@ def display_bundles_default(args, is_license_success, conductr_license, bundles)
 
     if has_error:
         log.screen('There are errors: use `conduct events` or `conduct logs` for further information')
+
+
+def display_tag_or_compatibility_version(bundle, has_tags_key):
+    if has_tags_key:
+        return bundle['attributes']['tags'][0] if bundle['attributes']['tags'] else ""
+    else:
+        return 'v{}'.format(bundle['attributes']['compatibilityVersion'])
 
 
 def display_bundles_quiet(args, bundles):

--- a/conductr_cli/conduct_load.py
+++ b/conductr_cli/conduct_load.py
@@ -287,10 +287,10 @@ def string_io(input_text):
 
 def cleanup_old_bundles(cache_dir, bundle_file_name, excluded):
     bundle_name_parts = bundle_file_name.split('-')
-    # Remove digest, keeping only bundle name and compatible version
+    # Remove digest, keeping only bundle name and tag
     bundle_name = '-'.join(bundle_name_parts[:-1])
 
-    # List of bundle files having the same name and compatibility version, sorted from oldest to latest.
+    # List of bundle files having the same name and tag, sorted from oldest to latest.
     # This list excludes the file specified as `excluded`, and normally the `excluded` file is the recently loaded
     # bundle.
     older_bundle_files = sorted([

--- a/conductr_cli/resolvers/test/test_bintray_resolver.py
+++ b/conductr_cli/resolvers/test/test_bintray_resolver.py
@@ -20,7 +20,7 @@ class TestResolveBundle(TestCase):
             'org': 'typesafe',
             'repo': 'bundle',
             'package_name': 'bundle-name',
-            'compatibility_version': 'v1',
+            'tag': 'v1',
             'digest': 'digest',
             'version': 'v1-digest',
             'path': 'download.zip',
@@ -140,7 +140,7 @@ class TestResolveBundleConfiguration(TestCase):
             'org': 'typesafe',
             'repo': 'bundle-configuration',
             'package_name': 'bundle-name',
-            'compatibility_version': 'v1',
+            'tag': 'v1',
             'digest': 'digest',
             'path': 'download.zip',
             'download_url': 'https://dl.bintray.com/typesafe/bundle-configuration/download.zip'
@@ -296,7 +296,7 @@ class TestLoadBundleFromCache(TestCase):
             'org': 'typesafe',
             'repo': 'bundle',
             'package_name': 'bundle-name',
-            'compatibility_version': 'v1',
+            'tag': 'v1',
             'digest': 'digest',
             'path': 'download.zip',
             'download_url': 'https://dl.bintray.com/typesafe/bundle/download.zip'
@@ -453,7 +453,7 @@ class TestLoadBundleConfigurationFromCache(TestCase):
             'org': 'typesafe',
             'repo': 'bundle-configuration',
             'package_name': 'bundle-name',
-            'compatibility_version': 'v1',
+            'tag': 'v1',
             'digest': 'digest',
             'path': 'download.zip',
             'download_url': 'https://dl.bintray.com/typesafe/bundle-configuration/download.zip'
@@ -609,7 +609,7 @@ class TestBintrayResolveVersion(TestCase):
                 'org': 'typesafe',
                 'repo': 'bundle',
                 'package_name': 'reactive-maps-frontend',
-                'compatibility_version': 'v1',
+                'tag': 'v1',
                 'digest': '023f9da22',
                 'version': 'v1-023f9da22',
                 'path': 'download/path.zip',
@@ -695,7 +695,7 @@ class TestBintrayResolveVersionLatest(TestCase):
                 'org': 'typesafe',
                 'repo': 'bundle',
                 'package_name': 'reactive-maps-frontend',
-                'compatibility_version': 'v1',
+                'tag': 'v1',
                 'digest': '023f9da22',
                 'version': 'v1-023f9da22',
                 'path': 'download/path.zip',
@@ -750,7 +750,7 @@ class TestBintrayResolveVersionLatest(TestCase):
                 'org': 'typesafe',
                 'repo': 'bundle',
                 'package_name': 'reactive-maps-frontend',
-                'compatibility_version': 'v10',
+                'tag': 'v10',
                 'digest': '023f9da22',
                 'version': 'v10-023f9da22',
                 'path': 'download/path.zip',
@@ -831,7 +831,7 @@ class TestBintrayResolveVersionLatestCompatibilityVersion(TestCase):
                 'org': 'typesafe',
                 'repo': 'bundle',
                 'package_name': 'reactive-maps-frontend',
-                'compatibility_version': 'v1',
+                'tag': 'v1',
                 'digest': '023f9da22',
                 'version': 'v1-023f9da22',
                 'path': 'download/path.zip',
@@ -874,7 +874,7 @@ class TestResolveBundleVersion(TestCase):
             'org': 'typesafe',
             'repo': 'bundle',
             'package_name': 'bundle-name',
-            'compatibility_version': 'v1',
+            'tag': 'v1',
             'digest': 'digest',
             'version': 'v1-digest',
             'path': 'path/to/download.zip'
@@ -890,7 +890,7 @@ class TestResolveBundleVersion(TestCase):
         load_bintray_credentials_mock.assert_called_with(raise_error=False)
         parse_bundle_mock.assert_called_with('bundle-name:v1')
         bintray_resolve_version_mock.assert_called_with(self.bintray_auth, 'typesafe', 'bundle', 'bundle-name',
-                                                        compatibility_version='v1', digest='digest')
+                                                        tag='v1', digest='digest')
 
     def test_resolved_version_not_found(self):
         load_bintray_credentials_mock = MagicMock(return_value=self.bintray_auth)
@@ -906,7 +906,7 @@ class TestResolveBundleVersion(TestCase):
         load_bintray_credentials_mock.assert_called_with(raise_error=False)
         parse_bundle_mock.assert_called_with('bundle-name:v1')
         bintray_resolve_version_mock.assert_called_with(self.bintray_auth, 'typesafe', 'bundle', 'bundle-name',
-                                                        compatibility_version='v1', digest='digest')
+                                                        tag='v1', digest='digest')
 
     def test_malformed_bundle_uri_error(self):
         load_bintray_credentials_mock = MagicMock(return_value=self.bintray_auth)
@@ -922,7 +922,7 @@ class TestResolveBundleVersion(TestCase):
         load_bintray_credentials_mock.assert_called_with(raise_error=False)
         parse_bundle_mock.assert_called_with('bundle-name:v1')
         bintray_resolve_version_mock.assert_called_with(self.bintray_auth, 'typesafe', 'bundle', 'bundle-name',
-                                                        compatibility_version='v1', digest='digest')
+                                                        tag='v1', digest='digest')
 
     def test_http_error(self):
         load_bintray_credentials_mock = MagicMock(return_value=self.bintray_auth)
@@ -938,7 +938,7 @@ class TestResolveBundleVersion(TestCase):
         load_bintray_credentials_mock.assert_called_with(raise_error=False)
         parse_bundle_mock.assert_called_with('bundle-name:v1')
         bintray_resolve_version_mock.assert_called_with(self.bintray_auth, 'typesafe', 'bundle', 'bundle-name',
-                                                        compatibility_version='v1', digest='digest')
+                                                        tag='v1', digest='digest')
 
 
 class TestContinuousDeliveryUri(TestCase):

--- a/conductr_cli/sandbox_features.py
+++ b/conductr_cli/sandbox_features.py
@@ -120,7 +120,7 @@ class VisualizationFeature:
     bundle can also be configured using feature arguments. For example:
 
         `-f visualization`: default latest version of the Visualizer bundle
-        `-f visualization v2`: specify the compatibility version
+        `-f visualization v2`: specify a tag
     """
 
     name = 'visualization'

--- a/conductr_cli/test/data/conduct_info_inspect/bundle_with_acls.json
+++ b/conductr_cli/test/data/conduct_info_inspect/bundle_with_acls.json
@@ -10,6 +10,9 @@
             "roles": [
                 "elasticsearch"
             ],
+            "tags": [
+                "1.0.0"
+            ],
             "bundleName": "eslite",
             "systemVersion": "1",
             "compatibilityVersion": "1"
@@ -81,6 +84,10 @@
             "roles": [
                 "elasticsearch"
             ],
+            "tags": [
+                "1.0.0",
+                "latest"
+            ],
             "bundleName": "conductr-elasticsearch",
             "systemVersion": "1",
             "compatibilityVersion": "1"
@@ -122,6 +129,9 @@
             "diskSpace": 35000000,
             "roles": [
                 "haproxy"
+            ],
+            "tags": [
+                "2.0.0"
             ],
             "bundleName": "conductr-haproxy",
             "systemVersion": "2",
@@ -188,6 +198,9 @@
             "diskSpace": 200000000,
             "roles": [
                 "ptester"
+            ],
+            "tags": [
+                "1.0.0"
             ],
             "bundleName": "path-tester",
             "systemVersion": "1",

--- a/conductr_cli/test/data/conduct_info_inspect/bundle_with_service_uris_v2.json
+++ b/conductr_cli/test/data/conduct_info_inspect/bundle_with_service_uris_v2.json
@@ -10,6 +10,9 @@
       "roles": [
         "web"
       ],
+      "tags": [
+        "1.1.0"
+      ],
       "bundleName": "visualizer",
       "systemVersion": "1.1",
       "compatibilityVersion": "1.1"
@@ -60,6 +63,9 @@
       "diskSpace": 200000000,
       "roles": [
         "elasticsearch"
+      ],
+      "tags": [
+        "1.0.0"
       ],
       "bundleName": "eslite",
       "systemVersion": "1",

--- a/conductr_cli/test/test_bundle_deploy.py
+++ b/conductr_cli/test/test_bundle_deploy.py
@@ -238,7 +238,7 @@ class TestWaitForDeployment(CliTestCase):
             'org': 'typesafe',
             'repo': 'bundle',
             'package_name': 'cassandra',
-            'compatibility_version': 'v1',
+            'tag': 'v1',
             'digest': 'd073991ab918ee22c7426af8a62a48c5-a53237c1f4a067e13ef00090627fb3de',
             'resolver': bintray_resolver.__name__
         }
@@ -419,7 +419,7 @@ class TestWaitForDeployment(CliTestCase):
             'org': 'typesafe',
             'repo': 'bundle',
             'package_name': 'cassandra',
-            'compatibility_version': 'v1',
+            'tag': 'v1',
             'digest': 'd073991ab918ee22c7426af8a62a48c5-a53237c1f4a067e13ef00090627fb3de',
             'resolver': bintray_resolver.__name__
         }
@@ -514,7 +514,7 @@ class TestWaitForDeployment(CliTestCase):
             'org': 'typesafe',
             'repo': 'bundle',
             'package_name': 'cassandra',
-            'compatibility_version': 'v1',
+            'tag': 'v1',
             'digest': 'abcdef',
             'resolver': bintray_resolver.__name__
         }
@@ -572,7 +572,7 @@ class TestWaitForDeployment(CliTestCase):
             'org': 'typesafe',
             'repo': 'bundle',
             'package_name': 'cassandra',
-            'compatibility_version': 'v1',
+            'tag': 'v1',
             'digest': 'abcdef',
             'resolver': bintray_resolver.__name__
         }
@@ -714,7 +714,7 @@ class TestWaitForDeployment(CliTestCase):
             'org': 'typesafe',
             'repo': 'bundle',
             'package_name': 'cassandra',
-            'compatibility_version': 'v1',
+            'tag': 'v1',
             'digest': 'abcdef',
             'resolver': bintray_resolver.__name__
         }
@@ -902,7 +902,7 @@ class TestWaitForDeployment(CliTestCase):
             'org': 'typesafe',
             'repo': 'bundle',
             'package_name': 'cassandra',
-            'compatibility_version': 'v1',
+            'tag': 'v1',
             'digest': 'abcdef',
             'resolver': bintray_resolver.__name__
         }
@@ -1000,7 +1000,7 @@ class TestWaitForDeployment(CliTestCase):
             'org': 'typesafe',
             'repo': 'bundle',
             'package_name': 'cassandra',
-            'compatibility_version': 'v1',
+            'tag': 'v1',
             'digest': 'abcdef',
             'resolver': bintray_resolver.__name__
         }
@@ -1127,7 +1127,7 @@ class TestWaitForDeployment(CliTestCase):
             'org': 'typesafe',
             'repo': 'bundle',
             'package_name': 'cassandra',
-            'compatibility_version': 'v1',
+            'tag': 'v1',
             'digest': 'abcdef',
             'resolver': bintray_resolver.__name__
         }
@@ -1184,7 +1184,7 @@ class TestWaitForDeployment(CliTestCase):
             'org': 'typesafe',
             'repo': 'bundle',
             'package_name': 'cassandra',
-            'compatibility_version': 'v1',
+            'tag': 'v1',
             'digest': 'abcdef',
             'resolver': bintray_resolver.__name__
         }

--- a/conductr_cli/test/test_bundle_shorthand.py
+++ b/conductr_cli/test/test_bundle_shorthand.py
@@ -5,40 +5,48 @@ from conductr_cli.exceptions import MalformedBundleUriError
 
 class TestParseBundle(TestCase):
     def test_full_address(self):
-        uri = 'urn:x-bundle:typesafe/bundle/reactive-maps-frontend:v1-023f9da22'
+        uri = 'urn:x-bundle:typesafe/bundle/reactive-maps-frontend:1.0.0-023f9da22'
         expected_result = ('urn:x-bundle:',
                            'typesafe', 'bundle', 'reactive-maps-frontend',
-                           'v1', '023f9da22')
+                           '1.0.0', '023f9da22')
         result = bundle_shorthand.parse_bundle(uri)
         self.assertEqual(expected_result, result)
 
     def test_no_urn(self):
-        uri = 'typesafe/bundle/reactive-maps-frontend:v1-023f9da22'
+        uri = 'typesafe/bundle/reactive-maps-frontend:1.0.0-023f9da22'
         expected_result = ('urn:x-bundle:',
                            'typesafe', 'bundle', 'reactive-maps-frontend',
-                           'v1', '023f9da22')
+                           '1.0.0', '023f9da22')
         result = bundle_shorthand.parse_bundle(uri)
         self.assertEqual(expected_result, result)
 
     def test_no_org(self):
-        uri = 'bundle/reactive-maps-frontend:v1-023f9da22'
+        uri = 'bundle/reactive-maps-frontend:1.0.0-023f9da22'
         expected_result = ('urn:x-bundle:',
                            'typesafe', 'bundle', 'reactive-maps-frontend',
-                           'v1', '023f9da22')
+                           '1.0.0', '023f9da22')
         result = bundle_shorthand.parse_bundle(uri)
         self.assertEqual(expected_result, result)
 
     def test_no_repos(self):
-        uri = 'reactive-maps-frontend:v1-023f9da22'
+        uri = 'reactive-maps-frontend:1.0.0-023f9da22'
         expected_result = ('urn:x-bundle:',
                            'typesafe', 'bundle', 'reactive-maps-frontend',
-                           'v1', '023f9da22')
+                           '1.0.0', '023f9da22')
+        result = bundle_shorthand.parse_bundle(uri)
+        self.assertEqual(expected_result, result)
+
+    def test_no_repos_and_tag_with_hyphens(self):
+        uri = 'reactive-maps-frontend:my-tag-with-hyphens-023f9da22'
+        expected_result = ('urn:x-bundle:',
+                           'typesafe', 'bundle', 'reactive-maps-frontend',
+                           'my-tag-with-hyphens', '023f9da22')
         result = bundle_shorthand.parse_bundle(uri)
         self.assertEqual(expected_result, result)
 
     def test_no_digest(self):
-        uri = 'reactive-maps-frontend:v1'
-        expected_result = ('urn:x-bundle:', 'typesafe', 'bundle', 'reactive-maps-frontend', 'v1', None)
+        uri = 'reactive-maps-frontend:1.0.0'
+        expected_result = ('urn:x-bundle:', 'typesafe', 'bundle', 'reactive-maps-frontend', '1.0.0', None)
         result = bundle_shorthand.parse_bundle(uri)
         self.assertEqual(expected_result, result)
 
@@ -51,58 +59,59 @@ class TestParseBundle(TestCase):
 
 class TestParseBundleWithMalformedExpression(TestCase):
     def test_unsupported_urn(self):
-        uri = 'urn:x-bananas:typesafe/bundle/reactive-maps-frontend:v1-023f9da22'
+        uri = 'urn:x-bananas:typesafe/bundle/reactive-maps-frontend:1.0.0-023f9da22'
         self.assertRaises(MalformedBundleUriError, bundle_shorthand.parse_bundle, uri)
 
     def test_invalid_parts(self):
-        uri = 'urn:x-bundle:typesafe/bundle/this/is/not/a/valid/path/reactive-maps-frontend:v1-023f9da22'
+        uri = 'urn:x-bundle:typesafe/bundle/this/is/not/a/valid/path/reactive-maps-frontend:1.0.0-023f9da22'
         self.assertRaises(MalformedBundleUriError, bundle_shorthand.parse_bundle, uri)
 
     def test_file_path_should_be_invalid(self):
-        uri = '/home/user/workspace/my-project/target/bundle/my-project-v1-023f9da22.zip'
+        uri = '/home/user/workspace/my-project/target/bundle/my-project-1.0.0-023f9da22.zip'
         self.assertRaises(MalformedBundleUriError, bundle_shorthand.parse_bundle, uri)
 
     def test_http_url_should_be_invalid(self):
-        uri = 'http://some-url.com/dist/bundle/my-project-v1-023f9da22.zip'
+        uri = 'http://some-url.com/dist/bundle/my-project-1.0.0-023f9da22.zip'
         self.assertRaises(MalformedBundleUriError, bundle_shorthand.parse_bundle, uri)
 
 
 class TestParseBundleConfiguration(TestCase):
     def test_full_address(self):
-        uri = 'urn:x-bundle:typesafe/bundle-configuration/conductr-haproxy-dev-mode:v1-023f9da22'
+        uri = 'urn:x-bundle:typesafe/bundle-configuration/conductr-haproxy-dev-mode:1.0.0-023f9da22'
         expected_result = ('urn:x-bundle:',
                            'typesafe', 'bundle-configuration', 'conductr-haproxy-dev-mode',
-                           'v1', '023f9da22')
+                           '1.0.0', '023f9da22')
         result = bundle_shorthand.parse_bundle_configuration(uri)
         self.assertEqual(expected_result, result)
 
     def test_no_urn(self):
-        uri = 'typesafe/bundle-configuration/conductr-haproxy-dev-mode:v1-023f9da22'
+        uri = 'typesafe/bundle-configuration/conductr-haproxy-dev-mode:1.0.0-023f9da22'
         expected_result = ('urn:x-bundle:',
                            'typesafe', 'bundle-configuration', 'conductr-haproxy-dev-mode',
-                           'v1', '023f9da22')
+                           '1.0.0', '023f9da22')
         result = bundle_shorthand.parse_bundle_configuration(uri)
         self.assertEqual(expected_result, result)
 
     def test_no_org(self):
-        uri = 'bundle-configuration/conductr-haproxy-dev-mode:v1-023f9da22'
+        uri = 'bundle-configuration/conductr-haproxy-dev-mode:1.0.0-023f9da22'
         expected_result = ('urn:x-bundle:',
                            'typesafe', 'bundle-configuration', 'conductr-haproxy-dev-mode',
-                           'v1', '023f9da22')
+                           '1.0.0', '023f9da22')
         result = bundle_shorthand.parse_bundle_configuration(uri)
         self.assertEqual(expected_result, result)
 
     def test_no_repos(self):
-        uri = 'conductr-haproxy-dev-mode:v1-023f9da22'
+        uri = 'conductr-haproxy-dev-mode:1.0.0-023f9da22'
         expected_result = ('urn:x-bundle:',
                            'typesafe', 'bundle-configuration', 'conductr-haproxy-dev-mode',
-                           'v1', '023f9da22')
+                           '1.0.0', '023f9da22')
         result = bundle_shorthand.parse_bundle_configuration(uri)
         self.assertEqual(expected_result, result)
 
     def test_no_digest(self):
-        uri = 'conductr-haproxy-dev-mode:v1'
-        expected_result = ('urn:x-bundle:', 'typesafe', 'bundle-configuration', 'conductr-haproxy-dev-mode', 'v1', None)
+        uri = 'conductr-haproxy-dev-mode:1.0.0'
+        expected_result = ('urn:x-bundle:', 'typesafe', 'bundle-configuration',
+                           'conductr-haproxy-dev-mode', '1.0.0', None)
         result = bundle_shorthand.parse_bundle_configuration(uri)
         self.assertEqual(expected_result, result)
 
@@ -115,17 +124,17 @@ class TestParseBundleConfiguration(TestCase):
 
 class TestParseBundleConfigurationWithMalformedExpression(TestCase):
     def test_unsupported_urn(self):
-        uri = 'urn:x-bananas:typesafe/bundle-configuration/conductr-haproxy-dev-mode:v1-023f9da22'
+        uri = 'urn:x-bananas:typesafe/bundle-configuration/conductr-haproxy-dev-mode:1.0.0-023f9da22'
         self.assertRaises(MalformedBundleUriError, bundle_shorthand.parse_bundle_configuration, uri)
 
     def test_invalid_parts(self):
-        uri = 'urn:x-bundle:typesafe/bundle-configuration/this/is/not/a/valid/path/conductr-haproxy-dev-mode:v1-023f9da22'
+        uri = 'urn:x-bundle:typesafe/bundle-configuration/this/is/not/a/valid/path/conductr-haproxy-dev-mode:1.0.0-023f9da22'
         self.assertRaises(MalformedBundleUriError, bundle_shorthand.parse_bundle_configuration, uri)
 
     def test_file_path_should_be_invalid(self):
-        uri = '/home/user/workspace/my-project/target/configuration/my-project-v1-023f9da22.zip'
+        uri = '/home/user/workspace/my-project/target/configuration/my-project-1.0.0-023f9da22.zip'
         self.assertRaises(MalformedBundleUriError, bundle_shorthand.parse_bundle_configuration, uri)
 
     def test_http_url_should_be_invalid(self):
-        uri = 'http://some-url.com/dist/bundle-configuration/my-project-v1-023f9da22.zip'
+        uri = 'http://some-url.com/dist/bundle-configuration/my-project-1.0.0-023f9da22.zip'
         self.assertRaises(MalformedBundleUriError, bundle_shorthand.parse_bundle_configuration, uri)

--- a/conductr_cli/test/test_conduct_deploy.py
+++ b/conductr_cli/test/test_conduct_deploy.py
@@ -14,7 +14,7 @@ class TestConductDeploy(CliTestCase):
         'org': 'typesafe',
         'repo': 'bundle',
         'package_name': 'cassandra',
-        'compatibility_version': 'v1',
+        'tag': 'v1',
         'digest': 'abcabc'
     }
     deploy_uri = '/deployments/typesafe/bundle/typesafe'
@@ -376,7 +376,7 @@ class TestDeployConfirmation(CliTestCase):
         'org': 'typesafe',
         'repo': 'bundle',
         'package_name': 'cassandra',
-        'compatibility_version': 'v1',
+        'tag': 'v1',
         'digest': 'd073991ab918ee22c7426af8a62a48c5-a53237c1f4a067e13ef00090627fb3de'
     }
 

--- a/conductr_cli/test/test_conduct_info.py
+++ b/conductr_cli/test/test_conduct_info.py
@@ -165,7 +165,7 @@ class TestConductInfoShowAllBundlesCommand(CliTestCase):
                             |ConductR Version(s): 2.1.*
                             |Grants: akka-sbr, cinnamon, conductr
                             |
-                            |ID       NAME         TAG    #REP  #STR  #RUN  ROLES
+                            |ID       NAME           TAG  #REP  #STR  #RUN  ROLES
                             |45e0c47  test-bundle  1.0.0     1     0     0  tester
                             |"""),
             self.output(stdout))
@@ -226,10 +226,10 @@ class TestConductInfoShowAllBundlesCommand(CliTestCase):
                             |ConductR Version(s): 2.1.*
                             |Grants: akka-sbr, cinnamon, conductr
                             |
-                            |ID               NAME           TAG     #REP  #STR  #RUN  ROLES
-                            |45e0c47          test-bundle-1  1.0.0      1     0     1
+                            |ID               NAME              TAG  #REP  #STR  #RUN  ROLES
+                            |45e0c47          test-bundle-1   1.0.0     1     0     1
                             |45e0c47-c52e3f8  test-bundle-2  10.0.0     1     1     0  another, load-test, tester
-                            |45e0c47          test-bundle-3  8.0.0      1     0     0  tester
+                            |45e0c47          test-bundle-3   8.0.0     1     0     0  tester
                             |"""),
             self.output(stdout))
 
@@ -388,7 +388,7 @@ class TestConductInfoShowAllBundlesCommand(CliTestCase):
                             |ConductR Version(s): 2.1.*
                             |Grants: akka-sbr, cinnamon, conductr
                             |
-                            |ID       NAME           TAG    #REP  #STR  #RUN  ROLES
+                            |ID       NAME             TAG  #REP  #STR  #RUN  ROLES
                             |45e0c47  test-bundle-1  1.0.0     3     0     3
                             |c52e3f8  test-bundle-2  1.0.0     3     0     0  beta, load-test
                             |"""),
@@ -430,7 +430,7 @@ class TestConductInfoShowAllBundlesCommand(CliTestCase):
                             |ConductR Version(s): 2.1.*
                             |Grants: akka-sbr, cinnamon, conductr
                             |
-                            |ID                                NAME         TAG    #REP  #STR  #RUN  ROLES
+                            |ID                                NAME           TAG  #REP  #STR  #RUN  ROLES
                             |45e0c477d3e5ea92aa8d85c0d8f3e25c  test-bundle  1.0.0     1     0     0  api, front-end, public-facing
                             |"""),
             self.output(stdout))
@@ -499,7 +499,7 @@ class TestConductInfoShowAllBundlesCommand(CliTestCase):
                             |ConductR Version(s): 2.1.*
                             |Grants: akka-sbr, cinnamon, conductr
                             |
-                            |ID       NAME         TAG    #REP  #STR  #RUN  ROLES
+                            |ID       NAME           TAG  #REP  #STR  #RUN  ROLES
                             |45e0c47  test-bundle  1.0.0    10     0     0  test
                             |"""),
             self.output(stdout))
@@ -537,7 +537,7 @@ class TestConductInfoShowAllBundlesCommand(CliTestCase):
                             |ConductR Version(s): 2.1.*
                             |Grants: akka-sbr, cinnamon, conductr
                             |
-                            |ID       NAME         TAG    #REP  #STR  #RUN  ROLES
+                            |ID       NAME           TAG  #REP  #STR  #RUN  ROLES
                             |45e0c47  test-bundle  1.0.0     1     0     0  tester
                             |"""),
             self.output(stdout))
@@ -576,7 +576,7 @@ class TestConductInfoShowAllBundlesCommand(CliTestCase):
                             |Grants: akka-sbr, cinnamon, conductr
                             |
                             |ID       NAME         TAG  #REP  #STR  #RUN  ROLES
-                            |45e0c47  test-bundle  v1      1     0     0  tester
+                            |45e0c47  test-bundle          1     0     0  tester
                             |"""),
             self.output(stdout))
 
@@ -612,8 +612,8 @@ class TestConductInfoShowAllBundlesCommand(CliTestCase):
                             |ConductR Version(s): 2.1.*
                             |Grants: akka-sbr, cinnamon, conductr
                             |
-                            |ID       NAME         TAG  #REP  #STR  #RUN  ROLES
-                            |45e0c47  test-bundle  v1      1     0     0  tester
+                            |ID       NAME         VER  #REP  #STR  #RUN  ROLES
+                            |45e0c47  test-bundle   v1     1     0     0  tester
                             |"""),
             self.output(stdout))
 
@@ -651,7 +651,7 @@ class TestConductInfoShowAllBundlesCommand(CliTestCase):
                             |ConductR Version(s): 2.1.*
                             |Grants: akka-sbr, cinnamon, conductr
                             |
-                            |ID         NAME         TAG    #REP  #STR  #RUN  ROLES
+                            |ID         NAME           TAG  #REP  #STR  #RUN  ROLES
                             |! 45e0c47  test-bundle  1.0.0    10     0     0  test
                             |There are errors: use `conduct events` or `conduct logs` for further information
                             |"""),

--- a/conductr_cli/test/test_conduct_info.py
+++ b/conductr_cli/test/test_conduct_info.py
@@ -63,7 +63,7 @@ class TestConductInfoShowAllBundlesCommand(CliTestCase):
                             |ConductR Version(s): 2.1.*
                             |Grants: akka-sbr, cinnamon, conductr
                             |
-                            |ID  NAME  VER  #REP  #STR  #RUN  ROLES
+                            |ID  NAME  TAG  #REP  #STR  #RUN  ROLES
                             |"""),
             self.output(stdout))
 
@@ -89,7 +89,7 @@ class TestConductInfoShowAllBundlesCommand(CliTestCase):
                             |ConductR Version(s): 2.1.*
                             |Grants: akka-sbr, cinnamon, conductr
                             |
-                            |ID  NAME  VER  #REP  #STR  #RUN  ROLES
+                            |ID  NAME  TAG  #REP  #STR  #RUN  ROLES
                             |"""),
             self.output(stdout))
 
@@ -109,7 +109,7 @@ class TestConductInfoShowAllBundlesCommand(CliTestCase):
         http_method.assert_called_with(self.default_url, auth=self.conductr_auth, verify=self.server_verification_file,
                                        timeout=DEFAULT_HTTP_TIMEOUT, headers={'Host': '127.0.0.1'})
         self.assertEqual(
-            strip_margin("""|ID  NAME  VER  #REP  #STR  #RUN  ROLES
+            strip_margin("""|ID  NAME  TAG  #REP  #STR  #RUN  ROLES
                             |"""),
             self.output(stdout))
 
@@ -139,7 +139,8 @@ class TestConductInfoShowAllBundlesCommand(CliTestCase):
                 "attributes": {
                   "bundleName": "test-bundle",
                   "compatibilityVersion": "1",
-                  "roles": ["tester"]
+                  "roles": ["tester"],
+                  "tags": ["1.0.0"]
                 },
                 "bundleId": "45e0c477d3e5ea92aa8d85c0d8f3e25c",
                 "bundleExecutions": [],
@@ -164,8 +165,8 @@ class TestConductInfoShowAllBundlesCommand(CliTestCase):
                             |ConductR Version(s): 2.1.*
                             |Grants: akka-sbr, cinnamon, conductr
                             |
-                            |ID       NAME         VER  #REP  #STR  #RUN  ROLES
-                            |45e0c47  test-bundle   v1     1     0     0  tester
+                            |ID       NAME         TAG    #REP  #STR  #RUN  ROLES
+                            |45e0c47  test-bundle  1.0.0     1     0     0  tester
                             |"""),
             self.output(stdout))
 
@@ -176,7 +177,8 @@ class TestConductInfoShowAllBundlesCommand(CliTestCase):
                 "attributes": {
                     "bundleName": "test-bundle-1",
                     "compatibilityVersion": "1",
-                    "roles": []
+                    "roles": [],
+                    "tags": ["1.0.0"]
                 },
                 "bundleId": "45e0c477d3e5ea92aa8d85c0d8f3e25c",
                 "bundleExecutions": [{"isStarted": true}],
@@ -186,7 +188,8 @@ class TestConductInfoShowAllBundlesCommand(CliTestCase):
                 "attributes": {
                     "bundleName": "test-bundle-2",
                     "compatibilityVersion": "10",
-                    "roles": ["tester", "load-test", "another"]
+                    "roles": ["tester", "load-test", "another"],
+                    "tags": ["10.0.0"]
                 },
                 "bundleId": "45e0c477d3e5ea92aa8d85c0d8f3e25c-c52e3f8d0c58d8aa29ae5e3d774c0e54",
                 "bundleExecutions": [{"isStarted": false}],
@@ -196,7 +199,8 @@ class TestConductInfoShowAllBundlesCommand(CliTestCase):
                 "attributes": {
                     "bundleName": "test-bundle-3",
                     "compatibilityVersion": "8",
-                    "roles": ["tester"]
+                    "roles": ["tester"],
+                    "tags": ["8.0.0"]
                 },
                 "bundleId": "45e0c477d3e5ea92aa8d85c0d8f3e25c",
                 "bundleExecutions": [],
@@ -222,10 +226,10 @@ class TestConductInfoShowAllBundlesCommand(CliTestCase):
                             |ConductR Version(s): 2.1.*
                             |Grants: akka-sbr, cinnamon, conductr
                             |
-                            |ID               NAME           VER  #REP  #STR  #RUN  ROLES
-                            |45e0c47          test-bundle-1   v1     1     0     1
-                            |45e0c47-c52e3f8  test-bundle-2  v10     1     1     0  another, load-test, tester
-                            |45e0c47          test-bundle-3   v8     1     0     0  tester
+                            |ID               NAME           TAG     #REP  #STR  #RUN  ROLES
+                            |45e0c47          test-bundle-1  1.0.0      1     0     1
+                            |45e0c47-c52e3f8  test-bundle-2  10.0.0     1     1     0  another, load-test, tester
+                            |45e0c47          test-bundle-3  8.0.0      1     0     0  tester
                             |"""),
             self.output(stdout))
 
@@ -236,7 +240,8 @@ class TestConductInfoShowAllBundlesCommand(CliTestCase):
                 "attributes": {
                     "bundleName": "test-bundle-1",
                     "compatibilityVersion": "1",
-                    "roles": ["test"]
+                    "roles": ["test"],
+                    "tags": ["1.0.0"]
                 },
                 "bundleId": "45e0c477d3e5ea92aa8d85c0d8f3e25c",
                 "bundleExecutions": [{"isStarted": true}],
@@ -246,7 +251,8 @@ class TestConductInfoShowAllBundlesCommand(CliTestCase):
                 "attributes": {
                     "bundleName": "test-bundle-2",
                     "compatibilityVersion": "1",
-                    "roles": ["test"]
+                    "roles": ["test"],
+                    "tags": ["1.0.0"]
                 },
                 "bundleId": "45e0c477d3e5ea92aa8d85c0d8f3e25c-c52e3f8d0c58d8aa29ae5e3d774c0e54",
                 "bundleExecutions": [{"isStarted": false}],
@@ -256,7 +262,8 @@ class TestConductInfoShowAllBundlesCommand(CliTestCase):
                 "attributes": {
                     "bundleName": "test-bundle-3",
                     "compatibilityVersion": "1",
-                    "roles": ["test"]
+                    "roles": ["test"],
+                    "tags": ["1.0.0"]
                 },
                 "bundleId": "45e0c477d3e5ea92aa8d85c0d8f3e25c",
                 "bundleExecutions": [],
@@ -290,7 +297,8 @@ class TestConductInfoShowAllBundlesCommand(CliTestCase):
                 "attributes": {
                     "bundleName": "test-bundle-1",
                     "compatibilityVersion": "1",
-                    "roles": []
+                    "roles": [],
+                    "tags": ["1.0.0"]
                 },
                 "bundleId": "45e0c477d3e5ea92aa8d85c0d8f3e25c",
                 "bundleExecutions": [{"isStarted": true},{"isStarted": true},{"isStarted": true}],
@@ -300,7 +308,8 @@ class TestConductInfoShowAllBundlesCommand(CliTestCase):
                 "attributes": {
                     "bundleName": "test-bundle-2",
                     "compatibilityVersion": "1",
-                    "roles": ["beta", "load-test"]
+                    "roles": ["beta", "load-test"],
+                    "tags": ["1.0.0"]
                 },
                 "bundleId": "c52e3f8d0c58d8aa29ae5e3d774c0e54",
                 "bundleExecutions": [],
@@ -330,7 +339,10 @@ class TestConductInfoShowAllBundlesCommand(CliTestCase):
                             |    "attributes": {
                             |      "bundleName": "test-bundle-1",
                             |      "compatibilityVersion": "1",
-                            |      "roles": []
+                            |      "roles": [],
+                            |      "tags": [
+                            |        "1.0.0"
+                            |      ]
                             |    },
                             |    "bundleExecutions": [
                             |      {
@@ -357,6 +369,9 @@ class TestConductInfoShowAllBundlesCommand(CliTestCase):
                             |      "roles": [
                             |        "beta",
                             |        "load-test"
+                            |      ],
+                            |      "tags": [
+                            |        "1.0.0"
                             |      ]
                             |    },
                             |    "bundleExecutions": [],
@@ -373,9 +388,9 @@ class TestConductInfoShowAllBundlesCommand(CliTestCase):
                             |ConductR Version(s): 2.1.*
                             |Grants: akka-sbr, cinnamon, conductr
                             |
-                            |ID       NAME           VER  #REP  #STR  #RUN  ROLES
-                            |45e0c47  test-bundle-1   v1     3     0     3
-                            |c52e3f8  test-bundle-2   v1     3     0     0  beta, load-test
+                            |ID       NAME           TAG    #REP  #STR  #RUN  ROLES
+                            |45e0c47  test-bundle-1  1.0.0     3     0     3
+                            |c52e3f8  test-bundle-2  1.0.0     3     0     0  beta, load-test
                             |"""),
             self.output(stdout))
 
@@ -386,6 +401,7 @@ class TestConductInfoShowAllBundlesCommand(CliTestCase):
                 "attributes": {
                   "bundleName": "test-bundle",
                   "compatibilityVersion": "1",
+                  "tags": ["1.0.0"],
                   "roles": ["front-end", "public-facing", "api"]
                 },
                 "bundleId": "45e0c477d3e5ea92aa8d85c0d8f3e25c",
@@ -414,8 +430,8 @@ class TestConductInfoShowAllBundlesCommand(CliTestCase):
                             |ConductR Version(s): 2.1.*
                             |Grants: akka-sbr, cinnamon, conductr
                             |
-                            |ID                                NAME         VER  #REP  #STR  #RUN  ROLES
-                            |45e0c477d3e5ea92aa8d85c0d8f3e25c  test-bundle   v1     1     0     0  api, front-end, public-facing
+                            |ID                                NAME         TAG    #REP  #STR  #RUN  ROLES
+                            |45e0c477d3e5ea92aa8d85c0d8f3e25c  test-bundle  1.0.0     1     0     0  api, front-end, public-facing
                             |"""),
             self.output(stdout))
 
@@ -457,6 +473,7 @@ class TestConductInfoShowAllBundlesCommand(CliTestCase):
                 "attributes": {
                     "bundleName": "test-bundle",
                     "compatibilityVersion": "1",
+                    "tags": ["1.0.0"],
                     "roles": ["test"]
                 },
                 "bundleId": "45e0c477d3e5ea92aa8d85c0d8f3e25c",
@@ -482,8 +499,121 @@ class TestConductInfoShowAllBundlesCommand(CliTestCase):
                             |ConductR Version(s): 2.1.*
                             |Grants: akka-sbr, cinnamon, conductr
                             |
-                            |ID       NAME         VER  #REP  #STR  #RUN  ROLES
-                            |45e0c47  test-bundle   v1    10     0     0  test
+                            |ID       NAME         TAG    #REP  #STR  #RUN  ROLES
+                            |45e0c47  test-bundle  1.0.0    10     0     0  test
+                            |"""),
+            self.output(stdout))
+
+    def test_multiple_tags(self):
+        mock_get_license = MagicMock(return_value=(True, self.license))
+        http_method = self.respond_with(text="""[
+            {
+                "attributes": {
+                  "bundleName": "test-bundle",
+                  "compatibilityVersion": "1",
+                  "roles": ["tester"],
+                  "tags": ["1.0.0", "latest"]
+                },
+                "bundleId": "45e0c477d3e5ea92aa8d85c0d8f3e25c",
+                "bundleExecutions": [],
+                "bundleInstallations": [1]
+            }
+        ]""")
+        stdout = MagicMock()
+
+        input_args = MagicMock(**self.default_args)
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.license.get_license', mock_get_license):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_info.info(input_args)
+            self.assertTrue(result)
+
+        mock_get_license.assert_called_once_with(input_args)
+        http_method.assert_called_with(self.default_url, auth=self.conductr_auth, verify=self.server_verification_file,
+                                       timeout=DEFAULT_HTTP_TIMEOUT, headers={'Host': '127.0.0.1'})
+        self.assertEqual(
+            strip_margin("""|Licensed To: cc64df31-ec6b-4e08-bb6b-3216721a56b@lightbend
+                            |Max ConductR agents: 3
+                            |ConductR Version(s): 2.1.*
+                            |Grants: akka-sbr, cinnamon, conductr
+                            |
+                            |ID       NAME         TAG    #REP  #STR  #RUN  ROLES
+                            |45e0c47  test-bundle  1.0.0     1     0     0  tester
+                            |"""),
+            self.output(stdout))
+
+    def test_empty_tags(self):
+        mock_get_license = MagicMock(return_value=(True, self.license))
+        http_method = self.respond_with(text="""[
+            {
+                "attributes": {
+                  "bundleName": "test-bundle",
+                  "compatibilityVersion": "1",
+                  "tags": [],
+                  "roles": ["tester"]
+                },
+                "bundleId": "45e0c477d3e5ea92aa8d85c0d8f3e25c",
+                "bundleExecutions": [],
+                "bundleInstallations": [1]
+            }
+        ]""")
+        stdout = MagicMock()
+
+        input_args = MagicMock(**self.default_args)
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.license.get_license', mock_get_license):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_info.info(input_args)
+            self.assertTrue(result)
+
+        mock_get_license.assert_called_once_with(input_args)
+        http_method.assert_called_with(self.default_url, auth=self.conductr_auth, verify=self.server_verification_file,
+                                       timeout=DEFAULT_HTTP_TIMEOUT, headers={'Host': '127.0.0.1'})
+        self.assertEqual(
+            strip_margin("""|Licensed To: cc64df31-ec6b-4e08-bb6b-3216721a56b@lightbend
+                            |Max ConductR agents: 3
+                            |ConductR Version(s): 2.1.*
+                            |Grants: akka-sbr, cinnamon, conductr
+                            |
+                            |ID       NAME         TAG  #REP  #STR  #RUN  ROLES
+                            |45e0c47  test-bundle  v1      1     0     0  tester
+                            |"""),
+            self.output(stdout))
+
+    def test_no_tags(self):
+        mock_get_license = MagicMock(return_value=(True, self.license))
+        http_method = self.respond_with(text="""[
+            {
+                "attributes": {
+                  "bundleName": "test-bundle",
+                  "compatibilityVersion": "1",
+                  "roles": ["tester"]
+                },
+                "bundleId": "45e0c477d3e5ea92aa8d85c0d8f3e25c",
+                "bundleExecutions": [],
+                "bundleInstallations": [1]
+            }
+        ]""")
+        stdout = MagicMock()
+
+        input_args = MagicMock(**self.default_args)
+        with patch('requests.get', http_method), \
+                patch('conductr_cli.license.get_license', mock_get_license):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_info.info(input_args)
+            self.assertTrue(result)
+
+        mock_get_license.assert_called_once_with(input_args)
+        http_method.assert_called_with(self.default_url, auth=self.conductr_auth, verify=self.server_verification_file,
+                                       timeout=DEFAULT_HTTP_TIMEOUT, headers={'Host': '127.0.0.1'})
+        self.assertEqual(
+            strip_margin("""|Licensed To: cc64df31-ec6b-4e08-bb6b-3216721a56b@lightbend
+                            |Max ConductR agents: 3
+                            |ConductR Version(s): 2.1.*
+                            |Grants: akka-sbr, cinnamon, conductr
+                            |
+                            |ID       NAME         TAG  #REP  #STR  #RUN  ROLES
+                            |45e0c47  test-bundle  v1      1     0     0  tester
                             |"""),
             self.output(stdout))
 
@@ -494,6 +624,7 @@ class TestConductInfoShowAllBundlesCommand(CliTestCase):
                 "attributes": {
                     "bundleName": "test-bundle",
                     "compatibilityVersion": "1",
+                    "tags": ["1.0.0"],
                     "roles": ["test"]
                 },
                 "bundleId": "45e0c477d3e5ea92aa8d85c0d8f3e25c",
@@ -520,8 +651,8 @@ class TestConductInfoShowAllBundlesCommand(CliTestCase):
                             |ConductR Version(s): 2.1.*
                             |Grants: akka-sbr, cinnamon, conductr
                             |
-                            |ID         NAME         VER  #REP  #STR  #RUN  ROLES
-                            |! 45e0c47  test-bundle   v1    10     0     0  test
+                            |ID         NAME         TAG    #REP  #STR  #RUN  ROLES
+                            |! 45e0c47  test-bundle  1.0.0    10     0     0  test
                             |There are errors: use `conduct events` or `conduct logs` for further information
                             |"""),
             self.output(stdout))
@@ -607,12 +738,14 @@ class TestConductInfoShowAllBundlesCommand(CliTestCase):
                             |ConductR Version(s): 2.1.*
                             |Grants: akka-sbr, cinnamon, conductr
                             |
-                            |ID  NAME  VER  #REP  #STR  #RUN  ROLES
+                            |ID  NAME  TAG  #REP  #STR  #RUN  ROLES
                             |"""),
             self.output(stdout))
 
 
 class TestConductInfoInspectBundleCommand(CliTestCase):
+    maxDiff = None
+
     default_url = 'http://127.0.0.1:9005/bundles'
 
     conductr_auth = ('username', 'password')
@@ -650,7 +783,6 @@ class TestConductInfoInspectBundleCommand(CliTestCase):
         http_method.assert_called_with(self.default_url, auth=self.conductr_auth, verify=self.server_verification_file,
                                        timeout=DEFAULT_HTTP_TIMEOUT, headers={'Host': '127.0.0.1'})
 
-        self.maxDiff = None
         expected_result = strip_margin(
             """|BUNDLE ATTRIBUTES
                |-----------------
@@ -659,6 +791,7 @@ class TestConductInfoInspectBundleCommand(CliTestCase):
                |Compatibility Version  1
                |System                 path-tester
                |System Version         1
+               |Tags                   1.0.0
                |Nr of CPUs             0.1
                |Memory                 402653184
                |Disk Space             200000000
@@ -798,6 +931,7 @@ class TestConductInfoInspectBundleCommand(CliTestCase):
                |Compatibility Version  1
                |System                 eslite
                |System Version         1
+               |Tags                   1.0.0
                |Nr of CPUs             0.1
                |Memory                 33554432
                |Disk Space             200000000
@@ -856,6 +990,7 @@ class TestConductInfoInspectBundleCommand(CliTestCase):
                |Compatibility Version  1
                |System                 path-tester
                |System Version         1
+               |Tags                   1.0.0
                |Nr of CPUs             0.1
                |Memory                 402653184
                |Disk Space             200000000
@@ -942,6 +1077,7 @@ class TestConductInfoInspectBundleCommand(CliTestCase):
                |Compatibility Version  1
                |System                 path-tester
                |System Version         1
+               |Tags                   1.0.0
                |Nr of CPUs             0.1
                |Memory                 402653184
                |Disk Space             200000000
@@ -1025,6 +1161,7 @@ class TestConductInfoInspectBundleCommand(CliTestCase):
                |Compatibility Version  2
                |System                 conductr-haproxy
                |System Version         2
+               |Tags                   2.0.0
                |Nr of CPUs             0.1
                |Memory                 402653184
                |Disk Space             35000000
@@ -1091,6 +1228,7 @@ class TestConductInfoInspectBundleCommand(CliTestCase):
                |Compatibility Version  2
                |System                 conductr-haproxy
                |System Version         2
+               |Tags                   2.0.0
                |Nr of CPUs             0.1
                |Memory                 402653184
                |Disk Space             35000000
@@ -1128,7 +1266,7 @@ class TestConductInfoInspectBundleCommand(CliTestCase):
 
         self.assertEqual('', self.output(stderr))
 
-    def test_stopped_bundle(self):
+    def test_stopped_bundle_multiple_tags(self):
         http_method = self.respond_with_file_contents('data/conduct_info_inspect/bundle_with_acls.json')
         stdout = MagicMock()
         stderr = MagicMock()
@@ -1145,7 +1283,6 @@ class TestConductInfoInspectBundleCommand(CliTestCase):
         http_method.assert_called_with(self.default_url, auth=self.conductr_auth, verify=self.server_verification_file,
                                        timeout=DEFAULT_HTTP_TIMEOUT, headers={'Host': '127.0.0.1'})
 
-        self.maxDiff = None
         expected_result = strip_margin(
             """|BUNDLE ATTRIBUTES
                |-----------------
@@ -1154,6 +1291,7 @@ class TestConductInfoInspectBundleCommand(CliTestCase):
                |Compatibility Version  1
                |System                 conductr-elasticsearch
                |System Version         1
+               |Tags                   1.0.0, latest
                |Nr of CPUs             0.1
                |Memory                 1572864000
                |Disk Space             100000000

--- a/conductr_cli/test/test_conduct_load_v2.py
+++ b/conductr_cli/test/test_conduct_load_v2.py
@@ -18,6 +18,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
         self.system = 'bundle'
         self.system_version = '2.3'
         self.compatibility_version = '2.0'
+        self.tags = ['2.0.0']
         self.custom_settings = Mock()
         self.bundle_resolve_cache_dir = 'bundle-resolve-cache-dir'
         self.configuration_resolve_cache_dir = 'configuration-resolve-cache-dir'
@@ -31,6 +32,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
                             |system                 = {}
                             |systemVersion          = {}
                             |compatibilityVersion   = {}
+                            |tags                   = [{}]
                             |""").format(self.nr_of_cpus,
                                          self.memory,
                                          self.disk_space,
@@ -38,7 +40,8 @@ class TestConductLoadCommand(ConductLoadTestBase):
                                          self.bundle_file_name,
                                          self.system,
                                          self.system_version,
-                                         self.compatibility_version))
+                                         self.compatibility_version,
+                                         self.tags))
 
         self.default_args = {
             'dcos_mode': False,


### PR DESCRIPTION
Using tags in the `conduct info` and `conduct info my-bundle` commands. Falling back to the compatibility version if `/bundles` does not include a `tags` key (prior to ConductR 2.1.0) or the tags are empty.