### PR TITLE
Add support for annotations to `bndl`

### DIFF
--- a/conductr_cli/bndl_create.py
+++ b/conductr_cli/bndl_create.py
@@ -1,4 +1,4 @@
-from conductr_cli.bndl_oci import oci_image_bundle_conf, oci_image_extract_config, oci_image_unpack
+from conductr_cli.bndl_oci import oci_image_bundle_conf, oci_image_extract_manifest_config, oci_image_unpack
 from conductr_cli.bndl_docker import docker_unpack
 from conductr_cli.bndl_utils import detect_format_dir, detect_format_stream
 from conductr_cli.constants import BNDL_PEEK_SIZE, IO_CHUNK_SIZE
@@ -100,8 +100,8 @@ def bndl_create(args):
 
             return 2
 
-        oci_config = oci_image_extract_config(oci_image_dir, args.tag)
-        bundle_conf = oci_image_bundle_conf(args, component_name, oci_config)
+        oci_manifest, oci_config = oci_image_extract_manifest_config(oci_image_dir, args.tag)
+        bundle_conf = oci_image_bundle_conf(args, component_name, oci_manifest, oci_config)
         bundle_conf_name = os.path.join(args.name, 'bundle.conf')
         bundle_conf_data = bundle_conf.encode('UTF-8')
 

--- a/conductr_cli/bndl_docker.py
+++ b/conductr_cli/bndl_docker.py
@@ -140,7 +140,9 @@ def docker_config_to_oci_image(manifest, config, sizes, layers_to_digests):
                 'size': sizes[layers_to_digests[layer]],
                 'digest': 'sha256:{}'.format(layers_to_digests[layer])
             } for layer in manifest['Layers']
-        ]
+        ],
+        'annotations': config['config']['Labels'] if 'Labels' in config['config'] and
+                                                     config['config']['Labels'] else None
     }
 
     oci_manifest_data = json.dumps(oci_manifest, sort_keys=True).encode('UTF-8')

--- a/conductr_cli/bndl_main.py
+++ b/conductr_cli/bndl_main.py
@@ -75,6 +75,14 @@ def build_parser():
                         help='Description to use for the generated ConductR component',
                         default='')
 
+    parser.add_argument('--annotation',
+                        action='append',
+                        default=[],
+                        dest='annotations',
+                        help='Annotations to add to bundle.conf\n'
+                             'Example: bndl --annotation my.first=value1 --annotation my.second=value2\n'
+                             'Defaults to []')
+
     zero_or_more_mappings = {'--roles'}
     type_mappings = {'--memory': int, '--disk-space': int, '--nr-of-cpus': float}
 

--- a/conductr_cli/bndl_oci.py
+++ b/conductr_cli/bndl_oci.py
@@ -7,9 +7,15 @@ import shutil
 import tempfile
 
 
-def oci_image_bundle_conf(args, component_name, oci_config):
+def oci_image_bundle_conf(args, component_name, oci_manifest, oci_config):
     conf = ConfigFactory.parse_string('')
     load_bundle_args_into_conf(conf, args)
+
+    if 'annotations' in oci_manifest and oci_manifest['annotations'] is not None:
+        annotations_tree = conf.get('annotations')
+
+        for key in sorted(oci_manifest['annotations']):
+            annotations_tree.put(key, oci_manifest['annotations'][key])
 
     endpoints_tree = ConfigTree()
 
@@ -56,7 +62,7 @@ def oci_image_bundle_conf(args, component_name, oci_config):
     return HOCONConverter.to_hocon(conf)
 
 
-def oci_image_extract_config(dir, tag):
+def oci_image_extract_manifest_config(dir, tag):
     refs_path = os.path.join(dir, 'refs', tag)
 
     if os.path.isfile(refs_path):
@@ -78,9 +84,9 @@ def oci_image_extract_config(dir, tag):
 
                     if os.path.isfile(config_path):
                         with open(config_path, 'r') as config_file:
-                            return json.load(config_file)
+                            return manifest_json, json.load(config_file)
 
-    return {}
+    return {}, {}
 
 
 def oci_image_unpack(destination, data, is_dir):

--- a/conductr_cli/bndl_utils.py
+++ b/conductr_cli/bndl_utils.py
@@ -7,6 +7,7 @@ from conductr_cli.constants import \
     BNDL_DEFAULT_NR_OF_CPUS, \
     BNDL_DEFAULT_ROLES, \
     BNDL_DEFAULT_VERSION
+from pyhocon import ConfigTree
 import hashlib
 import os
 import re
@@ -115,6 +116,17 @@ def load_bundle_args_into_conf(config, args):
         tags.append(args.tag)
 
     config.put('tags', tags)
+
+    annotations_tree = ConfigTree()
+
+    for annotation in args.annotations:
+        if '=' not in annotation:
+            raise ValueError('Invalid annotation format. Specify as name=value')
+
+        annotation_parts = annotation.split('=', 1)
+        annotations_tree.put(annotation_parts[0], annotation_parts[1])
+
+    config.put('annotations', annotations_tree)
 
 
 def file_write_bytes(path, bs):

--- a/conductr_cli/test/test_bndl_create.py
+++ b/conductr_cli/test/test_bndl_create.py
@@ -100,7 +100,8 @@ class TestBndlCreate(CliTestCase):
                 'output': tmpfile,
                 'component_description': '',
                 'use_shazar': True,
-                'use_default_endpoints': True
+                'use_default_endpoints': True,
+                'annotations': []
             })
 
             os.mkdir(os.path.join(tmpdir, 'refs'))
@@ -133,7 +134,8 @@ class TestBndlCreate(CliTestCase):
                 'output': tmpfile,
                 'component_description': '',
                 'use_shazar': False,
-                'use_default_endpoints': True
+                'use_default_endpoints': True,
+                'annotations': []
             })
 
             os.mkdir(os.path.join(tmpdir, 'refs'))
@@ -143,7 +145,7 @@ class TestBndlCreate(CliTestCase):
             refs.close()
 
             with \
-                    patch('conductr_cli.bndl_oci.oci_image_extract_config', extract_config_mock), \
+                    patch('conductr_cli.bndl_oci.oci_image_extract_manifest_config', extract_config_mock), \
                     patch('sys.stdin', MagicMock(**{'buffer': BytesIO(b'')})), \
                     patch('sys.stdout.buffer.write', stdout_mock):
                 self.assertEqual(bndl_create.bndl_create(attributes), 0)

--- a/conductr_cli/test/test_bndl_docker.py
+++ b/conductr_cli/test/test_bndl_docker.py
@@ -99,7 +99,11 @@ class TestBndlDocker(CliTestCase):
                     'Cmd': ['/bin'],
                     'ExposedPorts': {'80/tcp': {}},
                     'WorkingDir': '/root',
-                    'Volumes': '/data'
+                    'Volumes': '/data',
+                    'Labels': {
+                        'description': 'This is a test',
+                        'language': 'English'
+                    }
                 }
             },
             sizes={'some digest': 1234},
@@ -137,13 +141,17 @@ class TestBndlDocker(CliTestCase):
                 'size': 414,
                 'mediaType': 'application/vnd.oci.image.config.v1+json'
             },
-            'schemaVersion': 2
+            'schemaVersion': 2,
+            'annotations': {
+                'description': 'This is a test',
+                'language': 'English'
+            }
         })
 
         self.assertEqual(json.loads(data['refs'].decode('UTF-8')), {
-            'digest': 'sha256:69dc519502c77183a566955cc6d643df47e17eb185d6ad92a33d279c77485c78',
+            'digest': 'sha256:416375dd788642653657622b831d2e1901677dbe6b8184aa036cd8c0f2cc3bb1',
             'mediaType': 'application/vnd.oci.image.manifest.v1+json',
-            'size': 307
+            'size': 380
         })
 
     def test_docker_config_empty_data(self):

--- a/conductr_cli/test/test_bndl_main.py
+++ b/conductr_cli/test/test_bndl_main.py
@@ -49,7 +49,11 @@ class TestBndl(CliTestCase):
             'web',
             'backend',
             '--with-check',
-            '--no-default-endpoints'
+            '--no-default-endpoints',
+            '--annotation',
+            'com.lightbend.test=hello world',
+            '--annotation',
+            'description=this is a test'
         ])
 
         self.assertEqual(args.source, 'oci-image-dir')
@@ -67,6 +71,7 @@ class TestBndl(CliTestCase):
         self.assertEqual(args.memory, 65536)
         self.assertEqual(args.diskSpace, 16384)
         self.assertEqual(args.roles, ['web', 'backend'])
+        self.assertEqual(args.annotations, ['com.lightbend.test=hello world', 'description=this is a test'])
         self.assertFalse(args.use_default_endpoints)
 
     def test_parser_no_args(self):

--- a/conductr_cli/test/test_bndl_utils.py
+++ b/conductr_cli/test/test_bndl_utils.py
@@ -101,7 +101,8 @@ class TestBndlUtils(CliTestCase):
         base_args = create_attributes_object({
             'name': 'world',
             'component_description': 'testing desc 1',
-            'tag': 'testing'
+            'tag': 'testing',
+            'annotations': {}
         })
 
         extended_args = create_attributes_object({
@@ -115,7 +116,8 @@ class TestBndlUtils(CliTestCase):
             'memory': '65536',
             'diskSpace': '16384',
             'roles': ['web', 'backend'],
-            'tag': 'latest'
+            'tag': 'latest',
+            'annotations': ['com.lightbend.test=hello world', 'description=this is a test']
         })
 
         # test that config value is specified, with defaults etc
@@ -167,3 +169,16 @@ class TestBndlUtils(CliTestCase):
         tag_config = ConfigFactory.parse_string('{ tags = ["testing"] }')
         bndl_utils.load_bundle_args_into_conf(tag_config, base_args)
         self.assertEqual(tag_config.get('tags'), ['testing'])
+
+        # annotations added
+        annotations_config = ConfigFactory.parse_string('{ annotations = { name = "my-name" } }')
+        bndl_utils.load_bundle_args_into_conf(annotations_config, extended_args)
+        self.assertEqual(annotations_config.get('annotations'), {
+            'name': 'my-name',
+            'com': {
+                'lightbend': {
+                    'test': 'hello world'
+                }
+            },
+            'description': 'this is a test'
+        })


### PR DESCRIPTION
This PR adds annotation support to `bndl`.

The following have been implemented:
* `--annotation <name> <value>` command line flag for explicitly adding an annotation
* Docker `Label` values populate OCI image manifest `annotations`
* OCI image manifest `annotations` populate `bundle.conf` annotations