### PR TITLE
bndl --check argument

### DIFF
--- a/conductr_cli/bndl_main.py
+++ b/conductr_cli/bndl_main.py
@@ -127,7 +127,7 @@ def build_parser():
 
     endpoint_args = parser.add_argument_group('endpoints')
     endpoint_args.add_argument('-e', '--endpoint',
-                               help='Endpoints to add to bundle.conf\n'
+                               help='Endpoints to add to bundle\n'
                                     'If specified, existing endpoints are removed\n'
                                     'Example: bndl --endpoint web --component web --bind-protocol http '
                                     '--service-name web --acl http:/subpath',
@@ -173,10 +173,34 @@ def build_parser():
                                dest='endpoint_dicts',
                                action=EndpointAction)
 
-    parser.add_argument('--with-check',
-                        help='If enabled, a "check" component will be added to the bundle',
-                        default=False,
-                        action='store_true')
+    check_args = parser.add_argument_group('check')
+    check_args.add_argument('--check',
+                            help='Check command that is added to the bundle\n'
+                                 'Specify one or multiple addresses that are used to check for bundle connectivity\n'
+                                 'As an address, environment variables can be specified that are available '
+                                 'during Bundle startup, e.g. $MY_BUNDLE_HOST\n'
+                                 'If specified, the existing check command is removed\n'
+                                 'Example: bndl --check \$WEB_BUNDLE_HOST \$BACKEND_BUNDLE_HOST\n'
+                                 'Accepted address formats:\n'
+                                 '  \$ENV/<path>?<params>\n'
+                                 '  [docker+]http://<address>:<port>/<path>?<params>\n'
+                                 '  [docker+]tcp://<address>:<port>?<params>\n'
+                                 'Accepted params:\n'
+                                 '  retry-count=<int> - Number of retries\n'
+                                 '  retry-delay=<int> - Delay in seconds between retries\n'
+                                 '  docker-timeout=<int> - Timeout in seconds for docker container start',
+                            nargs='+',
+                            dest='check_addresses')
+    check_args.add_argument('--connection-timeout',
+                            help='Connection timeout in seconds\n'
+                                 'Used in conjunction with the --check option',
+                            type=int,
+                            dest='check_connection_timeout')
+    check_args.add_argument('--initial-delay',
+                            help='Initial delay in seconds\n'
+                                 'Used in conjunction with the --check option',
+                            type=int,
+                            dest='check_initial_delay')
 
     parser.add_argument('--component-description',
                         help='Description to use for the generated ConductR component\n'

--- a/conductr_cli/bndl_oci.py
+++ b/conductr_cli/bndl_oci.py
@@ -1,5 +1,5 @@
 from pyhocon import HOCONConverter, ConfigFactory, ConfigTree
-from conductr_cli.bndl_utils import load_bundle_args_into_conf
+from conductr_cli.bndl_utils import load_bundle_args_into_conf, create_check_hocon
 import json
 import os
 import re
@@ -9,7 +9,7 @@ import tempfile
 
 def oci_image_bundle_conf(args, component_name, oci_manifest, oci_config):
     conf = ConfigFactory.parse_string('')
-    load_bundle_args_into_conf(conf, args, with_defaults=True)
+    load_bundle_args_into_conf(conf, args, with_defaults=True, validate_components=False)
 
     if 'annotations' in oci_manifest and oci_manifest['annotations'] is not None:
         annotations_tree = conf.get('annotations')
@@ -46,12 +46,8 @@ def oci_image_bundle_conf(args, component_name, oci_manifest, oci_config):
 
             endpoints_tree.put(name, entry_tree)
 
-        if len(check_arguments) > 0:
-            oci_check_tree = ConfigTree()
-            oci_check_tree.put('description', 'Status check for oci-image component')
-            oci_check_tree.put('file-system-type', 'universal')
-            oci_check_tree.put('start-command', ['check'] + check_arguments)
-            oci_check_tree.put('endpoints', {})
+        if check_arguments:
+            oci_check_tree = create_check_hocon(check_arguments)
 
             components_tree = ConfigTree()
             components_tree.put(component_name, oci_tree)

--- a/conductr_cli/test/test_bndl_main.py
+++ b/conductr_cli/test/test_bndl_main.py
@@ -50,7 +50,13 @@ class TestBndl(CliTestCase):
             '--roles',
             'web',
             'backend',
-            '--with-check',
+            '--check',
+            '\$MY_ENV/path',
+            'http://192.168.10.1:9999',
+            '--connection-timeout',
+            '4',
+            '--initial-delay',
+            '5',
             '--no-default-endpoints',
             '--endpoint',
             'web',
@@ -87,6 +93,9 @@ class TestBndl(CliTestCase):
         self.assertEqual(args.disk_space, 16384)
         self.assertEqual(args.roles, ['web', 'backend'])
         self.assertEqual(args.annotations, ['com.lightbend.test=hello world', 'description=this is a test'])
+        self.assertEqual(args.check_addresses, ['\\$MY_ENV/path', 'http://192.168.10.1:9999'])
+        self.assertEqual(args.check_connection_timeout, 4)
+        self.assertEqual(args.check_initial_delay, 5)
         self.assertFalse(args.use_default_endpoints)
         self.assertEqual(args.endpoint_dicts, [
             {

--- a/conductr_cli/test/test_bndl_oci.py
+++ b/conductr_cli/test/test_bndl_oci.py
@@ -239,7 +239,7 @@ class TestBndlOci(CliTestCase):
                             |    }
                             |  }
                             |  my-component-status {
-                            |    description = "Status check for oci-image component"
+                            |    description = "Status check for the bundle component"
                             |    file-system-type = "universal"
                             |    start-command = [
                             |      "check"
@@ -349,7 +349,7 @@ class TestBndlOci(CliTestCase):
                             |    }
                             |  }
                             |  my-component-status {
-                            |    description = "Status check for oci-image component"
+                            |    description = "Status check for the bundle component"
                             |    file-system-type = "universal"
                             |    start-command = [
                             |      "check"
@@ -431,7 +431,7 @@ class TestBndlOci(CliTestCase):
                             |    }
                             |  }
                             |  my-component-status {
-                            |    description = "Status check for oci-image component"
+                            |    description = "Status check for the bundle component"
                             |    file-system-type = "universal"
                             |    start-command = [
                             |      "check"

--- a/conductr_cli/validation.py
+++ b/conductr_cli/validation.py
@@ -537,6 +537,22 @@ def handle_license_download_error(func):
     return handler
 
 
+def handle_bndl_create_error(func):
+    def handler(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except (ValueError, SyntaxError) as e:
+            log = get_logger_for_func(func)
+            log.error('bndl: {}'.format(e))
+            return 2
+
+            # Do not change the wrapped function name,
+            # so argparse configuration can be tested.
+    handler.__name__ = func.__name__
+
+    return handler
+
+
 def format_timestamp(timestamp, args):
     date = arrow.get(timestamp)
     date_display = date.to('UTC') if args.utc else date.to('local')


### PR DESCRIPTION
The bndl --check argument allows to add or replace an existing status component with a given start command to check the connectivity for a bundle.

**bndl --check help**

```
check:
  --check CHECK_ADDRESSES [CHECK_ADDRESSES ...]
                        Check command that is added to the bundle
                        Specify one or multiple addresses that are used to check for bundle connectivity
                        As an address, environment variables can be specified that are available during Bundle startup, e.g. $MY_BUNDLE_HOST
                        If specified, the existing check command is removed
                        Example: bndl --check \$WEB_BUNDLE_HOST \$BACKEND_BUNDLE_HOST
                        Accepted address formats:
                          \$ENV/<path>?<params>
                          [docker+]http://<address>:<port>/<path>?<params>
                          [docker+]tcp://<address>:<port>?<params>
                        Accepted params:
                          retry-count=<int> - Number of retries
                          retry-delay=<int> - Delay in seconds between retries
                          docker-timeout=<int> - Timeout in seconds for docker container start
  --connection-timeout CHECK_CONNECTION_TIMEOUT
                        Connection timeout in seconds
                        Used in conjunction with the --check option
  --initial-delay CHECK_INITIAL_DELAY
                        Initial delay in seconds
                        Used in conjunction with the --check option
```