### PR TITLE
Add `bndl` to readme, fix argument help for `bndl`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -165,6 +165,16 @@ When the switch ``enabled`` is set to ``true``, HTTP Basic Authentication is ena
 
 If HTTP Basic Authentication is enabled then the CLI will send HTTP requests using HTTPS instead of HTTP.
 
+bndl
+^^^^
+
+The ``bndl`` command is used to create or modify bundles. It can be used for the following:
+
+- Creating a bundle from Docker and OCI images
+- Modifying a bundle's ``bundle.conf`` properties to add annotations, roles, etc.
+
+To learn more, see ``bndl -h``.
+
 shazar
 ^^^^^^
 

--- a/conductr_cli/bndl_main.py
+++ b/conductr_cli/bndl_main.py
@@ -36,31 +36,35 @@ def run(argv=None):
 
 
 def build_parser():
-    parser = argparse.ArgumentParser('bndl', formatter_class=argparse.RawTextHelpFormatter)
+    parser = argparse.ArgumentParser(prog='bndl',
+                                     formatter_class=argparse.RawTextHelpFormatter,
+                                     description='Create or modify a bundle')
 
     parser.add_argument('-f', '--format',
                         choices=['docker', 'oci-image', 'bundle'],
                         required=False,
-                        help='The input format. When absent, auto-detection is attempted')
+                        help='The input format\n'
+                             'When absent, auto-detection is attempted')
 
     parser.add_argument('--image-tag',
                         required=False,
-                        help='The name of the tag to create a ConductR bundle from. '
-                             'For use with docker and oci-image formats. When absent, '
-                             'the first tag present is used')
+                        help='The name of the tag to create a ConductR bundle from\n'
+                             'For use with docker and oci-image formats\n'
+                             'When absent, the first tag present is used')
 
     parser.add_argument('--image-name',
                         required=False,
-                        help='The name of the image to create a ConductR bundle from. '
-                             'For use with docker and oci-image formats. When absent, '
-                             'the first image present is used.')
+                        help='The name of the image to create a ConductR bundle from\n'
+                             'For use with docker and oci-image formats\n'
+                             'When absent, the first image present is used')
 
     parser.add_argument('-o', '--output',
                         nargs='?',
-                        help='The target output file. When absent, stdout is used')
+                        help='The target output file\n'
+                             'When absent, stdout is used')
 
     parser.add_argument('source',
-                        help='Optional path to a directory or tar file'
+                        help='Optional path to a directory or tar file\n'
                              'When absent, stdin is used',
                         nargs='?')
 
@@ -71,19 +75,19 @@ def build_parser():
                         action='store_false')
 
     parser.add_argument('--no-default-endpoints',
-                        help='If provided, a bundle will not contain endpoints for ExposedPorts. '
+                        help='If provided, a bundle will not contain endpoints for ExposedPorts\n'
                              'For use with docker and oci-image formats',
                         default=True,
                         dest='use_default_endpoints',
                         action='store_false')
 
     parser.add_argument('--with-check',
-                        help='If enabled, a "check" component will be added to the bundle"',
+                        help='If enabled, a "check" component will be added to the bundle',
                         default=False,
                         action='store_true')
 
     parser.add_argument('--component-description',
-                        help='Description to use for the generated ConductR component. '
+                        help='Description to use for the generated ConductR component\n'
                              'For use with docker and oci-image formats',
                         default='')
 


### PR DESCRIPTION
This PR updates docs/argument help.

```bash
$ bndl
usage: bndl [-h] [-f {docker,oci-image,bundle}] [--image-tag IMAGE_TAG]
            [--image-name IMAGE_NAME] [-o [OUTPUT]] [--no-shazar]
            [--no-default-endpoints] [--with-check]
            [--component-description COMPONENT_DESCRIPTION]
            [--annotation ANNOTATIONS]
            [--compatibility-version [COMPATIBILITY_VERSION]]
            [--disk-space [DISK_SPACE]] [--memory [MEMORY]] [--name [NAME]]
            [--nr-of-cpus [NR_OF_CPUS]] [--roles [ROLES [ROLES ...]]]
            [--system [SYSTEM]] [--system-version [SYSTEM_VERSION]]
            [--tag TAGS] [--version [VERSION]]
            [source]

Create or modify a bundle

positional arguments:
  source                Optional path to a directory or tar file
                        When absent, stdin is used

optional arguments:
  -h, --help            show this help message and exit
  -f {docker,oci-image,bundle}, --format {docker,oci-image,bundle}
                        The input format
                        When absent, auto-detection is attempted
  --image-tag IMAGE_TAG
                        The name of the tag to create a ConductR bundle from
                        For use with docker and oci-image formats
                        When absent, the first tag present is used
  --image-name IMAGE_NAME
                        The name of the image to create a ConductR bundle from
                        For use with docker and oci-image formats
                        When absent, the first image present is used
  -o [OUTPUT], --output [OUTPUT]
                        The target output file
                        When absent, stdout is used
  --no-shazar           If enabled, a bundle will not be run through shazar
  --no-default-endpoints
                        If provided, a bundle will not contain endpoints for ExposedPorts
                        For use with docker and oci-image formats
  --with-check          If enabled, a "check" component will be added to the bundle
  --component-description COMPONENT_DESCRIPTION
                        Description to use for the generated ConductR component
                        For use with docker and oci-image formats
  --annotation ANNOTATIONS
                        Annotations to add to bundle.conf
                        Example: bndl --annotation my.first=value1 --annotation my.second=value2
                        Defaults to []
  --compatibility-version [COMPATIBILITY_VERSION]
                        Sets the "compatibilityVersion" bundle.conf value
  --disk-space [DISK_SPACE]
                        Sets the "diskSpace" bundle.conf value
  --memory [MEMORY]     Sets the "memory" bundle.conf value
  --name [NAME]         Sets the "name" bundle.conf value
  --nr-of-cpus [NR_OF_CPUS]
                        Sets the "nrOfCpus" bundle.conf value
  --roles [ROLES [ROLES ...]]
                        Sets the "roles" bundle.conf value
  --system [SYSTEM]     Sets the "system" bundle.conf value
  --system-version [SYSTEM_VERSION]
                        Sets the "systemVersion" bundle.conf value
  --tag TAGS            Tags to add to bundle.conf
                        Example: bndl --tag 16.04 --tag xenial
                        Defaults to []
  --version [VERSION]   Sets the "version" bundle.conf value
-> 0
```