### PR TITLE
Handle stopping state

### DIFF
--- a/conductr_cli/conduct_run.py
+++ b/conductr_cli/conduct_run.py
@@ -34,7 +34,7 @@ def run(args):
     log.info('Bundle run request sent.')
 
     if not args.no_wait:
-        bundle_scale.wait_for_scale(response_json['bundleId'], args.scale, args)
+        bundle_scale.wait_for_scale(response_json['bundleId'], args.scale, wait_for_is_active=True, args=args)
 
     if not args.disable_instructions:
         log.info('Stop bundle with:         {} stop{} {}'.format(args.command, args.cli_parameters, bundle_id))

--- a/conductr_cli/conduct_stop.py
+++ b/conductr_cli/conduct_stop.py
@@ -27,7 +27,7 @@ def stop(args):
     log.info('Bundle stop request sent.')
 
     if not args.no_wait:
-        bundle_scale.wait_for_scale(response_json['bundleId'], 0, args)
+        bundle_scale.wait_for_scale(response_json['bundleId'], 0, wait_for_is_active=False, args=args)
 
     if not args.disable_instructions:
         log.info('Unload bundle with:       {} unload{} {}'.format(args.command, args.cli_parameters, bundle_id))

--- a/conductr_cli/test/conduct_run_test_base.py
+++ b/conductr_cli/test/conduct_run_test_base.py
@@ -43,7 +43,7 @@ class ConductRunTestBase(CliTestCase):
 
         http_method.assert_called_with(self.default_url, auth=self.conductr_auth, verify=self.server_verification_file,
                                        headers={'Host': '127.0.0.1'})
-        wait_for_scale_mock.assert_called_with(self.bundle_id, self.scale, input_args)
+        wait_for_scale_mock.assert_called_with(self.bundle_id, self.scale, wait_for_is_active=True, args=input_args)
 
         self.assertEqual(self.default_output(), self.output(stdout))
 
@@ -64,7 +64,7 @@ class ConductRunTestBase(CliTestCase):
 
         http_method.assert_called_with(self.default_url, auth=self.conductr_auth, verify=self.server_verification_file,
                                        headers={'Host': '127.0.0.1'})
-        wait_for_scale_mock.assert_called_with(self.bundle_id, self.scale, input_args)
+        wait_for_scale_mock.assert_called_with(self.bundle_id, self.scale, wait_for_is_active=True, args=input_args)
 
         self.assertEqual(self.default_response + self.default_output(), self.output(stdout))
 
@@ -85,7 +85,7 @@ class ConductRunTestBase(CliTestCase):
 
         http_method.assert_called_with(self.default_url, auth=self.conductr_auth, verify=self.server_verification_file,
                                        headers={'Host': '127.0.0.1'})
-        wait_for_scale_mock.assert_called_with(self.bundle_id, self.scale, input_args)
+        wait_for_scale_mock.assert_called_with(self.bundle_id, self.scale, wait_for_is_active=True, args=input_args)
 
         self.assertEqual(self.default_output(bundle_id='45e0c477d3e5ea92aa8d85c0d8f3e25c'), self.output(stdout))
 
@@ -107,7 +107,7 @@ class ConductRunTestBase(CliTestCase):
 
         http_method.assert_called_with(self.default_url, auth=self.conductr_auth, verify=self.server_verification_file,
                                        headers={'Host': '127.0.0.1'})
-        wait_for_scale_mock.assert_called_with(self.bundle_id, self.scale, input_args)
+        wait_for_scale_mock.assert_called_with(self.bundle_id, self.scale, wait_for_is_active=True, args=input_args)
 
         self.assertEqual(
             self.default_output(params=cli_parameters),
@@ -131,7 +131,7 @@ class ConductRunTestBase(CliTestCase):
 
         http_method.assert_called_with(self.default_url, auth=self.conductr_auth, verify=self.server_verification_file,
                                        headers={'Host': '127.0.0.1'})
-        wait_for_scale_mock.assert_called_with(self.bundle_id, self.scale, input_args)
+        wait_for_scale_mock.assert_called_with(self.bundle_id, self.scale, wait_for_is_active=True, args=input_args)
 
         self.assertEqual(
             self.default_output(params=cli_parameters),
@@ -157,7 +157,7 @@ class ConductRunTestBase(CliTestCase):
 
         http_method.assert_called_with(self.default_url, auth=self.conductr_auth, verify=self.server_verification_file,
                                        headers={'Host': '127.0.0.1'})
-        wait_for_scale_mock.assert_called_with(self.bundle_id, self.scale, input_args)
+        wait_for_scale_mock.assert_called_with(self.bundle_id, self.scale, wait_for_is_active=True, args=input_args)
 
         self.assertEqual(self.default_output(), self.output(stdout))
 
@@ -229,7 +229,7 @@ class ConductRunTestBase(CliTestCase):
 
         http_method.assert_called_with(self.default_url, auth=self.conductr_auth, verify=self.server_verification_file,
                                        headers={'Host': '127.0.0.1'})
-        wait_for_scale_mock.assert_called_with(self.bundle_id, self.scale, input_args)
+        wait_for_scale_mock.assert_called_with(self.bundle_id, self.scale, wait_for_is_active=True, args=input_args)
 
         self.assertEqual(
             as_error(strip_margin("""|Error: Timed out: test wait timeout error

--- a/conductr_cli/test/test_bundle_scale.py
+++ b/conductr_cli/test/test_bundle_scale.py
@@ -52,7 +52,7 @@ class TestGetScaleIp(CliTestCase):
         }
         input_args = MagicMock(**args)
         with patch('requests.get', http_method):
-            result = bundle_scale.get_scale(bundle_id, input_args)
+            result = bundle_scale.get_scale(bundle_id, True, input_args)
             self.assertEqual(1, result)
 
         http_method.assert_called_with('http://127.0.0.1:9005/bundles', auth=self.conductr_auth,
@@ -101,7 +101,7 @@ class TestGetScaleIp(CliTestCase):
         }
         input_args = MagicMock(**args)
         with patch('requests.get', http_method):
-            result = bundle_scale.get_scale(bundle_id, input_args)
+            result = bundle_scale.get_scale(bundle_id, True, input_args)
             self.assertEqual(1, result)
 
         http_method.assert_called_with('http://127.0.0.1:9005/v2/bundles', auth=self.conductr_auth,
@@ -124,7 +124,7 @@ class TestGetScaleIp(CliTestCase):
         }
         input_args = MagicMock(**args)
         with patch('requests.get', http_method):
-            result = bundle_scale.get_scale(bundle_id, input_args)
+            result = bundle_scale.get_scale(bundle_id, True, input_args)
             self.assertEqual(0, result)
 
         http_method.assert_called_with('http://127.0.0.1:9005/bundles', auth=self.conductr_auth,
@@ -147,7 +147,7 @@ class TestGetScaleIp(CliTestCase):
         }
         input_args = MagicMock(**args)
         with patch('requests.get', http_method):
-            result = bundle_scale.get_scale(bundle_id, input_args)
+            result = bundle_scale.get_scale(bundle_id, True, input_args)
             self.assertEqual(0, result)
 
         http_method.assert_called_with('http://127.0.0.1:9005/v2/bundles', auth=self.conductr_auth,
@@ -202,7 +202,7 @@ class TestGetScaleHost(CliTestCase):
         }
         input_args = MagicMock(**args)
         with patch('requests.get', http_method):
-            result = bundle_scale.get_scale(bundle_id, input_args)
+            result = bundle_scale.get_scale(bundle_id, True, input_args)
             self.assertEqual(1, result)
 
         http_method.assert_called_with('http://127.0.0.1:9005/bundles', auth=self.conductr_auth,
@@ -251,7 +251,7 @@ class TestGetScaleHost(CliTestCase):
         }
         input_args = MagicMock(**args)
         with patch('requests.get', http_method):
-            result = bundle_scale.get_scale(bundle_id, input_args)
+            result = bundle_scale.get_scale(bundle_id, True, input_args)
             self.assertEqual(1, result)
 
         http_method.assert_called_with('http://127.0.0.1:9005/v2/bundles', auth=self.conductr_auth,
@@ -274,7 +274,7 @@ class TestGetScaleHost(CliTestCase):
         }
         input_args = MagicMock(**args)
         with patch('requests.get', http_method):
-            result = bundle_scale.get_scale(bundle_id, input_args)
+            result = bundle_scale.get_scale(bundle_id, True, input_args)
             self.assertEqual(0, result)
 
         http_method.assert_called_with('http://127.0.0.1:9005/bundles', auth=self.conductr_auth,
@@ -297,7 +297,7 @@ class TestGetScaleHost(CliTestCase):
         }
         input_args = MagicMock(**args)
         with patch('requests.get', http_method):
-            result = bundle_scale.get_scale(bundle_id, input_args)
+            result = bundle_scale.get_scale(bundle_id, True, input_args)
             self.assertEqual(0, result)
 
         http_method.assert_called_with('http://127.0.0.1:9005/v2/bundles', auth=self.conductr_auth,
@@ -340,14 +340,14 @@ class TestWaitForScale(CliTestCase):
                 patch('conductr_cli.sse_client.get_events', get_events_mock), \
                 patch('sys.stdout.isatty', is_tty_mock):
             logging_setup.configure_logging(args, stdout)
-            bundle_scale.wait_for_scale(bundle_id, 3, args)
+            bundle_scale.wait_for_scale(bundle_id, 3, wait_for_is_active=True, args=args)
 
         self.assertEqual(get_scale_mock.call_args_list, [
-            call(bundle_id, args),
-            call(bundle_id, args),
-            call(bundle_id, args),
-            call(bundle_id, args),
-            call(bundle_id, args)
+            call(bundle_id, True, args),
+            call(bundle_id, True, args),
+            call(bundle_id, True, args),
+            call(bundle_id, True, args),
+            call(bundle_id, True, args)
         ])
 
         url_mock.assert_called_with('bundles/events', args)
@@ -414,15 +414,15 @@ class TestWaitForScale(CliTestCase):
                 patch('conductr_cli.sse_client.get_events', get_events_mock), \
                 patch('sys.stdout.isatty', is_tty_mock):
             logging_setup.configure_logging(args, stdout)
-            bundle_scale.wait_for_scale(bundle_id, 3, args)
+            bundle_scale.wait_for_scale(bundle_id, 3, wait_for_is_active=True, args=args)
 
         self.assertEqual(get_scale_mock.call_args_list, [
-            call(bundle_id, args),
-            call(bundle_id, args),
-            call(bundle_id, args),
-            call(bundle_id, args),
-            call(bundle_id, args),
-            call(bundle_id, args)
+            call(bundle_id, True, args),
+            call(bundle_id, True, args),
+            call(bundle_id, True, args),
+            call(bundle_id, True, args),
+            call(bundle_id, True, args),
+            call(bundle_id, True, args)
         ])
 
         url_mock.assert_called_with('bundles/events', args)
@@ -490,12 +490,12 @@ class TestWaitForScale(CliTestCase):
                 patch('conductr_cli.sse_client.get_events', get_events_mock), \
                 patch('sys.stdout.isatty', is_tty_mock):
             logging_setup.configure_logging(args, stdout)
-            self.assertRaises(WaitTimeoutError, bundle_scale.wait_for_scale, bundle_id, 3, args)
+            self.assertRaises(WaitTimeoutError, bundle_scale.wait_for_scale, bundle_id, 3, wait_for_is_active=True, args=args)
 
         self.assertEqual(get_scale_mock.call_args_list, [
-            call(bundle_id, args),
-            call(bundle_id, args),
-            call(bundle_id, args)
+            call(bundle_id, True, args),
+            call(bundle_id, True, args),
+            call(bundle_id, True, args)
         ])
 
         url_mock.assert_called_with('bundles/events', args)
@@ -537,10 +537,10 @@ class TestWaitForScale(CliTestCase):
                 patch('conductr_cli.conduct_url.conductr_host', conductr_host_mock), \
                 patch('conductr_cli.sse_client.get_events', get_events_mock):
             logging_setup.configure_logging(args, stdout)
-            bundle_scale.wait_for_scale(bundle_id, 3, args)
+            bundle_scale.wait_for_scale(bundle_id, 3, wait_for_is_active=True, args=args)
 
         self.assertEqual(get_scale_mock.call_args_list, [
-            call(bundle_id, args)
+            call(bundle_id, True, args)
         ])
 
         conductr_host_mock.assert_not_called()
@@ -577,10 +577,10 @@ class TestWaitForScale(CliTestCase):
                 patch('conductr_cli.bundle_scale.get_scale', get_scale_mock), \
                 patch('conductr_cli.sse_client.get_events', get_events_mock):
             logging_setup.configure_logging(args, stdout)
-            self.assertRaises(WaitTimeoutError, bundle_scale.wait_for_scale, bundle_id, 3, args)
+            self.assertRaises(WaitTimeoutError, bundle_scale.wait_for_scale, bundle_id, 3, wait_for_is_active=True, args=args)
 
         self.assertEqual(get_scale_mock.call_args_list, [
-            call(bundle_id, args)
+            call(bundle_id, True, args)
         ])
 
         url_mock.assert_called_with('bundles/events', args)
@@ -621,13 +621,13 @@ class TestWaitForScale(CliTestCase):
                 patch('conductr_cli.sse_client.get_events', get_events_mock), \
                 patch('sys.stdout.isatty', is_tty_mock):
             logging_setup.configure_logging(args, stdout)
-            self.assertRaises(WaitTimeoutError, bundle_scale.wait_for_scale, bundle_id, 3, args)
+            self.assertRaises(WaitTimeoutError, bundle_scale.wait_for_scale, bundle_id, 3, wait_for_is_active=True, args=args)
 
         self.assertEqual(get_scale_mock.call_args_list, [
-            call(bundle_id, args),
-            call(bundle_id, args),
-            call(bundle_id, args),
-            call(bundle_id, args)
+            call(bundle_id, True, args),
+            call(bundle_id, True, args),
+            call(bundle_id, True, args),
+            call(bundle_id, True, args)
         ])
 
         url_mock.assert_called_with('bundles/events', args)

--- a/conductr_cli/test/test_conduct_run_v2.py
+++ b/conductr_cli/test/test_conduct_run_v2.py
@@ -107,6 +107,6 @@ class TestConductRunCommand(ConductRunTestBase):
 
         http_method.assert_called_with(expected_url, auth=self.conductr_auth, verify=self.server_verification_file,
                                        headers={'Host': '127.0.0.1'})
-        wait_for_scale_mock.assert_called_with(self.bundle_id, self.scale, input_args)
+        wait_for_scale_mock.assert_called_with(self.bundle_id, self.scale, wait_for_is_active=True, args=input_args)
 
         self.assertEqual(self.default_output(), self.output(stdout))

--- a/conductr_cli/test/test_conduct_stop.py
+++ b/conductr_cli/test/test_conduct_stop.py
@@ -63,7 +63,7 @@ class TestConductStopCommand(CliTestCase):
 
         http_method.assert_called_with(self.default_url, auth=self.conductr_auth, verify=self.server_verification_file,
                                        timeout=DEFAULT_HTTP_TIMEOUT, headers={'Host': '127.0.0.1'})
-        wait_for_scale_mock.assert_called_with(self.bundle_id, 0, input_args)
+        wait_for_scale_mock.assert_called_with(self.bundle_id, 0, wait_for_is_active=False, args=input_args)
 
         self.assertEqual(self.default_output(), self.output(stdout))
 
@@ -83,7 +83,7 @@ class TestConductStopCommand(CliTestCase):
 
         http_method.assert_called_with(self.default_url, auth=self.conductr_auth, verify=self.server_verification_file,
                                        timeout=DEFAULT_HTTP_TIMEOUT, headers={'Host': '127.0.0.1'})
-        wait_for_scale_mock.assert_called_with(self.bundle_id, 0, input_args)
+        wait_for_scale_mock.assert_called_with(self.bundle_id, 0, wait_for_is_active=False, args=input_args)
 
         self.assertEqual(self.default_response + self.default_output(), self.output(stdout))
 
@@ -103,7 +103,7 @@ class TestConductStopCommand(CliTestCase):
 
         http_method.assert_called_with(self.default_url, auth=self.conductr_auth, verify=self.server_verification_file,
                                        timeout=DEFAULT_HTTP_TIMEOUT, headers={'Host': '127.0.0.1'})
-        wait_for_scale_mock.assert_called_with(self.bundle_id, 0, input_args)
+        wait_for_scale_mock.assert_called_with(self.bundle_id, 0, wait_for_is_active=False, args=input_args)
 
         self.assertEqual(self.default_output(bundle_id='45e0c477d3e5ea92aa8d85c0d8f3e25c'), self.output(stdout))
 
@@ -125,7 +125,7 @@ class TestConductStopCommand(CliTestCase):
 
         http_method.assert_called_with(self.default_url, auth=self.conductr_auth, verify=self.server_verification_file,
                                        timeout=DEFAULT_HTTP_TIMEOUT, headers={'Host': '127.0.0.1'})
-        wait_for_scale_mock.assert_called_with(self.bundle_id, 0, input_args)
+        wait_for_scale_mock.assert_called_with(self.bundle_id, 0, wait_for_is_active=False, args=input_args)
 
         self.assertEqual(
             self.default_output(params=cli_parameters),
@@ -180,7 +180,7 @@ class TestConductStopCommand(CliTestCase):
 
         http_method.assert_called_with(self.default_url, auth=self.conductr_auth, verify=self.server_verification_file,
                                        timeout=DEFAULT_HTTP_TIMEOUT, headers={'Host': '127.0.0.1'})
-        wait_for_scale_mock.assert_called_with(self.bundle_id, 0, input_args)
+        wait_for_scale_mock.assert_called_with(self.bundle_id, 0, wait_for_is_active=False, args=input_args)
 
         self.assertEqual(
             as_error(strip_margin("""|Error: Timed out: test timeout error
@@ -208,6 +208,6 @@ class TestConductStopCommand(CliTestCase):
 
         http_method.assert_called_with(default_url, auth=self.conductr_auth, verify=self.server_verification_file,
                                        timeout=DEFAULT_HTTP_TIMEOUT, headers={'Host': '10.0.0.1'})
-        wait_for_scale_mock.assert_called_with(self.bundle_id, 0, input_args)
+        wait_for_scale_mock.assert_called_with(self.bundle_id, 0, wait_for_is_active=False, args=input_args)
 
         self.assertEqual(self.default_output(), self.output(stdout))


### PR DESCRIPTION
In ConductR 2.1, a bundle may now be stopping and thus set inActive (isStarted) to false... In this case, when a "conduct stop" command is issue, we want to wait for bundle execution entry to actually disappear before being out of the scale count i.e. we are only waiting on isActive to become True and thus to be part of the scale count when scaling up.