### PR TITLE
Fix version check

### DIFF
--- a/conductr_cli/sandbox_version.py
+++ b/conductr_cli/sandbox_version.py
@@ -17,7 +17,7 @@ def is_cinnamon_grafana_docker_based(version):
 
 
 def version_parts(version):
-    return tuple(map(int, version.split('.')))
+    return tuple(map(int, version.split('-')[0].split('.')))
 
 
 def major_version(version):

--- a/conductr_cli/test/test_sandbox_features.py
+++ b/conductr_cli/test/test_sandbox_features.py
@@ -31,39 +31,41 @@ class TestFeatures(TestCase):
         self.assertEqual(calculate_features(['monitoring', 'visualization']), ['logging', 'monitoring', 'visualization'])
 
     def test_collect_features(self):
-        # default features enabled works
-        self.assertEqual([ProxyingFeature, LiteLoggingFeature],
-                         [type(f) for f in collect_features([], False, LATEST_CONDUCTR_VERSION, False)])
+        mock_system = MagicMock(return_value='Linux')
+        with patch('platform.system', mock_system):
+            # default features enabled works
+            self.assertEqual([ProxyingFeature, LiteLoggingFeature],
+                             [type(f) for f in collect_features([], False, LATEST_CONDUCTR_VERSION, False)])
 
-        # default features disabled works
-        self.assertEqual([],
-                         [type(f) for f in collect_features([], True, LATEST_CONDUCTR_VERSION, False)])
+            # default features disabled works
+            self.assertEqual([],
+                             [type(f) for f in collect_features([], True, LATEST_CONDUCTR_VERSION, False)])
 
-        self.assertEqual([ProxyingFeature, LiteLoggingFeature, VisualizationFeature],
-                         [type(f) for f in collect_features([['visualization']], False, LATEST_CONDUCTR_VERSION, False)])
+            self.assertEqual([ProxyingFeature, LiteLoggingFeature, VisualizationFeature],
+                             [type(f) for f in collect_features([['visualization']], False, LATEST_CONDUCTR_VERSION, False)])
 
-        self.assertEqual([ProxyingFeature, LoggingFeature],
-                         [type(f) for f in collect_features([['logging']], False, LATEST_CONDUCTR_VERSION, False)])
+            self.assertEqual([ProxyingFeature, LoggingFeature],
+                             [type(f) for f in collect_features([['logging']], False, LATEST_CONDUCTR_VERSION, False)])
 
-        self.assertEqual([LoggingFeature],
-                         [type(f) for f in collect_features([['logging']], True, LATEST_CONDUCTR_VERSION, False)])
+            self.assertEqual([LoggingFeature],
+                             [type(f) for f in collect_features([['logging']], True, LATEST_CONDUCTR_VERSION, False)])
 
-        # enable dependencies
-        self.assertEqual([ProxyingFeature, LoggingFeature, MonitoringFeature],
-                         [type(f) for f in collect_features([['monitoring']], False, LATEST_CONDUCTR_VERSION, False)])
+            # enable dependencies
+            self.assertEqual([ProxyingFeature, LoggingFeature, MonitoringFeature],
+                             [type(f) for f in collect_features([['monitoring']], False, LATEST_CONDUCTR_VERSION, False)])
 
-        # allow explicit listing of dependencies
-        self.assertEqual([ProxyingFeature, LoggingFeature, MonitoringFeature],
-                         [type(f) for f in collect_features([['logging'], ['monitoring']], False, LATEST_CONDUCTR_VERSION, False)])
+            # allow explicit listing of dependencies
+            self.assertEqual([ProxyingFeature, LoggingFeature, MonitoringFeature],
+                             [type(f) for f in collect_features([['logging'], ['monitoring']], False, LATEST_CONDUCTR_VERSION, False)])
 
-        # topological ordering for dependencies
-        self.assertEqual([ProxyingFeature, LoggingFeature, MonitoringFeature],
-                         [type(f) for f in collect_features([['monitoring'], ['logging']], False, LATEST_CONDUCTR_VERSION, False)])
+            # topological ordering for dependencies
+            self.assertEqual([ProxyingFeature, LoggingFeature, MonitoringFeature],
+                             [type(f) for f in collect_features([['monitoring'], ['logging']], False, LATEST_CONDUCTR_VERSION, False)])
 
-        # topological ordering and ignore duplicates
-        self.assertEqual([ProxyingFeature, LoggingFeature, MonitoringFeature, VisualizationFeature],
-                         [type(f) for f in collect_features([['monitoring'], ['visualization'], ['logging'], ['monitoring']],
-                                                            False, LATEST_CONDUCTR_VERSION, False)])
+            # topological ordering and ignore duplicates
+            self.assertEqual([ProxyingFeature, LoggingFeature, MonitoringFeature, VisualizationFeature],
+                             [type(f) for f in collect_features([['monitoring'], ['visualization'], ['logging'], ['monitoring']],
+                                                                False, LATEST_CONDUCTR_VERSION, False)])
 
     def test_select_bintray_uri(self):
         self.assertEqual('cinnamon-grafana', select_bintray_uri('cinnamon-grafana')['name'])

--- a/conductr_cli/test/test_validation.py
+++ b/conductr_cli/test/test_validation.py
@@ -21,11 +21,11 @@ class TestTerminal(CliTestCase):
         expect_pass('1')
         expect_pass('1.1')
         expect_pass('1.1.0')
-        expect_pass('1.1.0-SNAPSHOT')
+        expect_pass('1.1.0-alpha.1')
         expect_pass('1.2.3.4.5')
         expect_pass('2')
         expect_pass('2.0.0')
-        expect_pass('2.0.0-SNAPSHOT')
+        expect_pass('2.0.0-beta.1')
 
         expect_fail('potato')
         expect_fail('1.')

--- a/conductr_cli/validation.py
+++ b/conductr_cli/validation.py
@@ -569,7 +569,7 @@ def argparse_version(value):
     import argparse
     import re
 
-    if re.match("^[0-9]+([.][0-9]+)*(\\-SNAPSHOT)?$", value):
+    if re.match("^[0-9]+([.][0-9]+)*(\\-[a-z]+\\.[0-9]+)?$", value):
         return value
 
     raise argparse.ArgumentTypeError("'%s' is not a valid version number" % value)


### PR DESCRIPTION
Version checking wasn't supporting our semantic versions i.e. 2.1.0-alpha.1.

Also fixed a problem when testing features on OS X - the tests didn't expect the OCI feature.