### PR TITLE
`conduct load-license` prompt improvements

### DIFF
--- a/conductr_cli/license_auth.py
+++ b/conductr_cli/license_auth.py
@@ -1,5 +1,6 @@
 from conductr_cli.constants import DEFAULT_AUTH_TOKEN_FILE
 import os
+import sys
 try:
     import readline
 except ImportError:
@@ -7,7 +8,7 @@ except ImportError:
 
 
 AUTH_TOKEN_PROMPT = '\nAn access token is required. Please visit https://www.lightbend.com/account/access-token to \n' \
-                    'obtain one, and a free license or your commercial one.\n' \
+                    'obtain one for free and commercial licenses.\n' \
                     '\n' \
                     'Please enter your access token: '
 
@@ -34,7 +35,10 @@ def prompt_for_auth_token():
     readline.clear_history()
 
     try:
-        return input(AUTH_TOKEN_PROMPT).strip()
+        if sys.stdin.isatty():
+            return input(AUTH_TOKEN_PROMPT).strip()
+        else:
+            return input().strip()
     except EOFError:
         return ''
 

--- a/conductr_cli/test/test_license_auth.py
+++ b/conductr_cli/test/test_license_auth.py
@@ -39,10 +39,24 @@ class TestPromptForAuthToken(TestCase):
         mock_input = MagicMock(return_value=auth_token)
 
         with patch('builtins.print', mock_print), \
-                patch('builtins.input', mock_input):
+                patch('builtins.input', mock_input), \
+                patch('sys.stdin.isatty', lambda: True):
             self.assertEqual(auth_token, license_auth.prompt_for_auth_token())
 
         mock_input.assert_called_once_with(license_auth.AUTH_TOKEN_PROMPT)
+
+    def test_no_tty_dont_prompt_for_auth_token(self):
+        auth_token = 'test auth token'
+
+        mock_print = MagicMock()
+        mock_input = MagicMock(return_value=auth_token)
+
+        with patch('builtins.print', mock_print), \
+                patch('builtins.input', mock_input), \
+                patch('sys.stdin.isatty', lambda: False):
+            self.assertEqual(auth_token, license_auth.prompt_for_auth_token())
+
+        mock_input.assert_called_once_with()
 
 
 class TestRemoveCachedAuthToken(TestCase):


### PR DESCRIPTION
This fixes `conduct load-license` to no longer display the "access token" prompt language if programmatically providing one, e.g. via file redirection. It also slightly tweaks the prompt language.

Fixes #445 