### PR TITLE
Make OCI in Docker a mandatory feature

### DIFF
--- a/conductr_cli/sandbox_features.py
+++ b/conductr_cli/sandbox_features.py
@@ -581,16 +581,22 @@ def collect_features(feature_args, no_default_features, image_version, offline_m
             if LoggingFeature.name not in names:
                 features.insert(0, feature_lookup[LiteLoggingFeature.name]([], image_version, offline_mode))
 
+        add_logging_lite(features)
+        add_proxying(features)
+
+    def add_mandatory_features(features):
+        names = [feature.name for feature in features]
+
         def add_oci_in_docker(features):
             if OciInDockerFeature.name not in names and not host.is_linux():
                 features.insert(0, feature_lookup[OciInDockerFeature.name]([], image_version, offline_mode))
 
-        add_logging_lite(features)
-        add_proxying(features)
         add_oci_in_docker(features)
 
     if not no_default_features:
         add_default_features(features)
+
+    add_mandatory_features(features)
 
     return features
 

--- a/conductr_cli/test/test_sandbox_features.py
+++ b/conductr_cli/test/test_sandbox_features.py
@@ -67,6 +67,29 @@ class TestFeatures(TestCase):
                              [type(f) for f in collect_features([['monitoring'], ['visualization'], ['logging'], ['monitoring']],
                                                                 False, LATEST_CONDUCTR_VERSION, False)])
 
+    def test_collect_features_oci_mandatory(self):
+        with patch('platform.system', lambda: 'Darwin'):
+            self.assertEqual(
+                [OciInDockerFeature],
+                [type(f) for f in collect_features(
+                    [],
+                    no_default_features=True,
+                    image_version=LATEST_CONDUCTR_VERSION,
+                    offline_mode=False
+                )]
+            )
+
+        with patch('platform.system', lambda: 'Linux'):
+            self.assertEqual(
+                [],
+                [type(f) for f in collect_features(
+                    [],
+                    no_default_features=True,
+                    image_version=LATEST_CONDUCTR_VERSION,
+                    offline_mode=False
+                )]
+            )
+
     def test_select_bintray_uri(self):
         self.assertEqual('cinnamon-grafana', select_bintray_uri('cinnamon-grafana')['name'])
         self.assertEqual('cinnamon-grafana', select_bintray_uri('cinnamon-grafana')['bundle'])


### PR DESCRIPTION
This ensures that the OCI-in-Docker feature is always added when applicable (i.e. not linux) -- the `--no-default-features` flag doesn't affect it.