### PR TITLE
Docker resolver

### DIFF
--- a/conductr_cli/exceptions.py
+++ b/conductr_cli/exceptions.py
@@ -37,6 +37,14 @@ class MalformedBundleUriError(Exception):
         return repr(self.value)
 
 
+class ResolverError(Exception):
+    def __init__(self, message):
+        self.message = message
+
+    def __str__(self):
+        return repr(self.message)
+
+
 class BintrayResolutionError(Exception):
     def __init__(self, message):
         self.message = message

--- a/conductr_cli/resolver.py
+++ b/conductr_cli/resolver.py
@@ -1,12 +1,13 @@
 from conductr_cli.exceptions import BundleResolutionError, ContinuousDeliveryError
-from conductr_cli.resolvers import bintray_resolver, stdin_resolver, uri_resolver, offline_resolver
+from conductr_cli.resolvers import \
+    bintray_resolver, docker_offline_resolver, docker_resolver, stdin_resolver, uri_resolver, offline_resolver
 import importlib
 import logging
 
 
 # Try to resolve from local file system before we attempting resolution using bintray
-DEFAULT_RESOLVERS = [stdin_resolver, uri_resolver, bintray_resolver]
-OFFLINE_RESOLVERS = [stdin_resolver, offline_resolver]
+DEFAULT_RESOLVERS = [stdin_resolver, uri_resolver, bintray_resolver, docker_resolver]
+OFFLINE_RESOLVERS = [stdin_resolver, offline_resolver, docker_offline_resolver]
 
 
 def resolve_bundle(custom_settings, cache_dir, uri, offline_mode=False):

--- a/conductr_cli/resolvers/bintray_resolver.py
+++ b/conductr_cli/resolvers/bintray_resolver.py
@@ -103,12 +103,14 @@ def load_bundle_configuration_from_cache(cache_dir, uri):
 
 
 def handle_http_error(http_error, org, repo):
+    log = logging.getLogger(__name__)
     if http_error.response.status_code == requests.codes.not_found:
         if all(s in http_error.response.text for s in ['Repo', repo, 'was not found']):
-            raise BintrayResolutionError(
+            log.debug(
                 'Unable to find Bintray repository {}/{}. '
                 'If this is a private repository make sure to setup the Bintray credentials at {}'
-                .format(org, repo, BINTRAY_CREDENTIAL_FILE_PATH))
+                .format(org, repo, BINTRAY_CREDENTIAL_FILE_PATH)
+            )
 
     return False, None, None
 

--- a/conductr_cli/resolvers/docker_offline_resolver.py
+++ b/conductr_cli/resolvers/docker_offline_resolver.py
@@ -1,0 +1,29 @@
+from conductr_cli.resolvers import docker_resolver
+
+
+def resolve_bundle(cache_dir, uri, auth=None):
+    return docker_resolver.do_resolve_bundle(cache_dir, uri, auth, offline_mode=True)
+
+
+def resolve_file(cache_dir, uri, auth=None):
+    return False, None, None
+
+
+def load_bundle_from_cache(cache_dir, uri):
+    return False, None, None
+
+
+def resolve_bundle_configuration(cache_dir, uri, auth=None):
+    return False, None, None
+
+
+def load_bundle_configuration_from_cache(cache_dir, uri):
+    return False, None, None
+
+
+def resolve_bundle_version(uri):
+    return None
+
+
+def continuous_delivery_uri(resolved_version):
+    return None

--- a/conductr_cli/resolvers/docker_resolver.py
+++ b/conductr_cli/resolvers/docker_resolver.py
@@ -1,0 +1,319 @@
+from collections import OrderedDict
+from conductr_cli import screen_utils
+from conductr_cli.constants import IO_CHUNK_SIZE
+from functools import partial
+from requests.auth import HTTPBasicAuth
+from urllib.parse import urlencode, urlparse
+import gzip
+import hashlib
+import logging
+import os
+import json
+import re
+import requests
+import shutil
+import tempfile
+import www_authenticate
+
+
+DOCKER_CREDENTIAL_FILE_PATH = '{}/.lightbend/docker.credentials'.format(os.path.expanduser('~'))
+DOCKER_PROPERTIES_RE = re.compile('^(\S+)\s*=\s*([\S]+)$')
+
+
+def get_with_token(ns, url, headers=None, raw=False, try_new_token=True):
+    if not hasattr(get_with_token, 'latest_token'):
+        get_with_token.latest_token = None
+
+    try:
+        new_headers = headers.copy() if headers is not None else {}
+
+        if get_with_token.latest_token is not None:
+            new_headers['Authorization'] = 'Bearer {}'.format(get_with_token.latest_token)
+
+        response = requests.get(url, stream=raw, headers=new_headers)
+        response.raise_for_status()
+
+        if raw:
+            response.raw.decode_content = True
+
+        return response
+    except requests.exceptions.HTTPError as error:
+        if error.response.status_code == 401 and 'Www-Authenticate' in error.response.headers and try_new_token:
+            credentials = load_docker_credentials(ns)
+            auth_info = www_authenticate.parse(error.response.headers['Www-Authenticate'])
+
+            token_params = {
+                'service': auth_info['bearer']['service'],
+                'scope': auth_info['bearer']['scope'],
+                'client_id': 'Lightbend ConductR'
+            }
+
+            if credentials is not None:
+                token_params['account'] = credentials[0]
+                auth = HTTPBasicAuth(credentials[0], credentials[1])
+            else:
+                auth = None
+
+            token_url = '{}?{}'.format(auth_info['bearer']['realm'], urlencode(token_params))
+
+            token_response = requests.get(token_url, auth=auth)
+            token_response.raise_for_status()
+            token_content = json.loads(token_response.text)
+
+            get_with_token.latest_token = token_content['token']
+
+            return get_with_token(ns, url, headers, raw, try_new_token=False)
+        else:
+
+            raise error
+
+
+def fetch_blobs(cache_dir, url, ns, image, blobs, offline_mode):
+    log = logging.getLogger(__name__)
+    files = {}
+    needs_retrieving = []
+    downloaded_size = 0
+    total_size = 0
+
+    for blob in blobs:
+        blob['cache_file'] = os.path.join(cache_dir, 'docker-blob-{}'.format(re.sub('\\W', '_', blob['digest'])))
+        blob['cache_file_temp'] = '{}.tmp'.format(blob['cache_file'])
+
+        if not os.path.isfile(blob['cache_file']):
+            needs_retrieving.append(strip_digest(blob['digest']))
+            total_size += blob['size']
+
+    if len(needs_retrieving) > 0:
+        log.info('Retrieving Docker layers:')
+        for layer in needs_retrieving:
+            log.info('    {}'.format(layer))
+
+    for blob in blobs:
+        cache_file = os.path.join(cache_dir, 'docker-blob-{}'.format(re.sub('\\W', '_', blob['digest'])))
+        cache_file_temp = '{}.tmp'.format(cache_file)
+
+        if not os.path.isfile(cache_file):
+            if offline_mode:
+                return None
+
+            full_url = 'https://{}/v2/{}/{}/blobs/{}'.format(url, ns, image, blob['digest'])
+            response = get_with_token(url, full_url, raw=True)
+            with open(cache_file_temp, 'wb') as cache_fileobj:
+                for chunk in iter(partial(response.raw.read, IO_CHUNK_SIZE), b''):
+                    cache_fileobj.write(chunk)
+                    downloaded_size += len(chunk)
+
+                    if log.is_progress_enabled():
+                        progress_bar_text = screen_utils.progress_bar(downloaded_size, total_size)
+                        log.progress(progress_bar_text, flush=downloaded_size >= total_size)
+            os.rename(cache_file_temp, cache_file)
+
+        files[blob['digest']] = cache_file
+
+    return files
+
+
+def fetch_manifest(cache_dir, url, ns, image, manifest, offline_mode):
+    full_url = 'https://{}/v2/{}/{}/manifests/{}'.format(url, ns, image, manifest)
+    full_url_digest = hashlib.sha256(full_url.encode('UTF-8')).hexdigest()
+    cache_file = os.path.join(cache_dir, 'docker-manifest-{}'.format(full_url_digest))
+
+    if offline_mode:
+        if os.path.isfile(cache_file):
+            with open(cache_file, 'r') as cache_fileobj:
+                return json.load(cache_fileobj)
+        else:
+            return None
+    else:
+        response = get_with_token(url,
+                                  full_url,
+                                  headers={'Accept': 'application/vnd.docker.distribution.manifest.v2+json'})
+        response.raise_for_status()
+
+        with open(cache_file, 'w') as cache_fileobj:
+            cache_fileobj.write(response.text)
+
+        return json.loads(response.text)
+
+
+def strip_digest(value):
+    try:
+        return value[value.index(':') + 1:]
+    except ValueError:
+        return value
+
+
+def parse_uri(uri):
+    parts = uri.split('/', 2)
+    num_parts = len(parts)
+
+    provided_url = parts[0] if num_parts > 2 else None
+    url = provided_url if provided_url is not None else 'registry.hub.docker.com'
+
+    provided_ns = parts[1] if num_parts > 2 else parts[0] if num_parts > 1 else None
+    ns = provided_ns if provided_ns is not None else 'library'
+
+    image_parts = (parts[2] if num_parts > 2 else parts[1] if num_parts > 1 else parts[0]).split(':', 1)
+    image = image_parts[0]
+
+    provided_tag = image_parts[1] if len(image_parts) > 1 else None
+    tag = provided_tag if provided_tag is not None else 'latest'
+
+    return (provided_url, url), (provided_ns, ns), (image, image), (provided_tag, tag)
+
+
+def resolve_bundle(cache_dir, uri, auth=None):
+    return do_resolve_bundle(cache_dir, uri, auth, offline_mode=False)
+
+
+def do_resolve_bundle(cache_dir, uri, auth, offline_mode):
+    log = logging.getLogger(__name__)
+
+    if is_local_file(uri):
+        return False, None, None
+
+    (provided_url, url), (provided_ns, ns), (provided_image, image), (provided_tag, tag) = parse_uri(uri)
+
+    temp_dir = tempfile.mkdtemp()
+
+    try:
+        manifest = fetch_manifest(cache_dir, url, ns, image, tag, offline_mode)
+
+        if manifest is None:
+            return False, None, None
+
+        files = fetch_blobs(cache_dir, url, ns, image, [manifest['config']] + manifest['layers'], offline_mode)
+
+        if files is None:
+            return False, None, None
+
+        shutil.copyfile(
+            files[manifest['config']['digest']],
+            os.path.join(temp_dir, strip_digest(manifest['config']['digest']) + '.json')
+        )
+
+        layers = []
+        layer_digests = []
+
+        for layer in manifest['layers']:
+            layer_file = files[layer['digest']]
+            digest = hashlib.sha256()
+            base_layer_digest = strip_digest(layer['digest'])
+            layer_digests.append(base_layer_digest)
+            base_layer_name = os.path.join(base_layer_digest, 'layer.tar')
+            file_name = os.path.join(temp_dir, base_layer_name)
+            os.makedirs(os.path.dirname(file_name))
+
+            with open(file_name, 'wb') as layer_out_file, open(layer_file, 'rb') as layer_in_file:
+                if layer['mediaType'].endswith('.gzip'):
+                    with gzip.GzipFile(fileobj=layer_in_file.raw, mode='rb') as gzip_file:
+                        for chunk in iter(partial(gzip_file.read, IO_CHUNK_SIZE), b''):
+                            layer_out_file.write(chunk)
+                            digest.update(chunk)
+                else:
+                    for chunk in iter(partial(layer_in_file.read, IO_CHUNK_SIZE), b''):
+                        layer_out_file.write(chunk)
+                        digest.update(chunk)
+
+            layers.append(base_layer_name)
+
+        manifests_tag = []
+        repositories = {}
+
+        if provided_url is not None and provided_ns is not None and tag is not None:
+            manifests_tag.append('{}/{}/{}:{}'.format(provided_url, provided_ns, image, tag))
+
+            if len(layer_digests) > 0:
+                repositories['{}/{}/{}'.format(provided_url, provided_ns, image)] = {tag: layer_digests[-1]}
+        elif provided_ns is not None and tag is not None:
+            manifests_tag.append('{}/{}:{}'.format(provided_ns, image, tag))
+
+            if len(layer_digests) > 0:
+                repositories['{}/{}'.format(provided_ns, image)] = {tag: layer_digests[-1]}
+        elif tag is not None:
+            manifests_tag.append('{}:{}'.format(image, tag))
+
+            if len(layer_digests) > 0:
+                repositories[image] = {tag: layer_digests[-1]}
+
+        manifests = [OrderedDict([
+            ('Config', '{}.json'.format(strip_digest(manifest['config']['digest']))),
+            ('RepoTags', manifests_tag),
+            ('Layers', layers)
+        ])]
+
+        with open(os.path.join(temp_dir, 'manifest.json'), 'w') as manifest_fileobj:
+            manifest_fileobj.write(json.dumps(manifests))
+
+        with open(os.path.join(temp_dir, 'repositories'), 'w') as repositories_fileobj:
+            repositories_fileobj.write(json.dumps(repositories))
+
+        return True, None, temp_dir
+    except Exception as e:
+        log.debug(e, exc_info=1)
+        return False, None, None
+
+
+def load_bundle_from_cache(cache_dir, uri):
+    return False, None, None
+
+
+def resolve_bundle_configuration(cache_dir, uri, auth=None):
+    return False, None, None
+
+
+def load_bundle_configuration_from_cache(cache_dir, uri):
+    return False, None, None
+
+
+def resolve_bundle_version(uri):
+    return None
+
+
+def continuous_delivery_uri(resolved_version):
+    return None
+
+
+def is_bundle_name(uri):
+    return uri.count('/') == 0 and uri.count('.') == 0
+
+
+def is_local_file(uri):
+    parsed = urlparse(uri, scheme='file')
+    return parsed.scheme == 'file' and os.path.exists(parsed.path)
+
+
+def load_docker_credentials(server):
+    log = logging.getLogger(__name__)
+
+    override_path = '{}-{}'.format(DOCKER_CREDENTIAL_FILE_PATH, server)
+
+    if os.path.exists(override_path):
+        path = override_path
+    elif os.path.exists(DOCKER_CREDENTIAL_FILE_PATH):
+        path = DOCKER_CREDENTIAL_FILE_PATH
+    else:
+        path = None
+
+    if path is None:
+            return None
+    else:
+        with open(path, 'r') as cred_file:
+            lines = [line.replace('\n', '') for line in cred_file.readlines()]
+            data = dict()
+            for line in lines:
+                match = DOCKER_PROPERTIES_RE.match(line)
+                if match is not None:
+                    try:
+                        key, value = match.group(1, 2)
+                        key = 'user' if key == 'username' else key
+                        data[key] = value
+                    except IndexError:
+                        pass
+
+            if 'user' not in data or 'password' not in data:
+                return None
+
+            log.info('Docker credentials loaded from {}'.format(path))
+
+            return data['user'], data['password']

--- a/conductr_cli/resolvers/test/test_bintray_resolver.py
+++ b/conductr_cli/resolvers/test/test_bintray_resolver.py
@@ -83,8 +83,7 @@ class TestResolveBundle(TestCase):
         with patch('conductr_cli.resolvers.bintray_resolver.load_bintray_credentials', load_bintray_credentials_mock), \
                 patch('conductr_cli.bundle_shorthand.parse_bundle', parse_bundle_mock), \
                 patch('conductr_cli.resolvers.bintray_resolver.bintray_resolve_version', bintray_resolve_version_mock):
-            self.assertRaises(BintrayResolutionError, bintray_resolver.resolve_bundle,
-                              '/cache-dir', 'bundle-name:v1')
+            self.assertEqual(bintray_resolver.resolve_bundle('/cache-dir', 'bundle-name:v1'), (False, None, None))
 
         exists_mock.assert_not_called()
         load_bintray_credentials_mock.assert_called_with(raise_error=False)
@@ -207,8 +206,8 @@ class TestResolveBundleConfiguration(TestCase):
         with patch('conductr_cli.resolvers.bintray_resolver.load_bintray_credentials', load_bintray_credentials_mock), \
                 patch('conductr_cli.bundle_shorthand.parse_bundle_configuration', parse_bundle_configuration_mock), \
                 patch('conductr_cli.resolvers.bintray_resolver.bintray_resolve_version', bintray_resolve_version_mock):
-            self.assertRaises(BintrayResolutionError, bintray_resolver.resolve_bundle_configuration,
-                              '/cache-dir', 'bundle-name:v1')
+            self.assertEqual(bintray_resolver.resolve_bundle_configuration('/cache-dir', 'bundle-name:v1'),
+                             (False, None, None))
 
         load_bintray_credentials_mock.assert_called_with(raise_error=False)
         parse_bundle_configuration_mock.assert_called_with('bundle-name:v1')
@@ -371,8 +370,8 @@ class TestLoadBundleFromCache(TestCase):
                 patch('conductr_cli.resolvers.bintray_resolver.load_bintray_credentials', load_bintray_credentials_mock), \
                 patch('conductr_cli.bundle_shorthand.parse_bundle', parse_bundle_mock), \
                 patch('conductr_cli.resolvers.bintray_resolver.bintray_resolve_version', bintray_resolve_version_mock):
-            self.assertRaises(BintrayResolutionError, bintray_resolver.load_bundle_from_cache,
-                              '/cache-dir', 'bundle-name:v1')
+            self.assertEqual(bintray_resolver.load_bundle_from_cache('/cache-dir', 'bundle-name:v1'),
+                             (False, None, None))
 
         exists_mock.assert_not_called()
         load_bintray_credentials_mock.assert_called_with(raise_error=False)
@@ -530,8 +529,10 @@ class TestLoadBundleConfigurationFromCache(TestCase):
                 patch('conductr_cli.resolvers.bintray_resolver.load_bintray_credentials', load_bintray_credentials_mock), \
                 patch('conductr_cli.bundle_shorthand.parse_bundle_configuration', parse_bundle_configuration_mock), \
                 patch('conductr_cli.resolvers.bintray_resolver.bintray_resolve_version', bintray_resolve_version_mock):
-            self.assertRaises(BintrayResolutionError, bintray_resolver.load_bundle_configuration_from_cache,
-                              '/cache-dir', 'bundle-name:v1')
+            self.assertEquals(
+                bintray_resolver.load_bundle_configuration_from_cache('/cache-dir', 'bundle-name:v1'),
+                (False, None, None)
+            )
 
         exists_mock.assert_not_called()
         load_bintray_credentials_mock.assert_called_with(raise_error=False)

--- a/conductr_cli/test/test_resolver.py
+++ b/conductr_cli/test/test_resolver.py
@@ -1,9 +1,10 @@
 from unittest import TestCase
-from unittest.mock import patch, MagicMock, Mock
+from unittest.mock import call, patch, MagicMock, Mock
 from conductr_cli.test.cli_test_case import strip_margin, create_mock_logger
 from conductr_cli.exceptions import BundleResolutionError, ContinuousDeliveryError
 from conductr_cli import resolver
-from conductr_cli.resolvers import bintray_resolver, uri_resolver, offline_resolver, stdin_resolver
+from conductr_cli.resolvers import \
+    bintray_resolver, docker_resolver, docker_offline_resolver, uri_resolver, offline_resolver, stdin_resolver
 from pyhocon import ConfigFactory
 import tempfile
 
@@ -277,7 +278,7 @@ class TestResolverChain(TestCase):
 
     def test_none_input(self):
         result = resolver.resolver_chain(None, False)
-        expected_result = [stdin_resolver, uri_resolver, bintray_resolver]
+        expected_result = [stdin_resolver, uri_resolver, bintray_resolver, docker_resolver]
         self.assertEqual(expected_result, result)
 
     def test_custom_settings_no_resolver_config(self):
@@ -286,12 +287,12 @@ class TestResolverChain(TestCase):
                             |""")
         )
         result = resolver.resolver_chain(custom_settings, False)
-        expected_result = [stdin_resolver, uri_resolver, bintray_resolver]
+        expected_result = [stdin_resolver, uri_resolver, bintray_resolver, docker_resolver]
         self.assertEqual(expected_result, result)
 
     def test_offline_mode(self):
         result = resolver.resolver_chain(None, True)
-        expected_result = [stdin_resolver, offline_resolver]
+        expected_result = [stdin_resolver, offline_resolver, docker_offline_resolver]
         self.assertEqual(expected_result, result)
 
 
@@ -326,3 +327,104 @@ class TestResolverStdIn(TestCase):
             file.seek(0)
 
             self.assertEqual(file.read(), b'hello')
+
+
+class TestResolverDocker(TestCase):
+    def test_parse_uri(self):
+        self.assertEqual(docker_resolver.parse_uri('alpine'), (
+            (None, 'registry.hub.docker.com'),
+            (None, 'library'),
+            ('alpine', 'alpine'),
+            (None, 'latest')
+        ))
+
+        self.assertEqual(docker_resolver.parse_uri('alpine:3.5'), (
+            (None, 'registry.hub.docker.com'),
+            (None, 'library'),
+            ('alpine', 'alpine'),
+            ('3.5', '3.5')
+        ))
+
+        self.assertEqual(docker_resolver.parse_uri('lightbend-docker.registry.bintray.io/conductr/oci-in-docker'), (
+            ('lightbend-docker.registry.bintray.io', 'lightbend-docker.registry.bintray.io'),
+            ('conductr', 'conductr'),
+            ('oci-in-docker', 'oci-in-docker'),
+            (None, 'latest')
+        ))
+
+        self.assertEqual(docker_resolver.parse_uri('lightbend-docker.registry.bintray.io/conductr/oci-in-docker:0.1'), (
+            ('lightbend-docker.registry.bintray.io', 'lightbend-docker.registry.bintray.io'),
+            ('conductr', 'conductr'),
+            ('oci-in-docker', 'oci-in-docker'),
+            ('0.1', '0.1')
+        ))
+
+    def test_offline_mode(self):
+        mock_is_file = MagicMock(return_value=True)
+        mock_json_load = MagicMock(return_value='1234')
+        mock_open = MagicMock(return_value=MagicMock())
+
+        with \
+                patch('os.path.isfile', mock_is_file), \
+                patch('json.load', mock_json_load), \
+                patch('builtins.open', mock_open):
+            self.assertEqual(
+                docker_resolver.fetch_manifest('/tmp', 'registry.hub.docker.com', 'library', 'alpine', '3.5', True),
+                '1234'
+            )
+
+        mock_is_file.assert_called_once_with('/tmp/docker-manifest-624ab327c0f6bb1039ca62'
+                                             '9a2c1ec806514b9194c30491c02e9800254c73d998')
+
+    def test_load_docker_credentials(self):
+        with \
+                tempfile.NamedTemporaryFile('w') as one, \
+                tempfile.NamedTemporaryFile('w') as two, \
+                tempfile.NamedTemporaryFile('w') as three:
+            one.write('user=one\npassword=one-password')
+            one.flush()
+            two.write('username=two\npassword=two-password')
+            two.flush()
+            three.write('hello')
+            three.flush()
+
+            with \
+                    open(one.name, 'r') as one_in, \
+                    patch('os.path.exists', MagicMock(return_value=True)), \
+                    patch('builtins.open', MagicMock(return_value=one_in)):
+                self.assertEquals(
+                    resolver.docker_resolver.load_docker_credentials('test'),
+                    ('one', 'one-password')
+                )
+
+            with \
+                    open(two.name, 'r') as two_in, \
+                    patch('os.path.exists', MagicMock(return_value=True)), \
+                    patch('builtins.open', MagicMock(return_value=two_in)):
+                self.assertEquals(
+                    resolver.docker_resolver.load_docker_credentials('test'),
+                    ('two', 'two-password')
+                )
+
+            with \
+                    open(three.name, 'r') as three_in, \
+                    patch('os.path.exists', MagicMock(return_value=True)), \
+                    patch('builtins.open', MagicMock(return_value=three_in)):
+                self.assertEquals(
+                    resolver.docker_resolver.load_docker_credentials('test'),
+                    None
+                )
+
+            path_exists_mock = MagicMock(side_effect=[False, True])
+
+            with \
+                    open(one.name, 'r') as one_in, \
+                    patch('os.path.exists', path_exists_mock), \
+                    MagicMock(return_value=one_in) as open_mock, \
+                    patch('builtins.open', open_mock):
+                resolver.docker_resolver.load_docker_credentials('test')
+
+                path_exists_mock.assert_has_calls([
+                    call('{}-{}'.format(docker_resolver.DOCKER_CREDENTIAL_FILE_PATH, 'test')),
+                    call(docker_resolver.DOCKER_CREDENTIAL_FILE_PATH)
+                ])

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ install_requires = [
     'arrow>=0.6.0',
     'colorama>=0.3.7',
     'pyreadline>=2.1',
+    'www-authenticate==0.9.2',
 
     # FIXME: Remove the following dependencies when dcos can be depended on
     'jsonschema==2.4',  # pin the exact version, jsonschema 2.5 broke py3


### PR DESCRIPTION
This PR provides a docker resolver that can resolver from any `v2` registries. It implements support for the OAuth-based registry authentication. Unit tests are performed on the parts that can be reliability unit tested. I think we'd benefit from integration tests of it like we for the bintray resolvers so perhaps we should follow up with that in future `sbt-conductr` work.

- [x] Pull from public registry
- [x] Pull from alternate registries
- [x] Authentication
- [x] Cache docker layers
- [x] Unit Tests
- [x] Invoke `bndl` if necessary (resolver returns a directory)