### PR TITLE
Adjusts the sandbox to pull down the OCI in Docker image when starting

### DIFF
--- a/conductr_cli/docker.py
+++ b/conductr_cli/docker.py
@@ -44,6 +44,14 @@ def cpu_check(info):
     return existing_cpu_count, has_sufficient_cpu
 
 
+def is_docker_present():
+    try:
+        validate_docker_vm(vm_type())
+        return True
+    except DockerValidationError:
+        return False
+
+
 def validate_docker_vm(vm_type):
     log = logging.getLogger(__name__)
     if vm_type is DockerVmType.DOCKER_ENGINE:

--- a/conductr_cli/sandbox_proxy.py
+++ b/conductr_cli/sandbox_proxy.py
@@ -1,6 +1,6 @@
 from conductr_cli import conduct_main, docker, terminal
 from conductr_cli.constants import DEFAULT_SANDBOX_PROXY_DIR, DEFAULT_SANDBOX_PROXY_CONTAINER_NAME
-from conductr_cli.exceptions import DockerValidationError, NOT_FOUND_ERROR
+from conductr_cli.exceptions import NOT_FOUND_ERROR
 from conductr_cli.screen_utils import h1
 from subprocess import CalledProcessError
 import logging
@@ -32,7 +32,7 @@ DEFAULT_HAPROXY_CFG_ENTRIES = 'defaults\n' \
 
 
 def start_proxy(proxy_bind_addr, bundle_http_port, proxy_ports, all_feature_ports):
-    if is_docker_present():
+    if docker.is_docker_present():
         setup_haproxy_dirs()
         stop_proxy()
         start_docker_instance(proxy_bind_addr, bundle_http_port, proxy_ports, all_feature_ports)
@@ -45,7 +45,7 @@ def start_proxy(proxy_bind_addr, bundle_http_port, proxy_ports, all_feature_port
 def stop_proxy():
     log = logging.getLogger(__name__)
 
-    if is_docker_present():
+    if docker.is_docker_present():
         try:
             running_container = get_running_haproxy()
             if running_container:
@@ -59,15 +59,6 @@ def stop_proxy():
     else:
         # Docker is not present, so the proxy feature won't be running in the first place.
         return True
-
-
-def is_docker_present():
-    try:
-        vm_type = docker.vm_type()
-        docker.validate_docker_vm(vm_type)
-        return True
-    except DockerValidationError:
-        return False
 
 
 def setup_haproxy_dirs():

--- a/conductr_cli/sandbox_run_jvm.py
+++ b/conductr_cli/sandbox_run_jvm.py
@@ -532,10 +532,14 @@ def start_core_instances(core_extracted_dir, tmp_dir,
 
     pids = []
 
-    [
-        f.conductr_pre_core_start(envs, envs_core, args, args_core, bind_addrs, conductr_roles)
-        for f in features
-    ]
+    for f in features:
+        f.conductr_pre_core_start(envs,
+                                  envs_core,
+                                  args,
+                                  args_core,
+                                  core_extracted_dir,
+                                  bind_addrs,
+                                  conductr_roles)
 
     feature_conductr_roles = flatten([f.conductr_roles() for f in features])
     # Role matching is enabled if there's role present for any of the ConductR agent instances.
@@ -612,10 +616,15 @@ def start_agent_instances(agent_extracted_dir, tmp_dir,
     log = logging.getLogger(__name__)
     pids = []
 
-    [
-        f.conductr_pre_agent_start(envs, envs_agent, args, args_agent, bind_addrs, core_addrs, conductr_roles)
-        for f in features
-    ]
+    for f in features:
+        f.conductr_pre_agent_start(envs,
+                                   envs_agent,
+                                   args,
+                                   args_agent,
+                                   agent_extracted_dir,
+                                   bind_addrs,
+                                   core_addrs,
+                                   conductr_roles)
 
     feature_conductr_roles = flatten([f.conductr_roles() for f in features])
     args_features = flatten([f.conductr_args() for f in features])
@@ -637,9 +646,6 @@ def start_agent_instances(agent_extracted_dir, tmp_dir,
         ] + [
             '-Dconductr.agent.roles.{}={}'.format(j, role) for j, role in enumerate(agent_roles)
         ]
-
-        if not host.is_linux():
-            commands.append('-Dconductr.agent.run.force-oci-docker=on')
 
         if args:
             commands.extend(args)

--- a/conductr_cli/test/test_docker.py
+++ b/conductr_cli/test/test_docker.py
@@ -93,3 +93,27 @@ class TestDocker(CliTestCase):
             '  MacOS:                                         Docker for Mac',
             'For more information checkout: https://www.docker.com/products/overview'
         ], error.exception.messages)
+
+    def test_present(self):
+        mock_vm_type = MagicMock(return_value=docker.DockerVmType.DOCKER_ENGINE)
+        mock_validate_docker_vm = MagicMock()
+
+        with \
+                patch('conductr_cli.docker.vm_type', mock_vm_type), \
+                patch('conductr_cli.docker.validate_docker_vm', mock_validate_docker_vm):
+            self.assertTrue(docker.is_docker_present())
+
+        mock_vm_type.assert_called_once_with()
+        mock_validate_docker_vm.assert_called_once_with(docker.DockerVmType.DOCKER_ENGINE)
+
+    def test_not_present(self):
+        mock_vm_type = MagicMock(return_value=docker.DockerVmType.DOCKER_ENGINE)
+        mock_validate_docker_vm = MagicMock(side_effect=DockerValidationError([]))
+
+        with \
+                patch('conductr_cli.docker.vm_type', mock_vm_type), \
+                patch('conductr_cli.docker.validate_docker_vm', mock_validate_docker_vm):
+            self.assertFalse(docker.is_docker_present())
+
+        mock_vm_type.assert_called_once_with()
+        mock_validate_docker_vm.assert_called_once_with(docker.DockerVmType.DOCKER_ENGINE)

--- a/conductr_cli/test/test_sandbox_proxy.py
+++ b/conductr_cli/test/test_sandbox_proxy.py
@@ -1,6 +1,5 @@
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
-from conductr_cli import docker, logging_setup, sandbox_proxy
-from conductr_cli.exceptions import DockerValidationError
+from conductr_cli import logging_setup, sandbox_proxy
 from unittest.mock import call, patch, MagicMock
 from subprocess import CalledProcessError
 import ipaddress
@@ -19,7 +18,7 @@ class TestStartProxy(CliTestCase):
 
         args = MagicMock(**{})
 
-        with patch('conductr_cli.sandbox_proxy.is_docker_present', mock_is_docker_present), \
+        with patch('conductr_cli.docker.is_docker_present', mock_is_docker_present), \
                 patch('conductr_cli.sandbox_proxy.setup_haproxy_dirs', mock_setup_haproxy_dirs), \
                 patch('conductr_cli.sandbox_proxy.stop_proxy', mock_stop_proxy), \
                 patch('conductr_cli.sandbox_proxy.start_docker_instance', mock_start_docker_instance), \
@@ -46,7 +45,7 @@ class TestStartProxy(CliTestCase):
 
         args = MagicMock(**{})
 
-        with patch('conductr_cli.sandbox_proxy.is_docker_present', mock_is_docker_present), \
+        with patch('conductr_cli.docker.is_docker_present', mock_is_docker_present), \
                 patch('conductr_cli.sandbox_proxy.setup_haproxy_dirs', mock_setup_haproxy_dirs), \
                 patch('conductr_cli.sandbox_proxy.stop_proxy', mock_stop_proxy), \
                 patch('conductr_cli.sandbox_proxy.start_docker_instance', mock_start_docker_instance), \
@@ -73,7 +72,7 @@ class TestStopProxy(CliTestCase):
 
         args = MagicMock(**{})
 
-        with patch('conductr_cli.sandbox_proxy.is_docker_present', mock_is_docker_present), \
+        with patch('conductr_cli.docker.is_docker_present', mock_is_docker_present), \
                 patch('conductr_cli.sandbox_proxy.get_running_haproxy', mock_get_running_haproxy), \
                 patch('conductr_cli.terminal.docker_rm', mock_docker_rm):
             logging_setup.configure_logging(args, stdout)
@@ -98,7 +97,7 @@ class TestStopProxy(CliTestCase):
 
         args = MagicMock(**{})
 
-        with patch('conductr_cli.sandbox_proxy.is_docker_present', mock_is_docker_present), \
+        with patch('conductr_cli.docker.is_docker_present', mock_is_docker_present), \
                 patch('conductr_cli.sandbox_proxy.get_running_haproxy', mock_get_running_haproxy), \
                 patch('conductr_cli.terminal.docker_rm', mock_docker_rm):
             logging_setup.configure_logging(args, stdout)
@@ -118,7 +117,7 @@ class TestStopProxy(CliTestCase):
 
         args = MagicMock(**{})
 
-        with patch('conductr_cli.sandbox_proxy.is_docker_present', mock_is_docker_present), \
+        with patch('conductr_cli.docker.is_docker_present', mock_is_docker_present), \
                 patch('conductr_cli.sandbox_proxy.get_running_haproxy', mock_get_running_haproxy), \
                 patch('conductr_cli.terminal.docker_rm', mock_docker_rm):
             logging_setup.configure_logging(args, stdout)
@@ -138,7 +137,7 @@ class TestStopProxy(CliTestCase):
 
         args = MagicMock(**{})
 
-        with patch('conductr_cli.sandbox_proxy.is_docker_present', mock_is_docker_present), \
+        with patch('conductr_cli.docker.is_docker_present', mock_is_docker_present), \
                 patch('conductr_cli.sandbox_proxy.get_running_haproxy', mock_get_running_haproxy), \
                 patch('conductr_cli.terminal.docker_rm', mock_docker_rm):
             logging_setup.configure_logging(args, stdout)
@@ -158,7 +157,7 @@ class TestStopProxy(CliTestCase):
 
         args = MagicMock(**{})
 
-        with patch('conductr_cli.sandbox_proxy.is_docker_present', mock_is_docker_present), \
+        with patch('conductr_cli.docker.is_docker_present', mock_is_docker_present), \
                 patch('conductr_cli.sandbox_proxy.get_running_haproxy', mock_get_running_haproxy), \
                 patch('conductr_cli.terminal.docker_rm', mock_docker_rm):
             logging_setup.configure_logging(args, stdout)
@@ -168,30 +167,6 @@ class TestStopProxy(CliTestCase):
         mock_docker_rm.assert_not_called()
 
         self.assertEqual('', self.output(stdout))
-
-
-class TestIsDockerPresent(CliTestCase):
-    def test_present(self):
-        mock_vm_type = MagicMock(return_value=docker.DockerVmType.DOCKER_ENGINE)
-        mock_validate_docker_vm = MagicMock()
-
-        with patch('conductr_cli.docker.vm_type', mock_vm_type), \
-                patch('conductr_cli.docker.validate_docker_vm', mock_validate_docker_vm):
-            self.assertTrue(sandbox_proxy.is_docker_present())
-
-        mock_vm_type.assert_called_once_with()
-        mock_validate_docker_vm.assert_called_once_with(docker.DockerVmType.DOCKER_ENGINE)
-
-    def test_not_present(self):
-        mock_vm_type = MagicMock(return_value=docker.DockerVmType.DOCKER_ENGINE)
-        mock_validate_docker_vm = MagicMock(side_effect=DockerValidationError([]))
-
-        with patch('conductr_cli.docker.vm_type', mock_vm_type), \
-                patch('conductr_cli.docker.validate_docker_vm', mock_validate_docker_vm):
-            self.assertFalse(sandbox_proxy.is_docker_present())
-
-        mock_vm_type.assert_called_once_with()
-        mock_validate_docker_vm.assert_called_once_with(docker.DockerVmType.DOCKER_ENGINE)
 
 
 class TestSetupHAProxyDirs(CliTestCase):


### PR DESCRIPTION
**Updated 04/06/2017 4:14pm UTC**

This PR makes the sandbox pull down the relevant image for running OCI in Docker when it starts up. 

The code to do this has been implemented in a feature and that feature is enabled by default in non-linux environments. It can thus be enabled on linux via `sandbox run 2.0.5 --feature oci-in-docker`.

It determines the image to pull down by reading it from the agent's `application.conf`. If the value is not present, we assume we're in a pre-OCI version of ConductR and don't do anything.