### PR TITLE
Preserve file permission when extracting zip file

### DIFF
--- a/conductr_cli/bndl_utils.py
+++ b/conductr_cli/bndl_utils.py
@@ -245,6 +245,9 @@ def zip_extract_with_dates(zip_file, into):
             zip.extract(info, into)
             t = time.mktime(info.date_time + (0, 0, -1))
             os.utime(os.path.join(into, info.filename), (t, t))
+            # Preserve bits 0-8 only: rwxrwxrwx
+            mode = info.external_attr >> 16 & 0x1FF
+            os.chmod(os.path.join(into, info.filename), mode)
 
 
 class DigestReaderWriter(object):


### PR DESCRIPTION
Preserve file permission when extracting the bundle zip file with the bndl command:

```
bndl -o ~/.conductr/cache/bundle/new/test-bundle-0.1.0-3db13899b82f0b6efd476b3427a9ff714964022fa59ceee66e23f671cdc340b5.zip ~/.conductr/cache/bundle/test-bundle-0.1.0-3db13899b82f0b6efd476b3427a9ff714964022fa59ceee66e23f671cdc340b5.zip
```

Preserving the file permissions is necessary so that the `start` script  can execute the `my-bundle/bin/my-bundle` script. Otherwise, the bundle can not be started successfully in ConductR (visualizer example):

```
2017-04-25T15:53:48.928Z mj-mbpro.local WARN  Reaper [bundleId=2d45f2fbc79e2ad3b6ad09db4a200f4a, sourceThread=conductr-agent-akka.actor.default-dispatcher-30, akkaTimestamp=15:53:48.928UTC, akkaSource=akka://conductr-agent/user/reaper, sourceActorSystem=conductr-agent] - /Users/mj/.conductr/images/tmp/conductr-agent/192.168.10.1/bundles/2d45f2fbc79e2ad3b6ad09db4a200f4a/execution-0-345914939589908482/start: line 105: visualizer/bin/visualizer: Permission denied
```

Python’s `ZipFile.extract` function is not preserving the file permissions, see https://bugs.python.org/issue15795.