### PR TITLE
Use pyreadline on Windows

### DIFF
--- a/conductr_cli/license_auth.py
+++ b/conductr_cli/license_auth.py
@@ -1,6 +1,9 @@
 from conductr_cli.constants import DEFAULT_AUTH_TOKEN_FILE
 import os
-import readline
+try:
+    import readline
+except ImportError:
+    import pyreadline as readline
 
 
 AUTH_TOKEN_PROMPT = '\nAn access token is required. Please visit https://www.lightbend.com/account/access-token to \n' \

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ install_requires = [
     'pyhocon==0.3.35',
     'arrow>=0.6.0',
     'colorama>=0.3.7',
+    'pyreadline>=2.1',
 
     # FIXME: Remove the following dependencies when dcos can be depended on
     'jsonschema==2.4',  # pin the exact version, jsonschema 2.5 broke py3


### PR DESCRIPTION
On Windows, the module `readline` is not available. We now therefore catch an the `ImportError` that would occur on Windows when importing `readline` and instead import `pyreadline`.