### PR TITLE
`bndl` now sets mtime

### DIFF
--- a/conductr_cli/bndl_docker.py
+++ b/conductr_cli/bndl_docker.py
@@ -218,7 +218,7 @@ def docker_unpack(destination, data, is_dir, maybe_name, maybe_tag):
                     # bundles are packaged into zips, so we don't want to compress, but OCI tooling
                     # as of 2017-03-14 is broken for plain tar files; they must be gzip
 
-                    with gzip.GzipFile(fileobj=dest_file_digest, mode='wb', compresslevel=0) as dest:
+                    with gzip.GzipFile(fileobj=dest_file_digest, mode='wb', compresslevel=0, mtime=0) as dest:
                         shutil.copyfileobj(fileobj, dest)
 
                     dest_file_hexdigest = dest_file_digest.digest_out.hexdigest()

--- a/conductr_cli/bndl_utils.py
+++ b/conductr_cli/bndl_utils.py
@@ -137,6 +137,14 @@ def file_write_bytes(path, bs):
         file.write(bs)
 
 
+def first_mtime(path):
+    for (dir_path, dir_names, file_names) in os.walk(path):
+        for file_name in file_names:
+            return os.path.getmtime(os.path.join(dir_path, file_name))
+
+    return 0
+
+
 class DigestReaderWriter(object):
     def __init__(self, fileobj):
         self.digest_in = hashlib.sha256()

--- a/conductr_cli/shazar_main.py
+++ b/conductr_cli/shazar_main.py
@@ -107,11 +107,15 @@ def shazar(args):
                 sys.stdout.write(dest + os.linesep)
 
 
-def dir_to_zip(dir, zip_file, source_base_name):
+def dir_to_zip(dir, zip_file, source_base_name, mtime=None):
     for (dir_path, dir_names, file_names) in os.walk(dir):
         for file_name in file_names:
             path = os.path.join(dir_path, file_name)
             name = os.path.join(source_base_name, os.path.relpath(path, start=dir))
+
+            if mtime is not None:
+                os.utime(path, (mtime, mtime))
+
             zip_file.write(path, name)
 
 

--- a/conductr_cli/test/test_bndl_create.py
+++ b/conductr_cli/test/test_bndl_create.py
@@ -4,7 +4,9 @@ from io import BytesIO
 from unittest.mock import patch, MagicMock
 import os
 import shutil
+import tarfile
 import tempfile
+import time
 import zipfile
 
 
@@ -60,31 +62,34 @@ class TestBndlCreate(CliTestCase):
     def test_no_ref(self):
         tmpdir = tempfile.mkdtemp()
 
-        with tempfile.NamedTemporaryFile() as output:
-            attributes = create_attributes_object({
-                'name': 'test',
-                'source': tmpdir,
-                'format': 'oci-image',
-                'tag': 'latest',
-                'output': output.name
-            })
+        try:
+            with tempfile.NamedTemporaryFile() as output:
+                attributes = create_attributes_object({
+                    'name': 'test',
+                    'source': tmpdir,
+                    'format': 'oci-image',
+                    'tag': 'latest',
+                    'output': output.name
+                })
 
-        stdout_mock = MagicMock()
-        stderr_mock = MagicMock()
-        logging_setup.configure_logging(MagicMock(), stdout_mock, stderr_mock)
+            stdout_mock = MagicMock()
+            stderr_mock = MagicMock()
+            logging_setup.configure_logging(MagicMock(), stdout_mock, stderr_mock)
 
-        os.mkdir(os.path.join(tmpdir, 'refs'))
-        open(os.path.join(tmpdir, 'oci-layout'), 'w').close()
+            os.mkdir(os.path.join(tmpdir, 'refs'))
+            open(os.path.join(tmpdir, 'oci-layout'), 'w').close()
 
-        with \
-                patch('sys.stdin', MagicMock(**{'buffer': BytesIO(b'')})), \
-                patch('sys.stdout.buffer.write', stdout_mock):
-            bndl_create.bndl_create(attributes)
+            with \
+                    patch('sys.stdin', MagicMock(**{'buffer': BytesIO(b'')})), \
+                    patch('sys.stdout.buffer.write', stdout_mock):
+                bndl_create.bndl_create(attributes)
 
-        self.assertEqual(
-            self.output(stderr_mock),
-            as_error('Error: bndl: Invalid OCI Image. Cannot find requested tag "latest" in OCI Image\n')
-        )
+            self.assertEqual(
+                self.output(stderr_mock),
+                as_error('Error: bndl: Invalid OCI Image. Cannot find requested tag "latest" in OCI Image\n')
+            )
+        finally:
+            shutil.rmtree(tmpdir)
 
     def test_with_shazar(self):
         stdout_mock = MagicMock()
@@ -106,9 +111,11 @@ class TestBndlCreate(CliTestCase):
 
             os.mkdir(os.path.join(tmpdir, 'refs'))
             open(os.path.join(tmpdir, 'oci-layout'), 'w').close()
+            os.utime(os.path.join(tmpdir, 'oci-layout'), (1234567890, 1234567890))
             refs = open(os.path.join(tmpdir, 'refs/latest'), 'w')
             refs.write('{}')
             refs.close()
+            os.utime(os.path.join(tmpdir, 'refs/latest'), (1234567890, 1234567890))
 
             with \
                     patch('sys.stdin', MagicMock(**{'buffer': BytesIO(b'')})), \
@@ -116,12 +123,16 @@ class TestBndlCreate(CliTestCase):
                 self.assertEqual(bndl_create.bndl_create(attributes), 0)
 
             self.assertTrue(zipfile.is_zipfile(tmpfile))
+
+            with zipfile.ZipFile(tmpfile) as zip:
+                infos = zip.infolist()
+
+                self.assertEqual(infos[0].date_time, time.localtime(1234567890)[:6])
         finally:
             shutil.rmtree(tmpdir)
 
     def test_without_shazar(self):
         stdout_mock = MagicMock()
-        extract_config_mock = MagicMock()
         tmpdir = tempfile.mkdtemp()
         tmpfile = os.path.join(tmpdir, 'output')
 
@@ -140,16 +151,188 @@ class TestBndlCreate(CliTestCase):
 
             os.mkdir(os.path.join(tmpdir, 'refs'))
             open(os.path.join(tmpdir, 'oci-layout'), 'w').close()
+            os.utime(os.path.join(tmpdir, 'oci-layout'), (1234567890, 1234567890))
             refs = open(os.path.join(tmpdir, 'refs/latest'), 'w')
             refs.write('{}')
             refs.close()
+            os.utime(os.path.join(tmpdir, 'refs/latest'), (1234567890, 1234567890))
 
             with \
-                    patch('conductr_cli.bndl_oci.oci_image_extract_manifest_config', extract_config_mock), \
+                    patch('conductr_cli.bndl_oci.oci_image_extract_manifest_config', lambda a, b: ({}, {})), \
                     patch('sys.stdin', MagicMock(**{'buffer': BytesIO(b'')})), \
                     patch('sys.stdout.buffer.write', stdout_mock):
                 self.assertEqual(bndl_create.bndl_create(attributes), 0)
 
             self.assertFalse(zipfile.is_zipfile(tmpfile))
+
+            with tarfile.TarFile.open(tmpfile) as tar:
+                for entry in tar:
+                    self.assertEqual(entry.mtime, 1234567890)
+                    break
         finally:
             shutil.rmtree(tmpdir)
+
+    def test_deterministic_with_shazar(self):
+        stdout_mock = MagicMock()
+        tmpdir = tempfile.mkdtemp()
+        tmpdir2 = tempfile.mkdtemp()
+        tmpfile = os.path.join(tmpdir, 'output')
+        tmpfile2 = os.path.join(tmpdir2, 'output')
+
+        try:
+            attributes = create_attributes_object({
+                'name': 'test',
+                'source': tmpdir,
+                'format': 'oci-image',
+                'tag': 'latest',
+                'output': tmpfile,
+                'component_description': '',
+                'use_shazar': True,
+                'use_default_endpoints': True,
+                'annotations': []
+            })
+
+            os.mkdir(os.path.join(tmpdir, 'refs'))
+            open(os.path.join(tmpdir, 'oci-layout'), 'w').close()
+            os.utime(os.path.join(tmpdir, 'oci-layout'), (1234567890, 1234567890))
+            refs = open(os.path.join(tmpdir, 'refs/latest'), 'w')
+            refs.write('{}')
+            refs.close()
+            os.utime(os.path.join(tmpdir, 'refs/latest'), (1234567890, 1234567890))
+
+            attributes2 = create_attributes_object({
+                'name': 'test',
+                'source': tmpdir2,
+                'format': 'oci-image',
+                'tag': 'latest',
+                'output': tmpfile2,
+                'component_description': '',
+                'use_shazar': True,
+                'use_default_endpoints': True,
+                'annotations': []
+            })
+
+            os.mkdir(os.path.join(tmpdir2, 'refs'))
+            open(os.path.join(tmpdir2, 'oci-layout'), 'w').close()
+            os.utime(os.path.join(tmpdir2, 'oci-layout'), (1234567890, 1234567890))
+            refs2 = open(os.path.join(tmpdir2, 'refs/latest'), 'w')
+            refs2.write('{}')
+            refs2.close()
+            os.utime(os.path.join(tmpdir2, 'refs/latest'), (1234567890, 1234567890))
+
+            with \
+                    patch('sys.stdin', MagicMock(**{'buffer': BytesIO(b'')})), \
+                    patch('sys.stdout.buffer.write', stdout_mock):
+                bndl_create.bndl_create(attributes)
+                bndl_create.bndl_create(attributes2)
+
+            with open(tmpfile, 'rb') as fileobj, open(tmpfile2, 'rb') as fileobj2:
+                self.assertEqual(fileobj.read(), fileobj2.read())
+
+        finally:
+            shutil.rmtree(tmpdir)
+            shutil.rmtree(tmpdir2)
+
+    def test_mtime_from_config(self):
+        config = {
+            'created': '2017-02-27T19:42:10.522384312Z'
+        }
+        stdout_mock = MagicMock()
+        tmpdir = tempfile.mkdtemp()
+        tmpfile = os.path.join(tmpdir, 'output')
+
+        try:
+            attributes = create_attributes_object({
+                'name': 'test',
+                'source': tmpdir,
+                'format': 'oci-image',
+                'tag': 'latest',
+                'output': tmpfile,
+                'component_description': '',
+                'use_shazar': True,
+                'use_default_endpoints': True,
+                'annotations': []
+            })
+
+            os.mkdir(os.path.join(tmpdir, 'refs'))
+            open(os.path.join(tmpdir, 'oci-layout'), 'w').close()
+            os.utime(os.path.join(tmpdir, 'oci-layout'), (1234567890, 1234567890))
+            refs = open(os.path.join(tmpdir, 'refs/latest'), 'w')
+            refs.write('{}')
+            refs.close()
+            os.utime(os.path.join(tmpdir, 'refs/latest'), (1234567890, 1234567890))
+
+            with \
+                    patch('conductr_cli.bndl_oci.oci_image_extract_manifest_config', lambda a, b: ({}, config)), \
+                    patch('sys.stdin', MagicMock(**{'buffer': BytesIO(b'')})), \
+                    patch('sys.stdout.buffer.write', stdout_mock):
+                self.assertEqual(bndl_create.bndl_create(attributes), 0)
+
+            with zipfile.ZipFile(tmpfile) as zip:
+                infos = zip.infolist()
+
+                self.assertEqual(infos[0].date_time, time.localtime(1488224530)[:6])
+
+        finally:
+            shutil.rmtree(tmpdir)
+
+    def test_deterministic_without_shazar(self):
+        stdout_mock = MagicMock()
+        tmpdir = tempfile.mkdtemp()
+        tmpdir2 = tempfile.mkdtemp()
+        tmpfile = os.path.join(tmpdir, 'output')
+        tmpfile2 = os.path.join(tmpdir2, 'output')
+
+        try:
+            attributes = create_attributes_object({
+                'name': 'test',
+                'source': tmpdir,
+                'format': 'oci-image',
+                'tag': 'latest',
+                'output': tmpfile,
+                'component_description': '',
+                'use_shazar': False,
+                'use_default_endpoints': True,
+                'annotations': []
+            })
+
+            os.mkdir(os.path.join(tmpdir, 'refs'))
+            open(os.path.join(tmpdir, 'oci-layout'), 'w').close()
+            os.utime(os.path.join(tmpdir, 'oci-layout'), (1234567890, 1234567890))
+            refs = open(os.path.join(tmpdir, 'refs/latest'), 'w')
+            refs.write('{}')
+            refs.close()
+            os.utime(os.path.join(tmpdir, 'refs/latest'), (1234567890, 1234567890))
+
+            attributes2 = create_attributes_object({
+                'name': 'test',
+                'source': tmpdir2,
+                'format': 'oci-image',
+                'tag': 'latest',
+                'output': tmpfile2,
+                'component_description': '',
+                'use_shazar': False,
+                'use_default_endpoints': True,
+                'annotations': []
+            })
+
+            os.mkdir(os.path.join(tmpdir2, 'refs'))
+            open(os.path.join(tmpdir2, 'oci-layout'), 'w').close()
+            os.utime(os.path.join(tmpdir2, 'oci-layout'), (1234567890, 1234567890))
+            refs2 = open(os.path.join(tmpdir2, 'refs/latest'), 'w')
+            refs2.write('{}')
+            refs2.close()
+            os.utime(os.path.join(tmpdir2, 'refs/latest'), (1234567890, 1234567890))
+
+            with \
+                    patch('sys.stdin', MagicMock(**{'buffer': BytesIO(b'')})), \
+                    patch('sys.stdout.buffer.write', stdout_mock):
+                bndl_create.bndl_create(attributes)
+                bndl_create.bndl_create(attributes2)
+
+            with open(tmpfile, 'rb') as fileobj, open(tmpfile2, 'rb') as fileobj2:
+                self.assertEqual(fileobj.read(), fileobj2.read())
+
+        finally:
+            shutil.rmtree(tmpdir)
+            shutil.rmtree(tmpdir2)

--- a/conductr_cli/test/test_bndl_utils.py
+++ b/conductr_cli/test/test_bndl_utils.py
@@ -97,6 +97,18 @@ class TestBndlUtils(CliTestCase):
         self.assertEqual(writer.size_in, 0)
         self.assertEqual(writer.size_out, 9)
 
+    def test_first_mtime(self):
+        tmpdir = tempfile.mkdtemp()
+
+        try:
+            open(os.path.join(tmpdir, 'one'), 'w').close()
+            os.mkdir(os.path.join(tmpdir, 'sub'))
+            open(os.path.join(tmpdir, 'sub', 'two'), 'w').close()
+            os.utime(os.path.join(tmpdir, 'one'), (1234, 1234))
+            self.assertEqual(bndl_utils.first_mtime(os.path.join(tmpdir)), 1234)
+        finally:
+            shutil.rmtree(tmpdir)
+
     def test_load_bundle_args_into_conf(self):
         base_args = create_attributes_object({
             'name': 'world',


### PR DESCRIPTION
This PR fixes `bndl` to preserve mtime across separate executions. This ensures that given the same input, the same digest (and thus bundle id) is calculated.  Fixes #408.

Since not all docker registries provide `Last-Modified` headers, we use the OCI config value `created` to determine which `mtime` value to use. This gives us an implementation that is always consistent among `docker save`, `conduct load` (with docker resolver), etc.

------------------
### Manual Tests

**Same output given same input**
```bash
$ docker save nginx | bndl --no-shazar | sha256sum
9b36920fc330a58abe3870f53da900d572fad7f0d3074ea94f57386fd850393f  -
-> 0

$ docker save nginx | bndl --no-shazar | sha256sum
9b36920fc330a58abe3870f53da900d572fad7f0d3074ea94f57386fd850393f  -
-> 0

$ docker save nginx | bndl | sha256sum
e19f87db56fbe49e51e1c59ee43ae78a93cb53a6fd50bca100fb72d13f981323  -
-> 0

$ docker save nginx | bndl | sha256sum
e19f87db56fbe49e51e1c59ee43ae78a93cb53a6fd50bca100fb72d13f981323  -
-> 0
```

**Same bundle id (end-to-end)**
```bash
$ docker save nginx | bndl | conduct load
Retrieving bundle..
Loading bundle from cache typesafe/bundle/-
Bintray credentials loaded from /home/longshorej/.lightbend/commercial.credentials
Loading bundle to ConductR..
[#################################################] 100%
Bundle edc0744e6c979d89349973363f48b0a3 is installed
Bundle loaded.
Start bundle with:        conduct run edc0744
Unload bundle with:       conduct unload edc0744
Print ConductR info with: conduct info
Print bundle info with:   conduct info edc0744
-> 0

$ docker save nginx | bndl | conduct load
Retrieving bundle..
Loading bundle from cache typesafe/bundle/-
Bintray credentials loaded from /home/longshorej/.lightbend/commercial.credentials
Loading bundle to ConductR..
[#################################################] 100%
Bundle edc0744e6c979d89349973363f48b0a3 is installed
Bundle loaded.
Start bundle with:        conduct run edc0744
Unload bundle with:       conduct unload edc0744
Print ConductR info with: conduct info
Print bundle info with:   conduct info edc0744
-> 0
```

**`docker save` matches `conduct load` with new resolver**
```bash
$ conduct load lightbend-docker-registry.bintray.io/conductr/oci-in-docker:0.1.0
Retrieving bundle..
Loading bundle from cache lightbend-docker-registry.bintray.io/conductr/oci-in-docker:0.1.0
Bintray credentials loaded from /home/longshorej/.lightbend/commercial.credentials
Retrieving file:///home/longshorej/desktop/mtimetest/lightbend-docker-registry.bintray.io/conductr/oci-in-docker:0.1.0
Resolving bundle lightbend-docker-registry.bintray.io/conductr/oci-in-docker:0.1.0
Bintray credentials loaded from /home/longshorej/.lightbend/commercial.credentials
Retrieving Docker layers:
    0cb1036dfbba848bf809de2c7916daae1c8223a1793e5b42ac2bc70f1a96ecf9
    ec37562cf8faa296abf1530f24cd2ffd9d47ee463a26dbf470a87203a95ae24e
    6007e0709baf80597af5c9c2c315f1b5e1df44851f03c3cf4b030eb2ee5bbfe7
[#################################################] 100%
Loading bundle to ConductR..
[#################################################] 100%
Bundle 2a5b6be2efebc58abcb2c162795ec059 is installed
Bundle loaded.
Start bundle with:        conduct run 2a5b6be
Unload bundle with:       conduct unload 2a5b6be
Print ConductR info with: conduct info
Print bundle info with:   conduct info 2a5b6be
-> 0

$ docker save lightbend-docker-registry.bintray.io/conductr/oci-in-docker:0.1.0 | bndl | conduct load
Retrieving bundle..
Loading bundle from cache typesafe/bundle/-
Bintray credentials loaded from /home/longshorej/.lightbend/commercial.credentials
Loading bundle to ConductR..
[#################################################] 100%
Bundle 2a5b6be2efebc58abcb2c162795ec059 is installed
Bundle loaded.
Start bundle with:        conduct run 2a5b6be
Unload bundle with:       conduct unload 2a5b6be
Print ConductR info with: conduct info
Print bundle info with:   conduct info 2a5b6be
-> 0
```