### PR TITLE
Allow `conduct load-license` to ignore cached auth token

### DIFF
--- a/conductr_cli/conduct_load_license.py
+++ b/conductr_cli/conduct_load_license.py
@@ -26,7 +26,7 @@ def load_license(args):
         if args.offline_mode:
             log.info('Skipping downloading license from Lightbend.com')
         else:
-            license.download_license(args, save_to=license_file)
+            license.download_license(args, save_to=license_file, use_cached_auth_token=(not args.force_flag_enabled))
 
         if os.path.exists(license_file):
             host = conductr_host(args)

--- a/conductr_cli/conduct_main.py
+++ b/conductr_cli/conduct_main.py
@@ -414,6 +414,12 @@ def build_parser(dcos_mode):
     add_custom_plugins_dir(load_license_parser)
     add_quiet_flag(load_license_parser)
     add_verbose(load_license_parser)
+    load_license_parser.add_argument('-f', '--force',
+                                     dest='force_flag_enabled',
+                                     default=False,
+                                     action='store_true',
+                                     help='Always prompts for authentication token when specified,\n'
+                                          'use this option to change authentication token between different users')
     load_license_parser.add_argument('--license-download-url',
                                      dest='license_download_url',
                                      help=argparse.SUPPRESS,

--- a/conductr_cli/license.py
+++ b/conductr_cli/license.py
@@ -16,7 +16,7 @@ UNLICENSED_DISPLAY_TEXT = 'UNLICENSED - please use "conduct load-license" to use
                           'Additional agents are freely available for registered users.'
 
 
-def download_license(args, save_to):
+def download_license(args, save_to, use_cached_auth_token):
     """
     Downloads license from Lightbend.com.
     :param args: input args obtained from argparse.
@@ -26,10 +26,11 @@ def download_license(args, save_to):
 
     log = logging.getLogger(__name__)
 
-    cached_token = license_auth.get_cached_auth_token()
-    if cached_token:
-        auth_token = cached_token
-    else:
+    auth_token = None
+    if use_cached_auth_token:
+        auth_token = license_auth.get_cached_auth_token()
+
+    if not auth_token:
         auth_token = license_auth.prompt_for_auth_token()
 
     auth_token_b64_bytes = base64.b64encode(bytes(auth_token, 'UTF-8'))

--- a/conductr_cli/test/test_conduct_load_license.py
+++ b/conductr_cli/test/test_conduct_load_license.py
@@ -12,7 +12,8 @@ class TestConductLoadLicense(CliTestCase):
 
     args = {
         'offline_mode': False,
-        'host': host
+        'host': host,
+        'force_flag_enabled': False,
     }
 
     license = {
@@ -50,7 +51,46 @@ class TestConductLoadLicense(CliTestCase):
             logging_setup.configure_logging(input_args, stdout)
             self.assertTrue(conduct_load_license.load_license(input_args))
 
-        mock_download_license.assert_called_once_with(input_args, save_to=DEFAULT_LICENSE_FILE)
+        mock_download_license.assert_called_once_with(input_args,
+                                                      save_to=DEFAULT_LICENSE_FILE,
+                                                      use_cached_auth_token=True)
+        mock_exists.assert_called_once_with(DEFAULT_LICENSE_FILE)
+        mock_post_license.assert_called_once_with(input_args, DEFAULT_LICENSE_FILE)
+        mock_get_license.assert_has_calls([call(input_args), call(input_args)])
+        mock_format_license.assert_called_once_with(self.license)
+
+        expected_output = strip_margin("""|Loading license into ConductR at {}
+                                          |
+                                          |{}
+                                          |
+                                          |License successfully loaded
+                                          |""".format(self.host, self.license_formatted))
+        self.assertEqual(expected_output, self.output(stdout))
+
+    def test_success_with_force_flag_enabled(self):
+        mock_download_license = MagicMock()
+        mock_exists = MagicMock(return_value=True)
+        mock_post_license = MagicMock(return_value=True)
+        mock_get_license = MagicMock(return_value=(True, self.license))
+        mock_format_license = MagicMock(return_value=self.license_formatted)
+
+        args = self.args.copy()
+        args.update({'force_flag_enabled': True})
+        input_args = MagicMock(**args)
+
+        stdout = MagicMock()
+
+        with patch('conductr_cli.license.download_license', mock_download_license), \
+                patch('os.path.exists', mock_exists), \
+                patch('conductr_cli.license.post_license', mock_post_license), \
+                patch('conductr_cli.license.get_license', mock_get_license), \
+                patch('conductr_cli.license.format_license', mock_format_license):
+            logging_setup.configure_logging(input_args, stdout)
+            self.assertTrue(conduct_load_license.load_license(input_args))
+
+        mock_download_license.assert_called_once_with(input_args,
+                                                      save_to=DEFAULT_LICENSE_FILE,
+                                                      use_cached_auth_token=False)
         mock_exists.assert_called_once_with(DEFAULT_LICENSE_FILE)
         mock_post_license.assert_called_once_with(input_args, DEFAULT_LICENSE_FILE)
         mock_get_license.assert_has_calls([call(input_args), call(input_args)])
@@ -73,7 +113,8 @@ class TestConductLoadLicense(CliTestCase):
 
         args = {
             'offline_mode': False,
-            'ip': self.host
+            'ip': self.host,
+            'force_flag_enabled': False
         }
 
         input_args = MagicMock(**args)
@@ -88,7 +129,9 @@ class TestConductLoadLicense(CliTestCase):
             logging_setup.configure_logging(input_args, stdout)
             self.assertTrue(conduct_load_license.load_license(input_args))
 
-        mock_download_license.assert_called_once_with(input_args, save_to=DEFAULT_LICENSE_FILE)
+        mock_download_license.assert_called_once_with(input_args,
+                                                      save_to=DEFAULT_LICENSE_FILE,
+                                                      use_cached_auth_token=True)
         mock_exists.assert_called_once_with(DEFAULT_LICENSE_FILE)
         mock_post_license.assert_called_once_with(input_args, DEFAULT_LICENSE_FILE)
         mock_get_license.assert_has_calls([call(input_args), call(input_args)])
@@ -195,7 +238,9 @@ class TestConductLoadLicense(CliTestCase):
             logging_setup.configure_logging(input_args, stdout, stderr)
             self.assertFalse(conduct_load_license.load_license(input_args))
 
-        mock_download_license.assert_called_once_with(input_args, save_to=DEFAULT_LICENSE_FILE)
+        mock_download_license.assert_called_once_with(input_args,
+                                                      save_to=DEFAULT_LICENSE_FILE,
+                                                      use_cached_auth_token=True)
         mock_exists.assert_called_once_with(DEFAULT_LICENSE_FILE)
         mock_post_license.assert_called_once_with(input_args, DEFAULT_LICENSE_FILE)
         mock_get_license.assert_has_calls([call(input_args), call(input_args)])
@@ -230,7 +275,9 @@ class TestConductLoadLicense(CliTestCase):
             logging_setup.configure_logging(input_args, stdout, stderr)
             self.assertFalse(conduct_load_license.load_license(input_args))
 
-        mock_download_license.assert_called_once_with(input_args, save_to=DEFAULT_LICENSE_FILE)
+        mock_download_license.assert_called_once_with(input_args,
+                                                      save_to=DEFAULT_LICENSE_FILE,
+                                                      use_cached_auth_token=True)
         mock_exists.assert_called_once_with(DEFAULT_LICENSE_FILE)
         mock_post_license.assert_called_once_with(input_args, DEFAULT_LICENSE_FILE)
         mock_get_license.assert_called_once_with(input_args)
@@ -256,7 +303,9 @@ class TestConductLoadLicense(CliTestCase):
             logging_setup.configure_logging(input_args, stdout, stderr)
             self.assertFalse(conduct_load_license.load_license(input_args))
 
-        mock_download_license.assert_called_once_with(input_args, save_to=DEFAULT_LICENSE_FILE)
+        mock_download_license.assert_called_once_with(input_args,
+                                                      save_to=DEFAULT_LICENSE_FILE,
+                                                      use_cached_auth_token=True)
         mock_exists.assert_called_once_with(DEFAULT_LICENSE_FILE)
         mock_post_license.assert_called_once_with(input_args, DEFAULT_LICENSE_FILE)
         mock_get_license.assert_called_once_with(input_args)
@@ -282,7 +331,9 @@ class TestConductLoadLicense(CliTestCase):
             logging_setup.configure_logging(input_args, stdout, stderr)
             self.assertFalse(conduct_load_license.load_license(input_args))
 
-        mock_download_license.assert_called_once_with(input_args, save_to=DEFAULT_LICENSE_FILE)
+        mock_download_license.assert_called_once_with(input_args,
+                                                      save_to=DEFAULT_LICENSE_FILE,
+                                                      use_cached_auth_token=True)
         mock_exists.assert_called_once_with(DEFAULT_LICENSE_FILE)
         mock_post_license.assert_called_once_with(input_args, DEFAULT_LICENSE_FILE)
         mock_get_license.assert_called_once_with(input_args)
@@ -308,7 +359,9 @@ class TestConductLoadLicense(CliTestCase):
             logging_setup.configure_logging(input_args, stdout, stderr)
             self.assertFalse(conduct_load_license.load_license(input_args))
 
-        mock_download_license.assert_called_once_with(input_args, save_to=DEFAULT_LICENSE_FILE)
+        mock_download_license.assert_called_once_with(input_args,
+                                                      save_to=DEFAULT_LICENSE_FILE,
+                                                      use_cached_auth_token=True)
         mock_exists.assert_not_called()
         mock_post_license.assert_not_called()
         mock_get_license.assert_called_once_with(input_args)

--- a/conductr_cli/test/test_conduct_main.py
+++ b/conductr_cli/test/test_conduct_main.py
@@ -232,6 +232,7 @@ class TestConduct(TestCase):
         self.assertEqual(args.cli_settings_dir, '{}/.conductr'.format(os.path.expanduser('~')))
         self.assertEqual(args.custom_settings_file, '{}/.conductr/settings.conf'.format(os.path.expanduser('~')))
         self.assertEqual(args.custom_plugins_dir, '{}/.conductr/plugins'.format(os.path.expanduser('~')))
+        self.assertFalse(args.force_flag_enabled)
         self.assertEqual(args.license_download_url, DEFAULT_LICENSE_DOWNLOAD_URL)
         self.assertEqual(args.local_connection, True)
 
@@ -244,6 +245,7 @@ class TestConduct(TestCase):
                                       '--settings-dir /tmp '
                                       '--custom-settings-file /tmp/foo.conf '
                                       '--custom-plugins-dir /tmp/plugins '
+                                      '--force '
                                       '--license-download-url http://example.org'.split())
 
         self.assertEqual(args.func.__name__, 'load_license')
@@ -254,6 +256,7 @@ class TestConduct(TestCase):
         self.assertEqual(args.cli_settings_dir, '/tmp')
         self.assertEqual(args.custom_settings_file, '/tmp/foo.conf')
         self.assertEqual(args.custom_plugins_dir, '/tmp/plugins')
+        self.assertTrue(args.force_flag_enabled)
         self.assertEqual(args.license_download_url, 'http://example.org')
         self.assertEqual(args.local_connection, True)
 


### PR DESCRIPTION
When `-f` or `--force` is specified, the cached auth token is ignored by the `conduct load-license`.

This will allow user to change auth token from different users.