### PR TITLE
Improve detection of a directory as a bundle

### DIFF
--- a/conductr_cli/resolvers/bintray_resolver.py
+++ b/conductr_cli/resolvers/bintray_resolver.py
@@ -1,9 +1,9 @@
 from conductr_cli.exceptions import MalformedBundleUriError, BintrayResolutionError, \
     BintrayCredentialsNotFoundError, MalformedBintrayCredentialsError
 from conductr_cli.resolvers import uri_resolver
+from conductr_cli.resolvers.resolvers_util import is_local_file
 from conductr_cli import bundle_shorthand
 from requests.exceptions import HTTPError, ConnectionError
-from urllib.parse import urlparse
 import json
 import logging
 import os
@@ -140,24 +140,6 @@ def continuous_delivery_uri(resolved_version):
         return 'deployments/{}/{}/{}'.format(resolved_version['org'], resolved_version['repo'], resolved_version['org'])
     else:
         return None
-
-
-def any_subdir_contains(dir, name):
-    for dir, sub_dirs, files in os.walk(dir):
-        if name in files:
-            return True
-
-    return False
-
-
-def is_local_file(uri, require_bundle_conf):
-    parsed = urlparse(uri, scheme='file')
-
-    return parsed.scheme == 'file' and os.path.exists(parsed.path) and (
-        not require_bundle_conf or os.path.isfile(parsed.path) or (
-            os.path.isdir(parsed.path) and any_subdir_contains(parsed.path, 'bundle.conf')
-        )
-    )
 
 
 def bintray_download_artefact(cache_dir, artefact, auth):

--- a/conductr_cli/resolvers/docker_resolver.py
+++ b/conductr_cli/resolvers/docker_resolver.py
@@ -1,9 +1,10 @@
 from collections import OrderedDict
 from conductr_cli import screen_utils
 from conductr_cli.constants import IO_CHUNK_SIZE
+from conductr_cli.resolvers.resolvers_util import is_local_file
 from functools import partial
 from requests.auth import HTTPBasicAuth
-from urllib.parse import urlencode, urlparse
+from urllib.parse import urlencode
 import gzip
 import hashlib
 import logging
@@ -169,7 +170,7 @@ def resolve_bundle(cache_dir, uri, auth=None):
 def do_resolve_bundle(cache_dir, uri, auth, offline_mode):
     log = logging.getLogger(__name__)
 
-    if is_local_file(uri):
+    if is_local_file(uri, require_bundle_conf=True):
         return False, None, None
 
     (provided_url, url), (provided_ns, ns), (provided_image, image), (provided_tag, tag) = parse_uri(uri)
@@ -276,11 +277,6 @@ def continuous_delivery_uri(resolved_version):
 
 def is_bundle_name(uri):
     return uri.count('/') == 0 and uri.count('.') == 0
-
-
-def is_local_file(uri):
-    parsed = urlparse(uri, scheme='file')
-    return parsed.scheme == 'file' and os.path.exists(parsed.path)
 
 
 def load_docker_credentials(server):

--- a/conductr_cli/resolvers/resolvers_util.py
+++ b/conductr_cli/resolvers/resolvers_util.py
@@ -1,0 +1,15 @@
+from conductr_cli.bndl_utils import detect_format_dir
+from urllib.parse import urlparse
+import os
+
+
+def is_local_file(uri, require_bundle_conf):
+    parsed = urlparse(uri, scheme='file')
+
+    return parsed.scheme == 'file' and os.path.exists(parsed.path) and (
+        os.path.isfile(parsed.path) or (
+            os.path.isdir(parsed.path) and
+            detect_format_dir(parsed.path) is not None and
+            (not require_bundle_conf or os.path.exists(os.path.join(parsed.path, 'bundle.conf')))
+        )
+    )

--- a/conductr_cli/resolvers/test/test_resolvers_util.py
+++ b/conductr_cli/resolvers/test/test_resolvers_util.py
@@ -1,0 +1,41 @@
+from unittest import TestCase
+from conductr_cli.resolvers import resolvers_util
+import os
+import shutil
+import tempfile
+
+
+class TestResolveBundle(TestCase):
+    def test_is_local_file_with_file(self):
+        with tempfile.NamedTemporaryFile() as temp:
+            self.assertTrue(resolvers_util.is_local_file(temp.name, require_bundle_conf=True))
+            self.assertTrue(resolvers_util.is_local_file(temp.name, require_bundle_conf=False))
+
+    def test_is_local_file_with_empty_dir(self):
+        temp = tempfile.mkdtemp()
+
+        try:
+            self.assertFalse(resolvers_util.is_local_file(temp, require_bundle_conf=True))
+            self.assertFalse(resolvers_util.is_local_file(temp, require_bundle_conf=False))
+        finally:
+            shutil.rmtree(temp)
+
+    def test_is_local_file_with_bundle_dir(self):
+        temp = tempfile.mkdtemp()
+        open(os.path.join(temp, 'bundle.conf'), 'w').close()
+
+        try:
+            self.assertTrue(resolvers_util.is_local_file(temp, require_bundle_conf=True))
+            self.assertTrue(resolvers_util.is_local_file(temp, require_bundle_conf=False))
+        finally:
+            shutil.rmtree(temp)
+
+    def test_is_local_file_with_bundle_conf_dir(self):
+        temp = tempfile.mkdtemp()
+        open(os.path.join(temp, 'runtime-config.sh'), 'w').close()
+
+        try:
+            self.assertFalse(resolvers_util.is_local_file(temp, require_bundle_conf=True))
+            self.assertTrue(resolvers_util.is_local_file(temp, require_bundle_conf=False))
+        finally:
+            shutil.rmtree(temp)


### PR DESCRIPTION
This PR improves the detection of a bundle (in a directory) introduced in the prior commit. It fixes a bug causing bundle directories to be loaded even though they weren't.

Fixes #431 