### PR TITLE
Auto-detection of endpoint component

### DIFF
--- a/conductr_cli/bndl_main.py
+++ b/conductr_cli/bndl_main.py
@@ -65,10 +65,6 @@ def set_endpoints(args):
         for endpoint_dict in args.endpoint_dicts:
             try:
                 endpoint = Endpoint(endpoint_dict)
-            except ValueError:
-                log.error('bndl: argument --component is required when specifying argument --endpoint {}'
-                          .format(endpoint_dict['name']))
-                sys.exit(2)
             except AmbigousBindProtocolError:
                 log.error('bndl: argument --bind-protocol is required '
                           'when acls with different protocol families are specified\n'
@@ -127,18 +123,20 @@ def build_parser():
 
     endpoint_args = parser.add_argument_group('endpoints')
     endpoint_args.add_argument('-e', '--endpoint',
-                               help='Endpoints to add to bundle\n'
+                               help='Endpoints that are added to the bundle\n'
                                     'If specified, existing endpoints are removed\n'
                                     'Example: bndl --endpoint web --component web --bind-protocol http '
                                     '--service-name web --acl http:/subpath',
-                               metavar='ENDPOINT [OPTS]',
+                               metavar='ENDPOINT',
                                dest='endpoint_dicts',
                                default=[],
                                action=EndpointAction)
     endpoint_args.add_argument('--component',
                                help='Component to which an endpoint should be added\n'
                                     'Used in conjunction with the --endpoint option\n'
-                                    'Required when specifying the --endpoint option',
+                                    'When absent, the endpoints of the first component are replaced\n'
+                                    'Required when a bundle has more than one component\n'
+                                    'The component bundle-status is not counted',
                                metavar='COMPONENT',
                                dest='endpoint_dicts',
                                action=EndpointAction)

--- a/conductr_cli/endpoint.py
+++ b/conductr_cli/endpoint.py
@@ -10,8 +10,6 @@ class Endpoint:
 
         if 'component' in endpoint_dict:
             self.component = endpoint_dict['component']
-        else:
-            raise ValueError('could not find {} in {}'.format('component', endpoint_dict))
 
         self.acls = []
         grouped_acls = defaultdict(list)

--- a/conductr_cli/test/test_bndl_main.py
+++ b/conductr_cli/test/test_bndl_main.py
@@ -224,25 +224,6 @@ class TestBndl(CliTestCase):
         finally:
             shutil.rmtree(temp)
 
-    def test_warn_no_endpoint_component(self):
-        bndl_mock = MagicMock()
-        stdout_mock = MagicMock()
-        stderr_mock = MagicMock()
-        configure_logging_mock = MagicMock()
-        bndl_main.logging_setup.configure_logging(MagicMock(), stdout_mock, stderr_mock)
-
-        with \
-                patch('conductr_cli.bndl_main.bndl', bndl_mock), \
-                patch('sys.stdout.isatty', lambda: False), \
-                patch('conductr_cli.logging_setup.configure_logging', configure_logging_mock), \
-                patch('sys.stdin.isatty', lambda: False):
-            self.assertRaises(SystemExit, bndl_main.run, ['-o', '-', '-', '--endpoint', 'web'])
-
-        self.assertEqual(
-            self.output(stderr_mock),
-            as_error('Error: bndl: argument --component is required when specifying argument --endpoint web\n')
-        )
-
     def test_warn_ambigous_bind_protocol(self):
         bndl_mock = MagicMock()
         stdout_mock = MagicMock()


### PR DESCRIPTION
Improves the `bndl --endpoint` argument by:
- Auto-detecting the endpoint component from the `bundle.conf` if the `--component` is not specified. Only works if one component in `bundle.conf` exist. If multiple components exist and the `--component` arg is not specified then a validation error is returned. The `bundle-status` component is excluded from the multiple endpoints list, i.e. is not counted.
- Adding a check if the `bundle.conf` contains at least one component. If not, a validation error is returned.
- Adding a check if the specified endpoint component exists in the `bundle.conf`. If not, a validation error is returned.

Fixes https://github.com/typesafehub/conductr-cli/issues/441.