### PR TITLE
bndl --endpoint argument

### DIFF
--- a/conductr_cli/bndl_main.py
+++ b/conductr_cli/bndl_main.py
@@ -61,7 +61,8 @@ class EndpointAction(argparse.Action):
 def set_endpoints(args):
     def validate(endpoint):
         if 'component' not in endpoint:
-            log.error('bndl: argument --component is required when specifying argument --endpoint')
+            log.error('bndl: argument --component is required when specifying argument --endpoint {}'
+                      .format(endpoint['name']))
             sys.exit(2)
 
     log = logging.getLogger(__name__)

--- a/conductr_cli/bndl_utils.py
+++ b/conductr_cli/bndl_utils.py
@@ -126,6 +126,7 @@ def load_bundle_args_into_conf(config, args, with_defaults):
 
     args_compatibility_version = getattr(args, 'compatibility_version', None)
     args_disk_space = getattr(args, 'disk_space', None)
+    args_endpoints = getattr(args, 'endpoints', None)
     args_memory = getattr(args, 'memory', None)
     args_name = getattr(args, 'name', None)
     args_nr_of_cpus = getattr(args, 'nr_of_cpus', None)
@@ -164,6 +165,17 @@ def load_bundle_args_into_conf(config, args, with_defaults):
         config.put('diskSpace', args_disk_space)
     if with_defaults and 'diskSpace' not in config:
         config.put('diskSpace', BNDL_DEFAULT_DISK_SPACE)
+
+    if args_endpoints is not None:
+        # Delete existing endpoints if exist in configuration
+        for endpoint in args_endpoints:
+            endpoint_key = 'components.{}.endpoints'.format(endpoint.component)
+            if endpoint_key in config:
+                config.put(endpoint_key, None)
+        # Add endpoints to bundle components based on the --endpoint argument
+        for endpoint in args_endpoints:
+            endpoint_key = 'components.{}.endpoints'.format(endpoint.component)
+            config.put(endpoint_key, endpoint.hocon())
 
     if args_memory is not None:
         config.put('memory', args_memory)

--- a/conductr_cli/endpoint.py
+++ b/conductr_cli/endpoint.py
@@ -7,12 +7,32 @@ from collections import defaultdict
 class Endpoint:
     def __init__(self, endpoint_dict):
         self.name = endpoint_dict['name']
-        self.component = endpoint_dict['component']
+
+        if 'component' in endpoint_dict:
+            self.component = endpoint_dict['component']
+        else:
+            raise ValueError('could not find {} in {}'.format('component', endpoint_dict))
+
+        self.acls = []
+        grouped_acls = defaultdict(list)
+        if 'acls' in endpoint_dict:
+            for acl in endpoint_dict['acls']:
+                protocol_family, request_mapping = RequestAcl.split_acl_string(acl)
+                grouped_acls[protocol_family].append(request_mapping)
+            for protocol_family, request_mappings in grouped_acls.items():
+                self.acls.append(RequestAcl(protocol_family, request_mappings))
 
         if 'bind-protocol' in endpoint_dict:
             self.bind_protocol = endpoint_dict['bind-protocol']
-        else:
+        elif not grouped_acls:
             self.bind_protocol = 'tcp'
+        elif len(grouped_acls) == 1:
+            self.bind_protocol = next(iter(grouped_acls.keys())).name
+        else:
+            protocol_families = [key.name for key in grouped_acls.keys()]
+            raise AmbigousBindProtocolError('could not set the bind protocol for an endpoint. '
+                                            'bind-protocol is not specified and '
+                                            'acls contain multiple protocol families: {}'.format(protocol_families))
 
         if 'bind-port' in endpoint_dict:
             self.bind_port = endpoint_dict['bind-port']
@@ -23,17 +43,6 @@ class Endpoint:
             self.service_name = endpoint_dict['service-name']
         else:
             self.service_name = None
-
-        self.acls = []
-        if 'acls' in endpoint_dict:
-            grouped_acls = defaultdict(list)
-            for acl in endpoint_dict['acls']:
-                protocol_family, request_mapping = RequestAcl.split_acl_string(acl)
-                grouped_acls[protocol_family].append(request_mapping)
-            if ProtocolFamily.http in grouped_acls:
-                self.bind_protocol = 'http'
-            for protocol_family, request_mappings in grouped_acls.items():
-                self.acls.append(RequestAcl(protocol_family, request_mappings))
 
     def hocon(self):
         endpoint_tree = ConfigTree()
@@ -118,3 +127,11 @@ class HttpRequest:
         request_list = ConfigList()
         request_list.append(request_tree)
         return request_list
+
+
+class AmbigousBindProtocolError(Exception):
+    def __init__(self, value):
+        self.value = value
+
+    def __str__(self):
+        return repr(self.value)

--- a/conductr_cli/endpoint.py
+++ b/conductr_cli/endpoint.py
@@ -1,0 +1,115 @@
+from enum import Enum
+from pyhocon import ConfigTree, ConfigList
+
+
+class Endpoint:
+    def __init__(self, endpoint_dict):
+        self.name = endpoint_dict['name']
+        self.component = endpoint_dict['component']
+
+        if 'bind-protocol' in endpoint_dict:
+            self.bind_protocol = endpoint_dict['bind-protocol']
+        else:
+            self.bind_protocol = 'tcp'
+
+        if 'bind-port' in endpoint_dict:
+            self.bind_port = endpoint_dict['bind-port']
+        else:
+            self.bind_port = 0
+
+        if 'service-name' in endpoint_dict:
+            self.service_name = endpoint_dict['service-name']
+        else:
+            self.service_name = None
+
+        self.acls = []
+        if 'acls' in endpoint_dict:
+            for acl in endpoint_dict['acls']:
+                if acl.startswith('http'):
+                    self.bind_protocol = 'http'
+                self.acls.append(RequestAcl(acl))
+
+    def hocon(self):
+        endpoint_tree = ConfigTree()
+        endpoint_tree.put('{}.bind-protocol'.format(self.name), self.bind_protocol)
+        endpoint_tree.put('{}.bind-port'.format(self.name), self.bind_port)
+        if self.service_name:
+            endpoint_tree.put('{}.service-name'.format(self.name), self.service_name)
+        for acl in self.acls:
+            acl_list = ConfigList()
+            acl_list.append(acl.hocon())
+            endpoint_tree.put('{}.acls'.format(self.name), acl_list)
+        return endpoint_tree
+
+
+class RequestAcl:
+    request_mappings = []
+
+    def __init__(self, shorthand_string):
+        protocol_family_string, other_parts = shorthand_string.split(':', 1)
+        protocol_family = ProtocolFamily[protocol_family_string]
+
+        if other_parts.startswith('[') and other_parts.endswith(']'):
+            ports = [int(port.strip()) for port in other_parts[1:-1].split(',')]
+            if protocol_family is ProtocolFamily.tcp:
+                self.request_mappings.append(TcpRequest(ports))
+            elif protocol_family is ProtocolFamily.udp:
+                self.request_mappings.append(UdpRequest(ports))
+        elif other_parts.startswith('/'):
+            if protocol_family is ProtocolFamily.http:
+                self.request_mappings.append(HttpRequest(other_parts))
+
+    def hocon(self):
+        acl_tree = ConfigTree()
+        for mapping in self.request_mappings:
+            acl_tree.put('{}.requests'.format(mapping.protocol_family.name), mapping.hocon(), append=True)
+        return acl_tree
+
+
+class ProtocolFamily(Enum):
+    tcp = 1
+    udp = 2
+    http = 3
+
+
+class TcpRequest:
+    protocol_family = ProtocolFamily.tcp
+    ports = []
+
+    def __init__(self, ports):
+        self.ports = ports
+
+    def hocon(self):
+        return ConfigList(self.ports)
+
+
+class UdpRequest:
+    protocol_family = ProtocolFamily.udp
+    ports = []
+
+    def __init__(self, ports):
+        self.ports = ports
+
+    def hocon(self):
+        return ConfigList(self.ports)
+
+
+class HttpRequest:
+    protocol_family = ProtocolFamily.http
+    method = None
+    path_beg = None
+    rewrite = None
+
+    def __init__(self, path_beg):
+        self.path_beg = path_beg
+
+    def hocon(self):
+        request_tree = ConfigTree()
+        request_tree.put('path-beg', self.path_beg)
+        if self.method:
+            request_tree.put('method', self.method)
+        if self.rewrite:
+            request_tree.put('rewrite', self.rewrite)
+        request_list = ConfigList()
+        request_list.append(request_tree)
+        return request_list

--- a/conductr_cli/test/test_bndl_main.py
+++ b/conductr_cli/test/test_bndl_main.py
@@ -233,3 +233,27 @@ class TestBndl(CliTestCase):
             self.output(stderr_mock),
             as_error('Error: bndl: argument --component is required when specifying argument --endpoint web\n')
         )
+
+    def test_warn_ambigous_bind_protocol(self):
+        bndl_mock = MagicMock()
+        stdout_mock = MagicMock()
+        stderr_mock = MagicMock()
+        configure_logging_mock = MagicMock()
+        bndl_main.logging_setup.configure_logging(MagicMock(), stdout_mock, stderr_mock)
+
+        with \
+                patch('conductr_cli.bndl_main.bndl', bndl_mock), \
+                patch('sys.stdout.isatty', lambda: False), \
+                patch('conductr_cli.logging_setup.configure_logging', configure_logging_mock), \
+                patch('sys.stdin.isatty', lambda: False):
+            self.assertRaises(SystemExit, bndl_main.run, ['-o', '-', '-', '--endpoint', 'web',
+                                                          '--component', 'test',
+                                                          '--acl', 'http:/', '--acl', 'tcp:[3000]'])
+
+        self.assertEqual(
+            self.output(stderr_mock),
+            as_error('Error: bndl: argument --bind-protocol is required '
+                     'when acls with different protocol families are specified\n'
+                     'endpoint: web\n'
+                     'acls: http:/, tcp:[3000]\n')
+        )

--- a/conductr_cli/test/test_bndl_main.py
+++ b/conductr_cli/test/test_bndl_main.py
@@ -231,5 +231,5 @@ class TestBndl(CliTestCase):
 
         self.assertEqual(
             self.output(stderr_mock),
-            as_error('Error: bndl: argument --component is required when specifying argument --endpoint\n')
+            as_error('Error: bndl: argument --component is required when specifying argument --endpoint web\n')
         )

--- a/conductr_cli/test/test_bndl_main.py
+++ b/conductr_cli/test/test_bndl_main.py
@@ -52,6 +52,18 @@ class TestBndl(CliTestCase):
             'backend',
             '--with-check',
             '--no-default-endpoints',
+            '--endpoint',
+            'web',
+            '--component',
+            'web-component',
+            '--bind-protocol',
+            'http',
+            '--bind-port',
+            '8080',
+            '--service-name',
+            'web',
+            '--acl',
+            'http:/subpath',
             '--annotation',
             'com.lightbend.test=hello world',
             '--annotation',
@@ -76,6 +88,16 @@ class TestBndl(CliTestCase):
         self.assertEqual(args.roles, ['web', 'backend'])
         self.assertEqual(args.annotations, ['com.lightbend.test=hello world', 'description=this is a test'])
         self.assertFalse(args.use_default_endpoints)
+        self.assertEqual(args.endpoint_dicts, [
+            {
+                'name': 'web',
+                'component': 'web-component',
+                'bind-protocol': 'http',
+                'bind-port': 8080,
+                'service-name': 'web',
+                'acls': ['http:/subpath']
+            }
+        ])
 
     def test_parser_no_args(self):
         args = self.parser.parse_args([])
@@ -192,3 +214,22 @@ class TestBndl(CliTestCase):
             exit_mock.assert_called_once_with(2)
         finally:
             shutil.rmtree(temp)
+
+    def test_warn_no_endpoint_component(self):
+        bndl_mock = MagicMock()
+        stdout_mock = MagicMock()
+        stderr_mock = MagicMock()
+        configure_logging_mock = MagicMock()
+        bndl_main.logging_setup.configure_logging(MagicMock(), stdout_mock, stderr_mock)
+
+        with \
+                patch('conductr_cli.bndl_main.bndl', bndl_mock), \
+                patch('sys.stdout.isatty', lambda: False), \
+                patch('conductr_cli.logging_setup.configure_logging', configure_logging_mock), \
+                patch('sys.stdin.isatty', lambda: False):
+            self.assertRaises(SystemExit, bndl_main.run, ['-o', '-', '-', '--endpoint', 'web'])
+
+        self.assertEqual(
+            self.output(stderr_mock),
+            as_error('Error: bndl: argument --component is required when specifying argument --endpoint\n')
+        )

--- a/conductr_cli/test/test_bndl_utils.py
+++ b/conductr_cli/test/test_bndl_utils.py
@@ -180,9 +180,27 @@ class TestBndlUtils(CliTestCase):
                     ]
                 }),
                 Endpoint({
-                    'name': 'akka-remote',
+                    'name': 'no-acls',
                     'component': 'test-bundle',
                     'bind-port': 2345
+                }),
+                Endpoint({
+                    'name': 'tcp',
+                    'component': 'test-bundle',
+                    'service-name': 'tcp',
+                    'acls': [
+                        'tcp:[5000, 5001]',
+                        'tcp:[5002, 5003]'
+                    ]
+                }),
+                Endpoint({
+                    'name': 'udp',
+                    'component': 'test-bundle',
+                    'service-name': 'udp',
+                    'acls': [
+                        'udp:[6000, 6001]',
+                        'udp:[6002, 6003]'
+                    ]
                 })
             ]
         })
@@ -286,18 +304,52 @@ class TestBndlUtils(CliTestCase):
                |      http {
                |        requests = [
                |          {
-               |            path-beg = "/"
+               |            path = "/"
                |          }
                |          {
-               |            path-beg = "/subpath"
+               |            path = "/subpath"
                |          }
                |        ]
                |      }
                |    }
                |  ]
                |}
-               |akka-remote {
+               |no-acls {
                |  bind-protocol = "tcp"
                |  bind-port = 2345
+               |}
+               |tcp {
+               |  bind-protocol = "tcp"
+               |  bind-port = 0
+               |  service-name = "tcp"
+               |  acls = [
+               |    {
+               |      tcp {
+               |        requests = [
+               |          5000,
+               |          5001,
+               |          5002,
+               |          5003
+               |        ]
+               |      }
+               |    }
+               |  ]
+               |}
+               |udp {
+               |  bind-protocol = "tcp"
+               |  bind-port = 0
+               |  service-name = "udp"
+               |  acls = [
+               |    {
+               |      udp {
+               |        requests = [
+               |          6000,
+               |          6001,
+               |          6002,
+               |          6003
+               |        ]
+               |      }
+               |    }
+               |  ]
                |}"""))
         self.assertEqual(endpoints_config.get('components.test-bundle.endpoints'), expected_endpoints_config)

--- a/conductr_cli/test/test_bndl_utils.py
+++ b/conductr_cli/test/test_bndl_utils.py
@@ -336,7 +336,7 @@ class TestBndlUtils(CliTestCase):
                |  ]
                |}
                |udp {
-               |  bind-protocol = "tcp"
+               |  bind-protocol = "udp"
                |  bind-port = 0
                |  service-name = "udp"
                |  acls = [


### PR DESCRIPTION
Adding argument `--endpoint` to `bndl` command. If specified, it replaces the existing endpoints of the given input, e.g. a bundle file

**Example**

```
bndl \
  test-bundle-v0-b1157bdcd7c9815100bdf2479704c66210c4dcd3d16f2519009ffafba935a4f9.zip \
  -o new-test-bundle-v0-b1157bdcd7c9815100bdf2479704c66210c4dcd3d16f2519009ffafba935a4f9.zip \
  --endpoint web \
  --component test-bundle bind-protocol http \
  --bind-port 5601 \
  --service-name web \
  --acl http:/ \
  --endpoint \
  --component test-bundle akka-remote
```

results into:

```
endpoints = {
  "web" = {
    bind-protocol = "http"
    bind-port     = 5601
    service-name  = "web"
    acls          = [
      {
        http = {
          requests = [
            {
              path-beg = "/"
            }
          ]
        }
      }
    ]
  },
  "akka-remote" = {
    bind-protocol = "tcp"
    bind-port     = 0
  }
}
```

Existing endpoints inside the specified component are removed.

An `--acl` option is converted into a request ACL with a `path-beg` attribute. The attributes `path` and `path-regex`, as well as `rewrite and `method` are not yet supported.

Specifying an endpoint as HOCON string is not yet supported but will be added in another commit.

All endpoint arguments have been grouped into a separate section in the `bndl --help`:

```
usage: bndl [-h] [-f {docker,oci-image,bundle}] [--image-tag IMAGE_TAG]
            [--image-name IMAGE_NAME] [-o [OUTPUT]] [--no-shazar]
            [--no-default-endpoints] [-e ENDPOINT [OPTS]]
            [--component COMPONENT] [--bind-protocol BIND_PROTOCOL]
            [--bind-port BIND_PORT] [--service-name SERVICE_NAME] [--acl ACL]
            [--with-check] [--component-description COMPONENT_DESCRIPTION]
            [--annotation ANNOTATIONS]
            [--compatibility-version [COMPATIBILITY_VERSION]]
            [--disk-space [DISK_SPACE]] [--memory [MEMORY]] [--name [NAME]]
            [--nr-of-cpus [NR_OF_CPUS]] [--roles [ROLES [ROLES ...]]]
            [--system [SYSTEM]] [--system-version [SYSTEM_VERSION]]
            [--tag TAGS] [--version [VERSION]]
            [source]

positional arguments:
...

endpoints:
  -e ENDPOINT [OPTS], --endpoint ENDPOINT [OPTS]
                        Endpoints to add to bundle.conf
                        If specified, existing endpoints are removed
                        Example: bndl --endpoint web --component web --bind-protocol http --service-name web --acl http:/subpath
  --component COMPONENT
                        Component to which an endpoint should be added
                        Used in conjunction with the --endpoint option
                        Required when specifying the --endpoint option
  --bind-protocol BIND_PROTOCOL
                        Bind protocol of an endpoint
                        Used in conjunction with the --endpoint option
                        When absent, tcp is used
  --bind-port BIND_PORT
                        Bind port of an endpoint
                        Used in conjunction with the --endpoint option
                        When absent, 0 is used, meaning a bind port is selected by ConductR
  --service-name SERVICE_NAME
                        Service name of an endpoint
                        Used in conjunction with the --endpoint option
                        When absent, the endpoint is not locatable via the service name
  --acl ACL             Request ACL of an endpoint
                        Used in conjunction with the --endpoint option
                        When absent, the endpoint will not be accessible via the Proxy

```

Note that the sub-argument `--component` is required so that we know at which component in the `bundle.conf` the endpoints need to be replaced. This could be simplified in the future, e.g. by replacing the endpoints of the first component if only one component exists in the `bundle.conf`. However, it is quite common that a `bundle.conf` contains at least two components, the service itself and the check component so I am not sure if we can find a good default here so that the user don't need to declare the `--component` argument for each `--endpoint` argument. 

@huntc @fsat @longshorej  Thoughts?