### PR TITLE
Sandbox run: warn if there's license validation error

### DIFF
--- a/conductr_cli/license_validation.py
+++ b/conductr_cli/license_validation.py
@@ -79,7 +79,7 @@ def validate_version(conductr_version, license_data):
                 return
 
         raise LicenseValidationError([
-            'Unable to run sandbox version {}'.format(conductr_version),
+            'Sandbox version {} requested'.format(conductr_version),
             'The license allows for version {}'.format(', '.join(versions))
         ])
 
@@ -88,7 +88,7 @@ def validate_nr_of_agents(nr_of_agent_instances, license_data):
     nr_of_allowed_agents = get_value(license_data, 'maxConductrAgents')
     if nr_of_allowed_agents and nr_of_agent_instances > nr_of_allowed_agents:
         raise LicenseValidationError([
-            'Unable to allocate {} agents'.format(nr_of_agent_instances),
+            '{} agents requested'.format(nr_of_agent_instances),
             'The license allows for {} agent(s)'.format(nr_of_allowed_agents)
         ])
 

--- a/conductr_cli/license_validation.py
+++ b/conductr_cli/license_validation.py
@@ -129,17 +129,32 @@ def get_value(license_data, key):
 
 
 def can_run_version(version_pattern, version_number):
-    version_pattern_parts = version_pattern.split('.')
-    version_number_parts = version_number.split('.')
+    if version_pattern != version_number:
+        if '-' in version_pattern:
+            version_pattern_parts = version_pattern.split('-')[0].split('.')
+            version_pattern_suffix = version_pattern.split('-')[-1]
+        else:
+            version_pattern_parts = version_pattern.split('.')
+            version_pattern_suffix = None
 
-    for idx, pattern in enumerate(version_pattern_parts):
-        if idx >= len(version_number_parts):
-            return False
-        elif pattern == '*':
-            return True
+        if '-' in version_number:
+            version_number_parts = version_number.split('-')[0].split('.')
+            version_number_suffix = version_number.split('-')[-1]
+        else:
+            version_number_parts = version_number.split('.')
+            version_number_suffix = None
 
-        number_part = version_number_parts[idx]
-        if int(pattern) != int(number_part):
+        if version_pattern_suffix and version_number_suffix and version_pattern_suffix != version_number_suffix:
             return False
+
+        for idx, pattern in enumerate(version_pattern_parts):
+            if idx >= len(version_number_parts):
+                return False
+            elif pattern == '*':
+                return True
+
+            number_part = version_number_parts[idx]
+            if int(pattern) != int(number_part):
+                return False
 
     return True

--- a/conductr_cli/sandbox_run.py
+++ b/conductr_cli/sandbox_run.py
@@ -22,7 +22,6 @@ import sys
 @validation.handle_jvm_validation_error
 @validation.handle_hostname_lookup_error
 @validation.handle_docker_validation_error
-@validation.handle_license_validation_error
 @validation.handle_conductr_startup_error
 def run(args):
     """`sandbox run` command"""

--- a/conductr_cli/test/test_license_validation.py
+++ b/conductr_cli/test/test_license_validation.py
@@ -267,25 +267,31 @@ class TestValidateGrants(TestCase):
 
 class TestCanRunVersion(TestCase):
     def test_major_version(self):
+        self.assertTrue(license_validation.can_run_version('2.*.*', '2.1.5-alpha.1'))
         self.assertTrue(license_validation.can_run_version('2.*.*', '2.1.5'))
         self.assertTrue(license_validation.can_run_version('2.*.*', '2.0.1'))
         self.assertTrue(license_validation.can_run_version('2.*.*', '2.0.0'))
 
+        self.assertTrue(license_validation.can_run_version('2.*', '2.1.5-alpha.1'))
         self.assertTrue(license_validation.can_run_version('2.*', '2.1.5'))
         self.assertTrue(license_validation.can_run_version('2.*', '2.0.1'))
         self.assertTrue(license_validation.can_run_version('2.*', '2.0.0'))
 
+        self.assertFalse(license_validation.can_run_version('1.*.*', '2.1.5-alpha.1'))
         self.assertFalse(license_validation.can_run_version('1.*.*', '2.1.5'))
         self.assertFalse(license_validation.can_run_version('1.*.*', '2.0.1'))
         self.assertFalse(license_validation.can_run_version('1.*.*', '2.0.0'))
 
+        self.assertFalse(license_validation.can_run_version('1.*', '2.1.5-alpha.1'))
         self.assertFalse(license_validation.can_run_version('1.*', '2.1.5'))
         self.assertFalse(license_validation.can_run_version('1.*', '2.0.1'))
         self.assertFalse(license_validation.can_run_version('1.*', '2.0.0'))
 
     def test_major_minor_version(self):
+        self.assertTrue(license_validation.can_run_version('2.1.*', '2.1.5-alpha.1'))
         self.assertTrue(license_validation.can_run_version('2.1.*', '2.1.5'))
 
+        self.assertFalse(license_validation.can_run_version('2.1.*', '2.2.1-alpha.1'))
         self.assertFalse(license_validation.can_run_version('2.1.*', '2.2.1'))
         self.assertFalse(license_validation.can_run_version('2.1.*', '2.1'))
         self.assertFalse(license_validation.can_run_version('2.1.*', '2'))
@@ -293,6 +299,12 @@ class TestCanRunVersion(TestCase):
     def test_major_minor_patch_version(self):
         self.assertTrue(license_validation.can_run_version('2.1.5', '2.1.5'))
         self.assertFalse(license_validation.can_run_version('2.1.5', '2.2.1'))
+
+    def test_major_minor_patch_label(self):
+        self.assertTrue(license_validation.can_run_version('2.1.5-alpha.1', '2.1.5-alpha.1'))
+
+        self.assertFalse(license_validation.can_run_version('2.1.5-alpha.1', '2.1.5-alpha.2'))
+        self.assertFalse(license_validation.can_run_version('2.1.5-alpha.1', '2.2.1-alpha.1'))
 
     def test_any_version(self):
         self.assertTrue(license_validation.can_run_version('*.*.*', '2.1.5'))

--- a/conductr_cli/test/test_sandbox_run.py
+++ b/conductr_cli/test/test_sandbox_run.py
@@ -2,7 +2,7 @@ from conductr_cli.test.cli_test_case import CliTestCase, as_error, strip_margin
 from conductr_cli import logging_setup, sandbox_run, sandbox_run_docker, sandbox_run_jvm, sandbox_features
 from conductr_cli.docker import DockerVmType
 from conductr_cli.exceptions import InstanceCountError, JavaCallError, JavaUnsupportedVendorError, \
-    JavaUnsupportedVersionError, JavaVersionParseError, LicenseValidationError
+    JavaUnsupportedVersionError, JavaVersionParseError
 from conductr_cli.sandbox_common import CONDUCTR_DEV_IMAGE, DEFAULT_WAIT_RETRIES, DEFAULT_WAIT_RETRY_INTERVAL
 from unittest.mock import patch, MagicMock
 
@@ -89,7 +89,7 @@ class TestSandboxRunCommand(CliTestCase):
         mock_collect_features = MagicMock(return_value=features)
 
         sandbox_run_result = sandbox_run_jvm.SandboxRunResult([1001], ['192.168.1.1'], [1002], ['192.168.1.1'],
-                                                              wait_for_conductr=True)
+                                                              wait_for_conductr=True, license_validation_error=None)
         mock_sandbox_run_jvm = MagicMock(return_value=sandbox_run_result)
         mock_wait_for_conductr = MagicMock(return_value=True)
         mock_log_run_attempt = MagicMock()
@@ -265,34 +265,5 @@ class TestSandboxRunCommand(CliTestCase):
 
         expected_output = strip_margin(as_error("""|Error: Unable to obtain java version from the `java -version` command.
                                                    |Error: Please ensure Oracle or OpenJDK JVM 1.8 and above is installed.
-                                                   |"""))
-        self.assertEqual(expected_output, self.output(stderr))
-
-    def test_jvm_license_validation_error(self):
-        conductr_version = '2.1.0'
-
-        stdout = MagicMock()
-        stderr = MagicMock()
-
-        mock_feature = MagicMock()
-        features = [mock_feature]
-        mock_collect_features = MagicMock(return_value=features)
-        mock_sandbox_run_jvm = MagicMock(side_effect=LicenseValidationError(['test']))
-
-        args = self.default_args.copy()
-        args.update({
-            'image_version': conductr_version
-        })
-        input_args = MagicMock(**args)
-        with \
-                patch('conductr_cli.sandbox_features.collect_features', mock_collect_features), \
-                patch('conductr_cli.sandbox_run_jvm.run', mock_sandbox_run_jvm):
-            logging_setup.configure_logging(input_args, stdout, stderr)
-            self.assertFalse(sandbox_run.run(input_args))
-
-        mock_sandbox_run_jvm.assert_called_once_with(input_args, features)
-
-        expected_output = strip_margin(as_error("""|Error: Unable to start ConductR due to license validation failure
-                                                   |Error: test
                                                    |"""))
         self.assertEqual(expected_output, self.output(stderr))

--- a/conductr_cli/validation.py
+++ b/conductr_cli/validation.py
@@ -16,8 +16,7 @@ from conductr_cli.exceptions import BindAddressNotFound, ConductrStartupError, \
     BintrayUnreachableError, BundleResolutionError, WaitTimeoutError, InsecureFilePermissions, \
     SandboxImageNotFoundError, JavaCallError, HostnameLookupError, JavaUnsupportedVendorError, \
     JavaUnsupportedVersionError, JavaVersionParseError, DockerValidationError, SandboxImageNotAvailableOfflineError, \
-    SandboxUnsupportedOsError, SandboxUnsupportedOsArchError, LicenseLoadError, LicenseValidationError, \
-    LicenseDownloadError, NOT_FOUND_ERROR
+    SandboxUnsupportedOsError, SandboxUnsupportedOsArchError, LicenseLoadError, LicenseDownloadError, NOT_FOUND_ERROR
 
 
 def connection_error(log, err, args):
@@ -508,25 +507,6 @@ def handle_license_load_error(func):
             log = get_logger_for_func(func)
             log.error('Error loading license into ConductR')
             log.error(e.message)
-            return False
-
-        # Do not change the wrapped function name,
-        # so argparse configuration can be tested.
-    handler.__name__ = func.__name__
-
-    return handler
-
-
-def handle_license_validation_error(func):
-
-    def handler(*args, **kwargs):
-        try:
-            return func(*args, **kwargs)
-        except LicenseValidationError as e:
-            log = get_logger_for_func(func)
-            log.error('Unable to start ConductR due to license validation failure')
-            for message in e.messages:
-                log.error(message)
             return False
 
         # Do not change the wrapped function name,


### PR DESCRIPTION
Display warning message instead of shutting down the sandbox to give end user a chance to run `conduct load-license` immediately after starting the sandbox.