### PR TITLE
Load License: use correct method to obtain host from parsed arguments

### DIFF
--- a/conductr_cli/conduct_load_license.py
+++ b/conductr_cli/conduct_load_license.py
@@ -1,5 +1,6 @@
 from conductr_cli import license, validation
 from conductr_cli.constants import DEFAULT_LICENSE_FILE
+from conductr_cli.conduct_url import conductr_host
 from conductr_cli.exceptions import LicenseLoadError
 import logging
 import os
@@ -28,7 +29,8 @@ def load_license(args):
             license.download_license(args, save_to=license_file)
 
         if os.path.exists(license_file):
-            log.info('Loading license into ConductR at {}'.format(args.host))
+            host = conductr_host(args)
+            log.info('Loading license into ConductR at {}'.format(host))
             license.post_license(args, license_file)
 
             _, uploaded_license = license.get_license(args)

--- a/conductr_cli/exceptions.py
+++ b/conductr_cli/exceptions.py
@@ -37,14 +37,6 @@ class MalformedBundleUriError(Exception):
         return repr(self.value)
 
 
-class ResolverError(Exception):
-    def __init__(self, message):
-        self.message = message
-
-    def __str__(self):
-        return repr(self.message)
-
-
 class BintrayResolutionError(Exception):
     def __init__(self, message):
         self.message = message

--- a/conductr_cli/test/test_resolver.py
+++ b/conductr_cli/test/test_resolver.py
@@ -392,7 +392,7 @@ class TestResolverDocker(TestCase):
                     open(one.name, 'r') as one_in, \
                     patch('os.path.exists', MagicMock(return_value=True)), \
                     patch('builtins.open', MagicMock(return_value=one_in)):
-                self.assertEquals(
+                self.assertEqual(
                     resolver.docker_resolver.load_docker_credentials('test'),
                     ('one', 'one-password')
                 )
@@ -401,7 +401,7 @@ class TestResolverDocker(TestCase):
                     open(two.name, 'r') as two_in, \
                     patch('os.path.exists', MagicMock(return_value=True)), \
                     patch('builtins.open', MagicMock(return_value=two_in)):
-                self.assertEquals(
+                self.assertEqual(
                     resolver.docker_resolver.load_docker_credentials('test'),
                     ('two', 'two-password')
                 )
@@ -410,7 +410,7 @@ class TestResolverDocker(TestCase):
                     open(three.name, 'r') as three_in, \
                     patch('os.path.exists', MagicMock(return_value=True)), \
                     patch('builtins.open', MagicMock(return_value=three_in)):
-                self.assertEquals(
+                self.assertEqual(
                     resolver.docker_resolver.load_docker_credentials('test'),
                     None
                 )


### PR DESCRIPTION
This is to fix exception raised if `--ip` option instead of `--host` option is specified in DCOS mode.