### PR TITLE
Implement support for processing ConductR bundles to `bndl`

### DIFF
--- a/conductr_cli/bndl_docker.py
+++ b/conductr_cli/bndl_docker.py
@@ -269,28 +269,31 @@ def docker_unpack(destination, data, is_dir, maybe_name, maybe_tag):
                         manifest = m
                         break
 
-                image_name, image_tag = docker_parse_image_name(manifest['RepoTags'][0])
+                if manifest is None:
+                    return None
+                else:
+                    image_name, image_tag = docker_parse_image_name(manifest['RepoTags'][0])
 
-                with open(os.path.join(contents_dir, manifest['Config'])) as config_file:
-                    config = json.load(config_file)
+                    with open(os.path.join(contents_dir, manifest['Config'])) as config_file:
+                        config = json.load(config_file)
 
-                    oci_spec = docker_config_to_oci_image(manifest, config, sizes, layers_to_digests)
+                        oci_spec = docker_config_to_oci_image(manifest, config, sizes, layers_to_digests)
 
-                    file_write_bytes(
-                        '{}/blobs/sha256/{}'.format(destination, oci_spec['config_digest']),
-                        oci_spec['config']
-                    )
+                        file_write_bytes(
+                            '{}/blobs/sha256/{}'.format(destination, oci_spec['config_digest']),
+                            oci_spec['config']
+                        )
 
-                    file_write_bytes(
-                        '{}/blobs/sha256/{}'.format(destination, oci_spec['manifest_digest']),
-                        oci_spec['manifest']
-                    )
+                        file_write_bytes(
+                            '{}/blobs/sha256/{}'.format(destination, oci_spec['manifest_digest']),
+                            oci_spec['manifest']
+                        )
 
-                    file_write_bytes(
-                        '{}/refs/{}'.format(destination, image_tag),
-                        oci_spec['refs']
-                    )
+                        file_write_bytes(
+                            '{}/refs/{}'.format(destination, image_tag),
+                            oci_spec['refs']
+                        )
 
-                return image_name
+                    return image_name
     finally:
         shutil.rmtree(temp_dir)

--- a/conductr_cli/bndl_oci.py
+++ b/conductr_cli/bndl_oci.py
@@ -9,7 +9,7 @@ import tempfile
 
 def oci_image_bundle_conf(args, component_name, oci_manifest, oci_config):
     conf = ConfigFactory.parse_string('')
-    load_bundle_args_into_conf(conf, args)
+    load_bundle_args_into_conf(conf, args, with_defaults=True)
 
     if 'annotations' in oci_manifest and oci_manifest['annotations'] is not None:
         annotations_tree = conf.get('annotations')
@@ -22,7 +22,7 @@ def oci_image_bundle_conf(args, component_name, oci_manifest, oci_config):
     oci_tree = ConfigTree()
     oci_tree.put('description', args.component_description)
     oci_tree.put('file-system-type', 'oci-image')
-    oci_tree.put('start-command', ['ociImageTag', args.tag])
+    oci_tree.put('start-command', ['ociImageTag', args.image_tag])
     oci_tree.put('endpoints', endpoints_tree)
 
     components_tree = ConfigTree()

--- a/conductr_cli/bndl_utils.py
+++ b/conductr_cli/bndl_utils.py
@@ -1,35 +1,30 @@
-from collections import OrderedDict
 from conductr_cli.constants import \
+    BNDL_DEFAULT_ANNOTATIONS, \
     BNDL_DEFAULT_COMPATIBILITY_VERSION, \
     BNDL_DEFAULT_DISK_SPACE, \
     BNDL_IGNORE_TAGS, \
     BNDL_DEFAULT_MEMORY, \
+    BNDL_DEFAULT_NAME, \
     BNDL_DEFAULT_NR_OF_CPUS, \
     BNDL_DEFAULT_ROLES, \
-    BNDL_DEFAULT_VERSION
-from pyhocon import ConfigTree
+    BNDL_DEFAULT_TAGS, \
+    BNDL_DEFAULT_VERSION, \
+    MAGIC_NUMBER_TAR, \
+    MAGIC_NUMBER_TAR_OFFSET, \
+    MAGIC_NUMBERS_ZIP
+from pyhocon import ConfigFactory, ConfigTree
 import hashlib
 import os
 import re
-
-mappings = OrderedDict([
-    ('--name', 'name'),
-    ('--version', 'version'),
-    ('--compatibility-version', 'compatibilityVersion'),
-    ('--system', 'system'),
-    ('--system-version', 'systemVersion'),
-    ('--nr-of-cpus', 'nrOfCpus'),
-    ('--memory', 'memory'),
-    ('--disk-space', 'diskSpace'),
-    ('--roles', 'roles')
-])
+import time
+import zipfile
 
 
 def detect_format_dir(dir):
     """
     Detects the format of a directory on disk.
     :param dir:
-    :return: one of 'docker', 'oci-image', or None
+    :return: one of 'docker', 'oci-image', 'bundle', or None
     """
     if \
             os.path.isfile(os.path.join(dir, 'oci-layout')) and \
@@ -40,11 +35,26 @@ def detect_format_dir(dir):
             os.path.isfile(os.path.join(dir, 'repositories')) and \
             os.path.isfile(os.path.join(dir, 'manifest.json')):
         return 'docker'
+    elif \
+            os.path.isfile(os.path.join(dir, 'runtime-config.sh')):
+        return 'bundle'
+    elif \
+            os.path.isfile(os.path.join(dir, 'bundle.conf')):
+        return 'bundle'
     else:
         return None
 
 
 def detect_format_stream(initial_chunk):
+    """
+    Detects the format of a stream given some initial chunk of data. This is fairly crude
+    but does work pretty well with detecting `docker save` streams. OCI detection may need
+    to be expanded as the tooling matures.
+
+    :param initial_chunk:
+    :return: one of 'docker', 'oci-image', or None
+    """
+
     def try_match(pattern, slice):
         try:
             return not not re.match(pattern, slice.decode('UTF-8'))
@@ -55,14 +65,6 @@ def detect_format_stream(initial_chunk):
 
             return False
 
-    """
-    Detects the format of a stream given some initial chunk of data. This is fairly crude
-    but does work pretty well with detecting `docker save` streams. OCI detection may need
-    to be expanded as the tooling matures.
-
-    :param initial_chunk:
-    :return: one of 'docker', 'oci-image', or None
-    """
     if try_match('^[0-9a-f]{64}[/]', initial_chunk[0:65]):
         # docker save <image>
         return 'docker'
@@ -75,61 +77,145 @@ def detect_format_stream(initial_chunk):
     elif b'/manifest.json\x00\x00\x00' in initial_chunk and b'/layer.tar\x00\x00\x00' in initial_chunk:
         # tar c on a docker folder (somewhat unreliable)
         return 'docker'
+    elif b'\x00' not in initial_chunk and initial_chunk != b'' and data_is_bundle_conf(initial_chunk):
+        return 'bundle'
+    elif data_is_zip(initial_chunk):
+        return 'bundle'
+    elif data_is_tar(initial_chunk):
+        # TAR marker
+        return 'bundle'
     else:
         return None
 
 
-def load_bundle_args_into_conf(config, args):
-    if args.name is not None:
-        config.put('name', args.name)
+def data_is_bundle_conf(data):
+    try:
+        ConfigFactory.parse_string(data.decode('UTF-8'))
+        return True
+    except:
+        return False
 
-    for argument, bundle_key in mappings.items():
-        value = getattr(args, bundle_key, None)
 
-        if value is not None:
-            config.put(bundle_key, value)
+def data_is_tar(data):
+    """
+    Detects if an initial 1KB+ chunk of data from a stream indicates the stream
+    is a tar file. This is determined by TAR's magic number.
+    https://en.wikipedia.org/wiki/Tar_(computing)
+    :param data: first chunk from a tar stream
+    :return: True if tar
+    """
+    return \
+        len(data) >= MAGIC_NUMBER_TAR_OFFSET + len(MAGIC_NUMBER_TAR) and \
+        data[MAGIC_NUMBER_TAR_OFFSET:MAGIC_NUMBER_TAR_OFFSET + len(MAGIC_NUMBER_TAR)] == MAGIC_NUMBER_TAR
 
-    if 'roles' not in config:
-        config.put('roles', BNDL_DEFAULT_ROLES)
 
-    if 'compatibilityVersion' not in config:
+def data_is_zip(data):
+    """
+    Detects if an initial 1KB+ chunk of data from a stream indicates the stream
+    is a zip file. This is determined by ZIP's magic numbers.
+    https://en.wikipedia.org/wiki/Zip_(file_format)
+    :param data: first chunk from a zip stream
+    :return: True if zip
+    """
+    return any(data.startswith(number) for number in MAGIC_NUMBERS_ZIP)
+
+
+def load_bundle_args_into_conf(config, args, with_defaults):
+    # this is unrolled because it's actually pretty complicated to get the order
+    # correct given that some attributes need special handling and defaults
+
+    args_compatibility_version = getattr(args, 'compatibility_version', None)
+    args_disk_space = getattr(args, 'disk_space', None)
+    args_memory = getattr(args, 'memory', None)
+    args_name = getattr(args, 'name', None)
+    args_nr_of_cpus = getattr(args, 'nr_of_cpus', None)
+    args_roles = getattr(args, 'roles', None)
+    args_system = getattr(args, 'system', None)
+    args_system_version = getattr(args, 'system_version', None)
+    args_version = getattr(args, 'version', None)
+
+    if hasattr(args, 'annotations') and len(args.annotations) > 0:
+        annotations_tree = ConfigTree()
+
+        invalid_annotations = []
+
+        for annotation in args.annotations:
+            if '=' in annotation:
+                annotation_parts = annotation.split('=', 1)
+                annotations_tree.put(annotation_parts[0], annotation_parts[1])
+            else:
+                invalid_annotations.append(annotation)
+
+        if len(invalid_annotations) > 0:
+            raise ValueError(
+                'Invalid annotation format for {}. Specify as name=value'.format(', '.join(invalid_annotations))
+            )
+
+        config.put('annotations', annotations_tree)
+    if with_defaults and 'annotations' not in config:
+        config.put('annotations', ConfigTree(BNDL_DEFAULT_ANNOTATIONS.copy()))
+
+    if args_compatibility_version is not None:
+        config.put('compatibilityVersion', args_compatibility_version)
+    if with_defaults and 'compatibilityVersion' not in config:
         config.put('compatibilityVersion', BNDL_DEFAULT_COMPATIBILITY_VERSION)
 
-    if 'diskSpace' not in config:
+    if args_disk_space is not None:
+        config.put('diskSpace', args_disk_space)
+    if with_defaults and 'diskSpace' not in config:
         config.put('diskSpace', BNDL_DEFAULT_DISK_SPACE)
 
-    if 'memory' not in config:
+    if args_memory is not None:
+        config.put('memory', args_memory)
+    if with_defaults and 'memory' not in config:
         config.put('memory', BNDL_DEFAULT_MEMORY)
 
-    if 'nrOfCpus' not in config:
+    if args_name is not None:
+        config.put('name', args_name)
+    if with_defaults and 'name' not in config:
+        config.put('name', BNDL_DEFAULT_NAME)
+
+    if args_nr_of_cpus is not None:
+        config.put('nrOfCpus', args_nr_of_cpus)
+    if with_defaults and 'nrOfCpus' not in config:
         config.put('nrOfCpus', BNDL_DEFAULT_NR_OF_CPUS)
 
-    if 'version' not in config:
+    if args_roles is not None:
+        config.put('roles', args_roles)
+    if with_defaults and 'roles' not in config:
+        config.put('roles', BNDL_DEFAULT_ROLES.copy())
+
+    if args_system is not None:
+        config.put('system', args_system)
+    if with_defaults and 'system' not in config:
+        config.put('system', config.get('name') if 'name' in config else BNDL_DEFAULT_NAME)
+
+    if args_system_version is not None:
+        config.put('systemVersion', args_system_version)
+    if with_defaults and 'systemVersion' not in config:
+        config.put('systemVersion', config.get('version') if 'version' in config else BNDL_DEFAULT_VERSION)
+
+    if hasattr(args, 'image_tag'):
+        tags = config.get('tags') if 'tags' in config else []
+
+        if args.image_tag is not None and args.image_tag not in tags and args.image_tag not in BNDL_IGNORE_TAGS:
+            tags.append(args.image_tag)
+            config.put('tags', tags)
+    if hasattr(args, 'tags') and len(args.tags) > 0:
+        tags = []
+
+        for tag in args.tags:
+            if tag not in tags:
+                tags.append(tag)
+
+        config.put('tags', tags)
+    if with_defaults and 'tags' not in config:
+        config.put('tags', BNDL_DEFAULT_TAGS.copy())
+
+    if args_version is not None:
+        config.put('version', args_version)
+    if with_defaults and 'version' not in config:
         config.put('version', BNDL_DEFAULT_VERSION)
-
-    if 'system' not in config:
-        config.put('system', config.get('name'))
-
-    if 'systemVersion' not in config:
-        config.put('systemVersion', config.get('version'))
-
-    tags = config.get('tags') if 'tags' in config else []
-
-    if args.tag not in tags and args.tag not in BNDL_IGNORE_TAGS:
-        tags.append(args.tag)
-
-    config.put('tags', tags)
-
-    annotations_tree = ConfigTree()
-
-    for annotation in args.annotations:
-        if '=' not in annotation:
-            raise ValueError('Invalid annotation format. Specify as name=value')
-
-        annotation_parts = annotation.split('=', 1)
-        annotations_tree.put(annotation_parts[0], annotation_parts[1])
-
-    config.put('annotations', annotations_tree)
 
 
 def file_write_bytes(path, bs):
@@ -137,12 +223,28 @@ def file_write_bytes(path, bs):
         file.write(bs)
 
 
-def first_mtime(path):
+def find_bundle_conf_dir(dir):
+    for dir_path, dir_names, file_names in os.walk(dir):
+        for file_name in file_names:
+            if file_name == 'bundle.conf' or file_name == 'runtime-config.sh':
+                return dir_path
+    return None
+
+
+def first_mtime(path, default=0):
     for (dir_path, dir_names, file_names) in os.walk(path):
         for file_name in file_names:
             return os.path.getmtime(os.path.join(dir_path, file_name))
 
-    return 0
+    return default
+
+
+def zip_extract_with_dates(zip_file, into):
+    with zipfile.ZipFile(file=zip_file, mode='r') as zip:
+        for info in zip.infolist():
+            zip.extract(info, into)
+            t = time.mktime(info.date_time + (0, 0, -1))
+            os.utime(os.path.join(into, info.filename), (t, t))
 
 
 class DigestReaderWriter(object):

--- a/conductr_cli/constants.py
+++ b/conductr_cli/constants.py
@@ -1,14 +1,19 @@
 import os
 
-# Preload this much data in the bndl tool to determine input type of a stream
-BNDL_PEEK_SIZE = 16384
+# Preload this much data in the bndl tool to determine input type of a stream. Since we use this to determine
+# if a stream is a plain bundle conf, this should be set to hold the maximum size of a reasonable bundle.conf
+# or else auto-detection will fail.
+BNDL_PEEK_SIZE = 65536
 
 # Defaults for creating bundles without specifying params
+BNDL_DEFAULT_ANNOTATIONS = {}
 BNDL_DEFAULT_COMPATIBILITY_VERSION = '0'
 BNDL_DEFAULT_DISK_SPACE = 1073741824
 BNDL_DEFAULT_MEMORY = 402653184
+BNDL_DEFAULT_NAME = 'bundle'
 BNDL_DEFAULT_NR_OF_CPUS = 0.1
-BNDL_DEFAULT_ROLES = []
+BNDL_DEFAULT_ROLES = ['web']
+BNDL_DEFAULT_TAGS = []
 BNDL_DEFAULT_VERSION = '1'
 BNDL_IGNORE_TAGS = ['latest']
 
@@ -62,3 +67,14 @@ FEATURE_PROVIDE_LOGGING = 'logging'
 
 # When reading and writing to IO devices, buffer this many bytes at a time
 IO_CHUNK_SIZE = 32768
+
+# ZIP has a minimum date for timestamps - 315705599 is 01/02/1980 @ 11:59pm (UTC)
+SHAZAR_TIMESTAMP_MIN = 315705599
+
+# For auto-detection of input streams, per:
+# https://en.wikipedia.org/wiki/Tar_(computing)
+# https://en.wikipedia.org/wiki/Zip_(file_format)
+
+MAGIC_NUMBER_TAR = b'ustar'
+MAGIC_NUMBER_TAR_OFFSET = 257
+MAGIC_NUMBERS_ZIP = [b'PK\x03\x04', b'PK\x05\x06', b'PK\x07\x08']

--- a/conductr_cli/shazar_main.py
+++ b/conductr_cli/shazar_main.py
@@ -2,7 +2,7 @@ import argcomplete
 import argparse
 from functools import partial
 from conductr_cli import logging_setup
-from conductr_cli.constants import IO_CHUNK_SIZE
+from conductr_cli.constants import IO_CHUNK_SIZE, SHAZAR_TIMESTAMP_MIN
 import hashlib
 import logging
 import os
@@ -123,8 +123,7 @@ def tar_to_zip(tar, zip_file):
     log = logging.getLogger(__name__)
 
     for entry in tar:
-        # this is to work around zip's minimum date, 315705599 is 01/02/1980 @ 11:59pm (UTC)
-        mtime_to_use = max(entry.mtime, 315705599)
+        mtime_to_use = max(entry.mtime, SHAZAR_TIMESTAMP_MIN)
 
         if entry.isfile():
             with tempfile.NamedTemporaryFile() as entry_file:

--- a/conductr_cli/test/test_bndl_create.py
+++ b/conductr_cli/test/test_bndl_create.py
@@ -1,5 +1,5 @@
 from conductr_cli import bndl_create, logging_setup
-from conductr_cli.test.cli_test_case import CliTestCase, create_attributes_object, as_error
+from conductr_cli.test.cli_test_case import CliTestCase, create_attributes_object, as_error, strip_margin
 from io import BytesIO
 from unittest.mock import patch, MagicMock
 import os
@@ -13,9 +13,10 @@ import zipfile
 class TestBndlCreate(CliTestCase):
     def test_no_format(self):
         attributes = create_attributes_object({
+            'name': 'test',
             'source': None,
             'format': None,
-            'tag': 'latest',
+            'image_tag': 'latest',
             'output': None
         })
 
@@ -41,7 +42,7 @@ class TestBndlCreate(CliTestCase):
                 'name': 'test',
                 'source': tmpdir,
                 'format': 'oci-image',
-                'tag': 'latest',
+                'image_tag': 'latest',
                 'output': output.name
             })
 
@@ -68,7 +69,7 @@ class TestBndlCreate(CliTestCase):
                     'name': 'test',
                     'source': tmpdir,
                     'format': 'oci-image',
-                    'tag': 'latest',
+                    'image_tag': 'latest',
                     'output': output.name
                 })
 
@@ -101,7 +102,7 @@ class TestBndlCreate(CliTestCase):
                 'name': 'test',
                 'source': tmpdir,
                 'format': 'oci-image',
-                'tag': 'latest',
+                'image_tag': 'latest',
                 'output': tmpfile,
                 'component_description': '',
                 'use_shazar': True,
@@ -141,7 +142,7 @@ class TestBndlCreate(CliTestCase):
                 'name': 'test',
                 'source': tmpdir,
                 'format': 'oci-image',
-                'tag': 'latest',
+                'image_tag': 'latest',
                 'output': tmpfile,
                 'component_description': '',
                 'use_shazar': False,
@@ -184,7 +185,7 @@ class TestBndlCreate(CliTestCase):
                 'name': 'test',
                 'source': tmpdir,
                 'format': 'oci-image',
-                'tag': 'latest',
+                'image_tag': 'latest',
                 'output': tmpfile,
                 'component_description': '',
                 'use_shazar': True,
@@ -204,7 +205,7 @@ class TestBndlCreate(CliTestCase):
                 'name': 'test',
                 'source': tmpdir2,
                 'format': 'oci-image',
-                'tag': 'latest',
+                'image_tag': 'latest',
                 'output': tmpfile2,
                 'component_description': '',
                 'use_shazar': True,
@@ -246,7 +247,7 @@ class TestBndlCreate(CliTestCase):
                 'name': 'test',
                 'source': tmpdir,
                 'format': 'oci-image',
-                'tag': 'latest',
+                'image_tag': 'latest',
                 'output': tmpfile,
                 'component_description': '',
                 'use_shazar': True,
@@ -288,7 +289,7 @@ class TestBndlCreate(CliTestCase):
                 'name': 'test',
                 'source': tmpdir,
                 'format': 'oci-image',
-                'tag': 'latest',
+                'image_tag': 'latest',
                 'output': tmpfile,
                 'component_description': '',
                 'use_shazar': False,
@@ -308,7 +309,7 @@ class TestBndlCreate(CliTestCase):
                 'name': 'test',
                 'source': tmpdir2,
                 'format': 'oci-image',
-                'tag': 'latest',
+                'image_tag': 'latest',
                 'output': tmpfile2,
                 'component_description': '',
                 'use_shazar': False,
@@ -327,8 +328,8 @@ class TestBndlCreate(CliTestCase):
             with \
                     patch('sys.stdin', MagicMock(**{'buffer': BytesIO(b'')})), \
                     patch('sys.stdout.buffer.write', stdout_mock):
-                bndl_create.bndl_create(attributes)
-                bndl_create.bndl_create(attributes2)
+                self.assertEqual(bndl_create.bndl_create(attributes), 0)
+                self.assertEqual(bndl_create.bndl_create(attributes2), 0)
 
             with open(tmpfile, 'rb') as fileobj, open(tmpfile2, 'rb') as fileobj2:
                 self.assertEqual(fileobj.read(), fileobj2.read())
@@ -336,3 +337,191 @@ class TestBndlCreate(CliTestCase):
         finally:
             shutil.rmtree(tmpdir)
             shutil.rmtree(tmpdir2)
+
+    def test_bundle_conf(self):
+        with tempfile.NamedTemporaryFile() as file_in, tempfile.NamedTemporaryFile() as file_out:
+            file_in.write(b'name = "testing"\ndescription = "my test description"\nroles = ["web", "web2"]')
+            file_in.flush()
+
+            args = create_attributes_object({
+                'name': 'test',
+                'format': None,
+                'source': file_in.name,
+                'output': file_out.name,
+                'use_shazar': False,
+                'use_default_endpoints': True,
+                'roles': ['test']
+            })
+
+            self.assertEqual(bndl_create.bndl_create(args), 0)
+            self.assertTrue(tarfile.is_tarfile(file_out.name))
+
+            # check that config bundle is named properly and is ignoring arguments
+
+            with tarfile.open(file_out.name, 'r') as tar:
+                for entry in tar:
+                    self.assertEqual('test/bundle.conf', entry.name)
+                    self.assertEqual(
+                        tar.extractfile(entry).read().decode("UTF-8"),
+                        strip_margin(
+                            '''|name = "test"
+                               |description = "my test description"
+                               |roles = [
+                               |  "test"
+                               |]''')
+                    )
+
+    def test_bundle_arg_no_name(self):
+        with tempfile.NamedTemporaryFile() as file_in, tempfile.NamedTemporaryFile() as file_out:
+            file_in.write(b'name = "test"\ndescription = "my test description"\nroles = ["web", "web2"]')
+            file_in.flush()
+
+            args = create_attributes_object({
+                'name': None,
+                'format': None,
+                'source': file_in.name,
+                'output': file_out.name,
+                'use_shazar': False,
+                'use_default_endpoints': True
+            })
+
+            self.assertEqual(bndl_create.bndl_create(args), 0)
+            self.assertTrue(tarfile.is_tarfile(file_out.name))
+
+            with tarfile.open(file_out.name, 'r') as tar:
+                for entry in tar:
+                    self.assertEqual('test/bundle.conf', entry.name)
+                    self.assertEqual(
+                        tar.extractfile(entry).read().decode("UTF-8"),
+                        strip_margin(
+                            '''|name = "test"
+                               |description = "my test description"
+                               |roles = [
+                               |  "web"
+                               |  "web2"
+                               |]''')
+                    )
+
+    def test_bundle_conf_no_name(self):
+        with tempfile.NamedTemporaryFile() as file_in, tempfile.NamedTemporaryFile() as file_out:
+            file_in.write(b'description = "my test description"\nroles = ["web", "web2"]')
+            file_in.flush()
+
+            args = create_attributes_object({
+                'name': None,
+                'format': None,
+                'source': file_in.name,
+                'output': file_out.name,
+                'use_shazar': False,
+                'use_default_endpoints': True
+            })
+
+            self.assertEqual(bndl_create.bndl_create(args), 0)
+            self.assertTrue(tarfile.is_tarfile(file_out.name))
+
+            with tarfile.open(file_out.name, 'r') as tar:
+                for entry in tar:
+                    self.assertEqual('bundle/bundle.conf', entry.name)
+                    self.assertEqual(
+                        tar.extractfile(entry).read().decode("UTF-8"),
+                        strip_margin(
+                            '''|description = "my test description"
+                               |roles = [
+                               |  "web"
+                               |  "web2"
+                               |]''')
+                    )
+
+    def test_bundle(self):
+        temp_dir = tempfile.mkdtemp()
+
+        try:
+            with \
+                    open(os.path.join(temp_dir, 'bundle.conf'), 'wb') as bundle_conf_file, \
+                    tempfile.NamedTemporaryFile() as file_out:
+                bundle_conf_file.write(b'name = "testing"\ndescription = "my test description"\nroles = ["web", "web2"]')
+                bundle_conf_file.flush()
+
+                args = create_attributes_object({
+                    'name': 'test',
+                    'format': 'bundle',
+                    'source': temp_dir,
+                    'output': file_out.name,
+                    'use_shazar': False,
+                    'use_default_endpoints': True,
+                    'roles': ['test'],
+                    'annotations': [
+                        'my.test=testing'
+                    ]
+                })
+
+                self.assertEqual(bndl_create.bndl_create(args), 0)
+                self.assertTrue(tarfile.is_tarfile(file_out.name))
+
+                with tarfile.open(file_out.name, 'r') as tar:
+                    for entry in tar:
+                        self.assertEqual('test/bundle.conf', entry.name)
+                        self.assertEqual(
+                            tar.extractfile(entry).read().decode("UTF-8"),
+                            strip_margin(
+                                '''|name = "test"
+                                   |description = "my test description"
+                                   |roles = [
+                                   |  "test"
+                                   |]
+                                   |annotations {
+                                   |  my {
+                                   |    test = "testing"
+                                   |  }
+                                   |}''')
+                        )
+        finally:
+            shutil.rmtree(temp_dir)
+
+    def test_bundle_conf_dir(self):
+        temp_dir = tempfile.mkdtemp()
+
+        try:
+            with \
+                    open(os.path.join(temp_dir, 'bundle.conf'), 'wb') as bundle_conf_file, \
+                    tempfile.NamedTemporaryFile() as file_out:
+                bundle_conf_file.write(b'name = "testing"\ndescription = "my test description"\nroles = ["web", "web2"]')
+                bundle_conf_file.flush()
+
+                args = create_attributes_object({
+                    'name': 'test',
+                    'format': 'bundle',
+                    'source': temp_dir,
+                    'output': file_out.name,
+                    'use_shazar': False,
+                    'use_default_endpoints': True,
+                    'annotations': [
+                        'my.test=testing'
+                    ]
+                })
+
+                self.assertEqual(bndl_create.bndl_create(args), 0)
+                self.assertTrue(tarfile.is_tarfile(file_out.name))
+
+                # config bundles shouldn't have any defaults added
+
+                with tarfile.open(file_out.name, 'r') as tar:
+                    for entry in tar:
+                        self.assertEqual('test/bundle.conf', entry.name)
+                        self.assertEqual(
+                            tar.extractfile(entry).read().decode("UTF-8"),
+                            strip_margin(
+                                '''|name = "test"
+                                   |description = "my test description"
+                                   |roles = [
+                                   |  "web"
+                                   |  "web2"
+                                   |]
+                                   |annotations {
+                                   |  my {
+                                   |    test = "testing"
+                                   |  }
+                                   |}''')
+                        )
+        finally:
+            shutil.rmtree(temp_dir)

--- a/conductr_cli/test/test_bndl_main.py
+++ b/conductr_cli/test/test_bndl_main.py
@@ -11,11 +11,11 @@ class TestBndl(CliTestCase):
     parser = bndl_main.build_parser()
 
     def test_parser_with_min_params(self):
-        args = self.parser.parse_args(['--name', 'hello', '-t', 'latest'])
+        args = self.parser.parse_args(['--name', 'hello', '--image-tag', 'latest'])
 
         self.assertEqual(args.func.__name__, 'bndl')
         self.assertEqual(args.name, 'hello')
-        self.assertEqual(args.tag, 'latest')
+        self.assertEqual(args.image_tag, 'latest')
         self.assertTrue(args.use_shazar)
         self.assertTrue(args.use_default_endpoints)
 
@@ -24,8 +24,10 @@ class TestBndl(CliTestCase):
             'oci-image-dir',
             '--name',
             'world',
-            '-t',
+            '--image-tag',
             'earliest',
+            '--image-name',
+            'test',
             '-o',
             '/dev/null',
             '--no-shazar',
@@ -59,17 +61,18 @@ class TestBndl(CliTestCase):
         self.assertEqual(args.source, 'oci-image-dir')
         self.assertEqual(args.func.__name__, 'bndl')
         self.assertEqual(args.name, 'world')
-        self.assertEqual(args.tag, 'earliest')
+        self.assertEqual(args.image_tag, 'earliest')
+        self.assertEqual(args.image_name, 'test')
         self.assertEqual(args.output, '/dev/null')
         self.assertFalse(args.use_shazar)
         self.assertEqual(args.component_description, 'some description')
         self.assertEqual(args.version, '4')
-        self.assertEqual(args.compatibilityVersion, '5')
+        self.assertEqual(args.compatibility_version, '5')
         self.assertEqual(args.system, 'myapp')
-        self.assertEqual(args.systemVersion, '3')
-        self.assertEqual(args.nrOfCpus, 8.0)
+        self.assertEqual(args.system_version, '3')
+        self.assertEqual(args.nr_of_cpus, 8.0)
         self.assertEqual(args.memory, 65536)
-        self.assertEqual(args.diskSpace, 16384)
+        self.assertEqual(args.disk_space, 16384)
         self.assertEqual(args.roles, ['web', 'backend'])
         self.assertEqual(args.annotations, ['com.lightbend.test=hello world', 'description=this is a test'])
         self.assertFalse(args.use_default_endpoints)
@@ -95,27 +98,6 @@ class TestBndl(CliTestCase):
         self.assertIsNone(bndl_mock.call_args[0][0].output)
         self.assertIsNone(bndl_mock.call_args[0][0].source)
 
-    def test_bndl_oci_image_missing_args(self):
-        stdout_mock = MagicMock()
-        stderr_mock = MagicMock()
-        exit_mock = MagicMock()
-        configure_logging_mock = MagicMock()
-        bndl_main.logging_setup.configure_logging(MagicMock(), stdout_mock, stderr_mock)
-
-        with \
-                patch('sys.stdin', MagicMock(**{'buffer': BytesIO(b'')})), \
-                patch('sys.stdout.isatty', lambda: False), \
-                patch('conductr_cli.logging_setup.configure_logging', configure_logging_mock), \
-                patch('sys.exit', exit_mock):
-            bndl_main.run(['-f', 'oci-image'])
-
-        self.assertEqual(
-            self.output(stderr_mock),
-            as_error('Error: bndl: OCI Image support requires that you provide a --name argument\n')
-        )
-
-        exit_mock.assert_called_once_with(2)
-
     def test_warn_output_tty(self):
         stdout_mock = MagicMock()
         stderr_mock = MagicMock()
@@ -128,7 +110,7 @@ class TestBndl(CliTestCase):
                 patch('sys.stdout.isatty', lambda: True), \
                 patch('conductr_cli.logging_setup.configure_logging', configure_logging_mock), \
                 patch('sys.exit', exit_mock):
-            bndl_main.run(['--name', 'test', '--tag', 'latest'])
+            bndl_main.run(['--name', 'test', '--image-tag', 'latest'])
 
         self.assertEqual(
             self.output(stderr_mock),
@@ -172,7 +154,7 @@ class TestBndl(CliTestCase):
                     patch('sys.stdout.isatty', lambda: False), \
                     patch('conductr_cli.logging_setup.configure_logging', configure_logging_mock), \
                     patch('sys.exit', exit_mock):
-                bndl_main.run(['--name', 'test', '-f', 'oci-image', '-t', 'latest', temp])
+                bndl_main.run(['--name', 'test', '-f', 'oci-image', '--image-tag', 'latest', temp])
 
             self.assertEqual(
                 self.output(stderr_mock),
@@ -200,7 +182,7 @@ class TestBndl(CliTestCase):
                     patch('sys.stdout.isatty', lambda: False), \
                     patch('conductr_cli.logging_setup.configure_logging', configure_logging_mock), \
                     patch('sys.exit', exit_mock):
-                bndl_main.run(['--name', 'test', '-f', 'oci-image', '-t', 'latest', temp])
+                bndl_main.run(['--name', 'test', '-f', 'oci-image', '--image-tag', 'latest', temp])
 
             self.assertEqual(
                 self.output(stderr_mock),

--- a/conductr_cli/test/test_bndl_oci.py
+++ b/conductr_cli/test/test_bndl_oci.py
@@ -105,43 +105,47 @@ class TestBndlOci(CliTestCase):
     def test_oci_image_bundle_conf(self):
         base_args = create_attributes_object({
             'name': 'world',
+            'tags': [],
             'component_description': 'testing desc 1',
-            'tag': 'testing',
+            'image_tag': 'testing',
             'use_default_endpoints': True,
             'annotations': []
         })
 
         extended_args = create_attributes_object({
             'name': 'world',
+            'tags': [],
+            'annotations': [],
             'component_description': 'testing desc 2',
             'version': '4',
-            'compatibilityVersion': '5',
+            'compatibility_version': '5',
             'system': 'myapp',
-            'systemVersion': '3',
-            'nrOfCpus': '8',
+            'system_version': '3',
+            'nr_of_cpus': '8',
             'memory': '65536',
-            'diskSpace': '16384',
+            'disk_space': '16384',
             'roles': ['web', 'backend'],
-            'tag': 'latest',
+            'image_tag': 'latest',
             'use_default_endpoints': True,
-            'annotations': []
         })
 
         self.assertEqual(
             bndl_oci.oci_image_bundle_conf(base_args, 'my-component', {}, {}),
-            strip_margin('''|name = "world"
-                            |roles = []
+            strip_margin('''|annotations {}
                             |compatibilityVersion = "0"
                             |diskSpace = 1073741824
                             |memory = 402653184
+                            |name = "world"
                             |nrOfCpus = 0.1
-                            |version = "1"
+                            |roles = [
+                            |  "web"
+                            |]
                             |system = "world"
                             |systemVersion = "1"
                             |tags = [
                             |  "testing"
                             |]
-                            |annotations {}
+                            |version = "1"
                             |components {
                             |  my-component {
                             |    description = "testing desc 1"
@@ -155,22 +159,24 @@ class TestBndlOci(CliTestCase):
                             |}''')
         )
 
+        self.maxDiff = None
+
         self.assertEqual(
             bndl_oci.oci_image_bundle_conf(extended_args, 'my-other-component', {}, {}),
-            strip_margin('''|name = "world"
-                            |version = "4"
+            strip_margin('''|annotations {}
                             |compatibilityVersion = "5"
-                            |system = "myapp"
-                            |systemVersion = "3"
-                            |nrOfCpus = "8"
-                            |memory = "65536"
                             |diskSpace = "16384"
+                            |memory = "65536"
+                            |name = "world"
+                            |nrOfCpus = "8"
                             |roles = [
                             |  "web"
                             |  "backend"
                             |]
+                            |system = "myapp"
+                            |systemVersion = "3"
                             |tags = []
-                            |annotations {}
+                            |version = "4"
                             |components {
                             |  my-other-component {
                             |    description = "testing desc 2"
@@ -188,7 +194,7 @@ class TestBndlOci(CliTestCase):
         base_args = create_attributes_object({
             'name': 'world',
             'component_description': 'testing desc 1',
-            'tag': 'testing',
+            'image_tag': 'testing',
             'use_default_endpoints': True,
             'annotations': []
         })
@@ -201,19 +207,21 @@ class TestBndlOci(CliTestCase):
 
         self.assertEqual(
             bndl_oci.oci_image_bundle_conf(base_args, 'my-component', {}, config),
-            strip_margin('''|name = "world"
-                            |roles = []
+            strip_margin('''|annotations {}
                             |compatibilityVersion = "0"
                             |diskSpace = 1073741824
                             |memory = 402653184
+                            |name = "world"
                             |nrOfCpus = 0.1
-                            |version = "1"
+                            |roles = [
+                            |  "web"
+                            |]
                             |system = "world"
                             |systemVersion = "1"
                             |tags = [
                             |  "testing"
                             |]
-                            |annotations {}
+                            |version = "1"
                             |components {
                             |  my-component {
                             |    description = "testing desc 1"
@@ -246,7 +254,7 @@ class TestBndlOci(CliTestCase):
         base_args = create_attributes_object({
             'name': 'world',
             'component_description': 'testing desc 1',
-            'tag': 'testing',
+            'image_tag': 'testing',
             'use_default_endpoints': False,
             'annotations': []
         })
@@ -259,19 +267,21 @@ class TestBndlOci(CliTestCase):
 
         self.assertEqual(
             bndl_oci.oci_image_bundle_conf(base_args, 'my-component', {}, config),
-            strip_margin('''|name = "world"
-                            |roles = []
+            strip_margin('''|annotations {}
                             |compatibilityVersion = "0"
                             |diskSpace = 1073741824
                             |memory = 402653184
+                            |name = "world"
                             |nrOfCpus = 0.1
-                            |version = "1"
+                            |roles = [
+                            |  "web"
+                            |]
                             |system = "world"
                             |systemVersion = "1"
                             |tags = [
                             |  "testing"
                             |]
-                            |annotations {}
+                            |version = "1"
                             |components {
                             |  my-component {
                             |    description = "testing desc 1"
@@ -289,7 +299,7 @@ class TestBndlOci(CliTestCase):
         base_args = create_attributes_object({
             'name': 'world',
             'component_description': 'testing desc 1',
-            'tag': 'testing',
+            'image_tag': 'testing',
             'use_default_endpoints': True,
             'annotations': {}
         })
@@ -302,19 +312,21 @@ class TestBndlOci(CliTestCase):
 
         self.assertEqual(
             bndl_oci.oci_image_bundle_conf(base_args, 'my-component', {}, config),
-            strip_margin('''|name = "world"
-                            |roles = []
+            strip_margin('''|annotations {}
                             |compatibilityVersion = "0"
                             |diskSpace = 1073741824
                             |memory = 402653184
+                            |name = "world"
                             |nrOfCpus = 0.1
-                            |version = "1"
+                            |roles = [
+                            |  "web"
+                            |]
                             |system = "world"
                             |systemVersion = "1"
                             |tags = [
                             |  "testing"
                             |]
-                            |annotations {}
+                            |version = "1"
                             |components {
                             |  my-component {
                             |    description = "testing desc 1"
@@ -355,7 +367,7 @@ class TestBndlOci(CliTestCase):
         base_args = create_attributes_object({
             'name': 'world',
             'component_description': 'testing desc 1',
-            'tag': 'testing',
+            'image_tag': 'testing',
             'use_default_endpoints': True,
             'annotations': []
         })
@@ -375,19 +387,7 @@ class TestBndlOci(CliTestCase):
 
         self.assertEqual(
             bndl_oci.oci_image_bundle_conf(base_args, 'my-component', manifest, config),
-            strip_margin('''|name = "world"
-                            |roles = []
-                            |compatibilityVersion = "0"
-                            |diskSpace = 1073741824
-                            |memory = 402653184
-                            |nrOfCpus = 0.1
-                            |version = "1"
-                            |system = "world"
-                            |systemVersion = "1"
-                            |tags = [
-                            |  "testing"
-                            |]
-                            |annotations {
+            strip_margin('''|annotations {
                             |  com {
                             |    lightbend {
                             |      test = 123
@@ -395,6 +395,20 @@ class TestBndlOci(CliTestCase):
                             |  }
                             |  description = "hello world"
                             |}
+                            |compatibilityVersion = "0"
+                            |diskSpace = 1073741824
+                            |memory = 402653184
+                            |name = "world"
+                            |nrOfCpus = 0.1
+                            |roles = [
+                            |  "web"
+                            |]
+                            |system = "world"
+                            |systemVersion = "1"
+                            |tags = [
+                            |  "testing"
+                            |]
+                            |version = "1"
                             |components {
                             |  my-component {
                             |    description = "testing desc 1"


### PR DESCRIPTION
This PR implements support for ConductR bundles and `bundle.conf` files to `bndl`. It can create bundles from directories, zips, tars all over stdin and provided via a file argument. See next comment for manual tests.

Separate from this PR is another one that adds support for invoking `bndl` from `conduct load`. Finally, building on these two PRs is a third PR that implements a docker resolver.