### PR TITLE
conduct setup-dcos improvements

### DIFF
--- a/conductr_cli/conduct_dcos.py
+++ b/conductr_cli/conduct_dcos.py
@@ -2,12 +2,22 @@ from dcos import constants
 import logging
 import os
 import shutil
+import sys
 
 
 def setup(args):
     """`conduct setup-dcos` command"""
     log = logging.getLogger(__name__)
-    src = shutil.which("conduct")
+
+    if sys.executable.endswith(os.path.sep + 'conduct'):
+        src = sys.executable
+    else:
+        src = shutil.which('conduct')
+
+        if src is None:
+            log.error('Unable to determine location of \'conduct\'; is it on the PATH?')
+            return False
+
     dst = os.path.join(os.path.expanduser('~'),
                        constants.DCOS_DIR,
                        constants.DCOS_SUBCOMMAND_SUBDIR,
@@ -15,10 +25,11 @@ def setup(args):
                        constants.DCOS_SUBCOMMAND_ENV_SUBDIR,
                        'bin',
                        constants.DCOS_COMMAND_PREFIX + 'conduct')
-    if os.path.exists(dst):
+
+    if os.path.exists(dst) or os.path.islink(dst):
         os.remove(dst)
-    else:
-        os.makedirs(os.path.dirname(dst), exist_ok=True)
+
+    os.makedirs(os.path.dirname(dst), exist_ok=True)
     os.symlink(src, dst)
     log.screen('The DC/OS CLI is now configured.\n'
                'Prefix \'conduct\' with \'dcos\' when you want to contact ConductR on DC/OS e.g. \'dcos conduct info\'')

--- a/conductr_cli/test/test_conduct_dcos.py
+++ b/conductr_cli/test/test_conduct_dcos.py
@@ -7,7 +7,7 @@ import os
 
 class TestConductDcosCommand(CliTestCase):
 
-    def test_success(self):
+    def test_success_which(self):
         args = MagicMock()
         stdout = MagicMock()
         makedirs = MagicMock()
@@ -16,6 +16,7 @@ class TestConductDcosCommand(CliTestCase):
         logging_setup.configure_logging(args, stdout)
 
         with patch('shutil.which', lambda x: '/somefile'), \
+                patch('sys.executable', '/usr/bin/python3'), \
                 patch('os.path.exists', lambda x: True), \
                 patch('os.remove', lambda x: True), \
                 patch('os.makedirs', makedirs), \
@@ -23,7 +24,10 @@ class TestConductDcosCommand(CliTestCase):
             result = conduct_dcos.setup(args)
         self.assertTrue(result)
 
-        makedirs.assert_not_called()
+        makedirs.assert_called_once_with(
+            '{}/.dcos/subcommands/conductr/env/bin'.format(os.path.expanduser('~')),
+            exist_ok=True
+        )
 
         symlink.assert_called_with('/somefile',
                                    '{}/.dcos/subcommands/conductr/env/bin/dcos-conduct'.format(os.path.expanduser('~')))
@@ -34,6 +38,27 @@ class TestConductDcosCommand(CliTestCase):
                             |"""),
             self.output(stdout))
 
+    def test_success_executable(self):
+        args = MagicMock()
+        stdout = MagicMock()
+        makedirs = MagicMock()
+        symlink = MagicMock()
+
+        logging_setup.configure_logging(args, stdout)
+
+        with \
+                patch('shutil.which', lambda x: '/somefile'), \
+                patch('sys.executable', '/path/to/conduct'), \
+                patch('os.path.exists', lambda x: True), \
+                patch('os.remove', lambda x: True), \
+                patch('os.makedirs', makedirs), \
+                patch('os.symlink', symlink):
+            result = conduct_dcos.setup(args)
+        self.assertTrue(result)
+
+        symlink.assert_called_with('/path/to/conduct',
+                                   '{}/.dcos/subcommands/conductr/env/bin/dcos-conduct'.format(os.path.expanduser('~')))
+
     def test_create_dir(self):
         args = MagicMock()
         stdout = MagicMock()
@@ -43,8 +68,10 @@ class TestConductDcosCommand(CliTestCase):
 
         logging_setup.configure_logging(args, stdout)
 
-        with patch('shutil.which', lambda x: '/somefile'), \
+        with \
+                patch('shutil.which', lambda x: '/somefile'), \
                 patch('os.path.exists', lambda x: False), \
+                patch('os.path.islink', lambda x: False), \
                 patch('os.remove', remove), \
                 patch('os.makedirs', makedirs), \
                 patch('os.symlink', symlink):


### PR DESCRIPTION
This PR improves `conduct setup-dcos` - 

* Use `sys.executable` if it contains the path to the `conduct` executable. This allows the command to work in situations when `conduct` isn't on the PATH.
* If unable to use `sys.executable` and `conduct` is not on the PATH, now plainly tells the user so.
* Detects if `~/.dcos/subcommands/conductr/env/bin/dcos-conduct` is a broken symlink and removes it if so