### PR TITLE
Incorporate PID output

### DIFF
--- a/conductr_cli/conduct_info_inspect.py
+++ b/conductr_cli/conduct_info_inspect.py
@@ -134,6 +134,7 @@ def display_bundle_executions(bundle):
             {
                 'endpoint': endpoint_name,
                 'host': bundle_execution['host'],
+                'pid': bundle_execution['pid'] if 'pid' in bundle_execution else 'Unknown',
                 'is_started': 'Yes' if bundle_execution['isStarted'] else 'No',
                 'bind_port': endpoint_details['bindPort'],
                 'host_port': endpoint_details['hostPort']
@@ -148,6 +149,7 @@ def display_bundle_executions(bundle):
             rows.insert(0, {
                 'endpoint': 'ENDPOINT',
                 'host': 'HOST',
+                'pid': 'PID',
                 'is_started': 'STARTED',
                 'bind_port': 'BIND_PORT',
                 'host_port': 'HOST_PORT',
@@ -156,6 +158,7 @@ def display_bundle_executions(bundle):
             for row in rows:
                 log.screen('{endpoint: <{endpoint_width}}{padding}'
                            '{host: <{host_width}}{padding}'
+                           '{pid: >{pid_width}}{padding}'
                            '{is_started: >{is_started_width}}{padding}'
                            '{bind_port: >{bind_port_width}}{padding}'
                            '{host_port: >{host_port_width}}'.format(**dict(row, **column_widths)).rstrip())

--- a/conductr_cli/test/data/conduct_info_inspect/bundle_with_acls.json
+++ b/conductr_cli/test/data/conduct_info_inspect/bundle_with_acls.json
@@ -32,6 +32,7 @@
         "bundleExecutions": [
             {
                 "host": "192.168.10.2",
+                "pid": 0,
                 "endpoints": {
                     "akka-remote": {
                         "bindPort": 10822,
@@ -141,6 +142,7 @@
         "bundleExecutions": [
             {
                 "host": "192.168.10.2",
+                "pid": 0,
                 "endpoints": {
                     "status": {
                         "bindPort": 9009,
@@ -258,6 +260,7 @@
         "bundleExecutions": [
             {
                 "host": "192.168.10.1",
+                "pid": 0,
                 "endpoints": {
                     "ptest": {
                         "bindPort": 10822,

--- a/conductr_cli/test/test_conduct_info.py
+++ b/conductr_cli/test/test_conduct_info.py
@@ -684,9 +684,9 @@ class TestConductInfoInspectBundleCommand(CliTestCase):
                |
                |BUNDLE EXECUTIONS
                |-----------------
-               |ENDPOINT  HOST          STARTED  BIND_PORT  HOST_PORT
-               |ptest     192.168.10.1      Yes      10822      10822
-               |ptunnel   192.168.10.1      Yes      10007      10007
+               |ENDPOINT  HOST          PID  STARTED  BIND_PORT  HOST_PORT
+               |ptest     192.168.10.1    0      Yes      10822      10822
+               |ptunnel   192.168.10.1    0      Yes      10007      10007
                |
                |HTTP ACLS
                |---------
@@ -758,9 +758,9 @@ class TestConductInfoInspectBundleCommand(CliTestCase):
                |
                |BUNDLE EXECUTIONS
                |-----------------
-               |ENDPOINT        HOST        STARTED  BIND_PORT  HOST_PORT
-               |akka-remote     172.17.0.2      Yes      10917      10917
-               |elastic-search  172.17.0.2      Yes      10007      10007
+               |ENDPOINT        HOST            PID  STARTED  BIND_PORT  HOST_PORT
+               |akka-remote     172.17.0.2  Unknown      Yes      10917      10917
+               |elastic-search  172.17.0.2  Unknown      Yes      10007      10007
                |
                |SERVICE NAMES
                |-------------
@@ -816,9 +816,9 @@ class TestConductInfoInspectBundleCommand(CliTestCase):
                |
                |BUNDLE EXECUTIONS
                |-----------------
-               |ENDPOINT        HOST        STARTED  BIND_PORT  HOST_PORT
-               |akka-remote     172.17.0.2      Yes      10917      10917
-               |elastic-search  172.17.0.2      Yes      10007      10007
+               |ENDPOINT        HOST            PID  STARTED  BIND_PORT  HOST_PORT
+               |akka-remote     172.17.0.2  Unknown      Yes      10917      10917
+               |elastic-search  172.17.0.2  Unknown      Yes      10007      10007
                |
                |SERVICE NAMES
                |-------------
@@ -881,9 +881,9 @@ class TestConductInfoInspectBundleCommand(CliTestCase):
                |
                |BUNDLE EXECUTIONS
                |-----------------
-               |ENDPOINT  HOST          STARTED  BIND_PORT  HOST_PORT
-               |ptest     192.168.10.1      Yes      10822      10822
-               |ptunnel   192.168.10.1      Yes      10007      10007
+               |ENDPOINT  HOST          PID  STARTED  BIND_PORT  HOST_PORT
+               |ptest     192.168.10.1    0      Yes      10822      10822
+               |ptunnel   192.168.10.1    0      Yes      10007      10007
                |
                |HTTP ACLS
                |---------
@@ -967,9 +967,9 @@ class TestConductInfoInspectBundleCommand(CliTestCase):
                |
                |BUNDLE EXECUTIONS
                |-----------------
-               |ENDPOINT  HOST          STARTED  BIND_PORT  HOST_PORT
-               |ptest     192.168.10.1      Yes      10822      10822
-               |ptunnel   192.168.10.1      Yes      10007      10007
+               |ENDPOINT  HOST          PID  STARTED  BIND_PORT  HOST_PORT
+               |ptest     192.168.10.1    0      Yes      10822      10822
+               |ptunnel   192.168.10.1    0      Yes      10007      10007
                |
                |HTTP ACLS
                |---------
@@ -1054,8 +1054,8 @@ class TestConductInfoInspectBundleCommand(CliTestCase):
                |
                |BUNDLE EXECUTIONS
                |-----------------
-               |ENDPOINT  HOST          STARTED  BIND_PORT  HOST_PORT
-               |status    192.168.10.2      Yes       9009       9009
+               |ENDPOINT  HOST          PID  STARTED  BIND_PORT  HOST_PORT
+               |status    192.168.10.2    0      Yes       9009       9009
                |
                |""")
         self.assertEqual(expected_result, self.output(stdout))
@@ -1120,8 +1120,8 @@ class TestConductInfoInspectBundleCommand(CliTestCase):
                |
                |BUNDLE EXECUTIONS
                |-----------------
-               |ENDPOINT  HOST          STARTED  BIND_PORT  HOST_PORT
-               |status    192.168.10.2      Yes       9009       9009
+               |ENDPOINT  HOST          PID  STARTED  BIND_PORT  HOST_PORT
+               |status    192.168.10.2    0      Yes       9009       9009
                |
                |""")
         self.assertEqual(expected_result, self.output(stdout))


### PR DESCRIPTION
ConductR 2.1 will represent an OS process identifier (PID) against each bundle execution. This commit caters for both ConductR 2.1 and existing ConductR releases by outputting a PID during "conduct info <my-bundle>" if there is one. If there is no PID field then "Unknown" is output.