### PR TITLE
Adjust sandbox stop retries to 10 as it can take upto 10 seconds

### DIFF
--- a/conductr_cli/sandbox_stop_jvm.py
+++ b/conductr_cli/sandbox_stop_jvm.py
@@ -44,7 +44,7 @@ def kill_processes(core_info, agent_info, pids_info):
     """
     log = logging.getLogger(__name__)
 
-    def wait_for_processes(remaining_pids_info, killed_pids_info=[], attempt=1, max_attempts=5):
+    def wait_for_processes(remaining_pids_info, killed_pids_info=[], attempt=1, max_attempts=10):
         time.sleep(1)
         new_remaining_pids_info = sandbox_common.find_pids(core_info['extraction_dir'], agent_info['extraction_dir'])
         new_killed_pids_info = [info for info in remaining_pids_info if info not in new_remaining_pids_info]


### PR DESCRIPTION
This PR changes the `max_attempts` for shutting down the sandbox to 10. Per ConductR's default configuration, it can take up to 8 seconds to stop a bundle so we need to make sure we wait at least that long before failing.