### PR TITLE
Bintray resolver no longer considers local directories a bundle if they are infact not one.

### DIFF
--- a/conductr_cli/bndl_create.py
+++ b/conductr_cli/bndl_create.py
@@ -136,12 +136,16 @@ def bndl_create(args):
                 return 2
 
             input_dir = find_bundle_conf_dir(temp_dir)
-
-            if input_dir is None:
-                log.error('bndl: Missing bundle.conf')
-                return 2
-
             bundle_conf_path = os.path.join(input_dir, 'bundle.conf')
+
+            if input_dir is None or not os.path.exists(bundle_conf_path):
+                log.error(
+                    'bndl: Missing bundle.conf (for source {})'.format(
+                        'stdin' if args.source is None else args.source
+                    )
+                )
+
+                return 2
 
             with open(bundle_conf_path, 'rb') as bundle_conf_fileobj:
                 bundle_conf_data = bundle_conf_fileobj.read()


### PR DESCRIPTION
This PR adjusts the circumstances under which a directory is considered for `conduct load`. When loading a bundle by name, if a directory exists with that same name, we only consider that directory viable if it contains a `bundle.conf` file.

Also improves error handling for `bndl` when given a directory without a `bundle.conf` - it used to blow up with a stack trace but now shows an error message.

Fixes #429.