### PR TITLE
Fix regression causing `sandbox stop` to have incorrect return code

### DIFF
--- a/conductr_cli/sandbox_features.py
+++ b/conductr_cli/sandbox_features.py
@@ -186,7 +186,7 @@ class OciInDockerFeature:
 
     @staticmethod
     def stop():
-        pass
+        return True
 
     @staticmethod
     def extract_image_name(dir):


### PR DESCRIPTION
From #396 this should have been `return True`, not `pass`.

Before this change: 
```bash
$ sandbox stop
-> 1
```

After this change:
```bash
$ sandbox stop
-> 0
```