### PR TITLE
Package cacert file in native executable builds

### DIFF
--- a/bndl.spec
+++ b/bndl.spec
@@ -1,0 +1,31 @@
+# -*- mode: python -*-
+
+import os
+
+
+block_cipher = None
+
+
+a = Analysis(['conductr_cli/bndl.py'],
+             pathex=[os.path.abspath(os.getcwd())],
+             binaries=[],
+             datas=[],
+             hiddenimports=[],
+             hookspath=[],
+             runtime_hooks=[],
+             excludes=[],
+             win_no_prefer_redirects=False,
+             win_private_assemblies=False,
+             cipher=block_cipher)
+pyz = PYZ(a.pure, a.zipped_data,
+             cipher=block_cipher)
+exe = EXE(pyz,
+          a.scripts,
+          a.binaries,
+          a.zipfiles,
+          a.datas,
+          name='bndl',
+          debug=False,
+          strip=False,
+          upx=True,
+          console=True )

--- a/conduct.spec
+++ b/conduct.spec
@@ -1,0 +1,53 @@
+# -*- mode: python -*-
+
+from PyInstaller.compat import is_darwin
+import os
+
+
+if is_darwin:
+    # Include Python's cacert file as part of the packaged native executable.
+    # This is because in OSX the OpenSSL from Macports and Homebrew doesn't fallback to CA certs stored in OSX keychain
+    # tool.
+    # The workaround is based on this PyInstaller recipe:
+    # https://github.com/pyinstaller/pyinstaller/wiki/Recipe-OpenSSL-Certificate
+    #
+    # and its corresponding PR:
+    # https://github.com/pyinstaller/pyinstaller/pull/1411/files
+    #
+    # This workaround relies on setting SSL_CERT_FILE environment variable, and this environment variable is applicable
+    # on Python 3.4 and 3.5: https://bugs.python.org/issue22449
+    #
+    # Some further info on how OSX OpenSSL cert validation:
+    # https://hynek.me/articles/apple-openssl-verification-surprises/
+    #
+    import ssl
+    cert_datas = [(ssl.get_default_verify_paths().cafile, 'lib')]
+else:
+    cert_datas = []
+
+block_cipher = None
+
+
+a = Analysis(['conductr_cli/conduct.py'],
+             pathex=[os.path.abspath(os.getcwd())],
+             binaries=[],
+             datas=cert_datas,
+             hiddenimports=[],
+             hookspath=[],
+             runtime_hooks=[],
+             excludes=[],
+             win_no_prefer_redirects=False,
+             win_private_assemblies=False,
+             cipher=block_cipher)
+pyz = PYZ(a.pure, a.zipped_data,
+             cipher=block_cipher)
+exe = EXE(pyz,
+          a.scripts,
+          a.binaries,
+          a.zipfiles,
+          a.datas,
+          name='conduct',
+          debug=False,
+          strip=False,
+          upx=True,
+          console=True )

--- a/conductr_cli/conduct.py
+++ b/conductr_cli/conduct.py
@@ -1,4 +1,25 @@
 from conductr_cli import main_handler
+import sys
+import os
+
+
+if getattr(sys, 'frozen', False):
+    # Assume Python's cacert file is included as part of the packaged native executable.
+    # This is because in OSX the OpenSSL from Macports and Homebrew doesn't fallback to CA certs stored in OSX keychain
+    # tool.
+    # The workaround is based on this PyInstaller recipe:
+    # https://github.com/pyinstaller/pyinstaller/wiki/Recipe-OpenSSL-Certificate
+    #
+    # and its corresponding PR:
+    # https://github.com/pyinstaller/pyinstaller/pull/1411/files
+    #
+    # This workaround relies on setting SSL_CERT_FILE environment variable, and this environment variable is applicable
+    # on Python 3.4 and 3.5: https://bugs.python.org/issue22449
+    #
+    # Some further info on how OSX OpenSSL cert validation:
+    # https://hynek.me/articles/apple-openssl-verification-surprises/
+    #
+    os.environ['SSL_CERT_FILE'] = os.path.join(sys._MEIPASS, 'lib', 'cert.pem')
 
 
 def main_method():

--- a/conductr_cli/exceptions.py
+++ b/conductr_cli/exceptions.py
@@ -120,6 +120,16 @@ class SandboxImageNotFoundError(Exception):
         return repr('{} {}'.format(self.component_type, self.image_version))
 
 
+class SandboxImageFetchError(Exception):
+    def __init__(self, component_type, image_version, cause):
+        self.component_type = component_type
+        self.image_version = image_version
+        self.cause = cause
+
+    def __str(self):
+        return repr('{} {} {}'.format(self.component_type, self.image_version, self.cause))
+
+
 class SandboxImageNotAvailableOfflineError(Exception):
     def __init__(self, image_version):
         self.image_version = image_version

--- a/conductr_cli/resolvers/bintray_resolver.py
+++ b/conductr_cli/resolvers/bintray_resolver.py
@@ -143,9 +143,9 @@ def continuous_delivery_uri(resolved_version):
         return None
 
 
-def bintray_download_artefact(cache_dir, artefact, auth):
+def bintray_download_artefact(cache_dir, artefact, auth, raise_error=False):
     if artefact:
-        return uri_resolver.resolve_file(cache_dir, artefact['download_url'], auth)
+        return uri_resolver.resolve_file(cache_dir, artefact['download_url'], auth, raise_error)
     else:
         return False, None, None
 

--- a/conductr_cli/resolvers/test/test_bintray_resolver.py
+++ b/conductr_cli/resolvers/test/test_bintray_resolver.py
@@ -42,7 +42,7 @@ class TestResolveBundle(TestCase):
         bintray_resolve_version_mock.assert_called_with(self.bintray_auth, 'typesafe', 'bundle', 'bundle-name',
                                                         'v1', 'digest')
         resolve_bundle_mock.assert_called_with('/cache-dir', 'https://dl.bintray.com/typesafe/bundle/download.zip',
-                                               self.bintray_auth)
+                                               self.bintray_auth, False)
 
     def test_bintray_version_not_found(self):
         load_bintray_credentials_mock = MagicMock(return_value=self.bintray_auth)
@@ -162,7 +162,8 @@ class TestResolveBundleConfiguration(TestCase):
                                                         'bundle-name', 'v1', 'digest')
         resolve_bundle_mock.assert_called_with('/cache-dir',
                                                'https://dl.bintray.com/typesafe/bundle-configuration/download.zip',
-                                               self.bintray_auth)
+                                               self.bintray_auth,
+                                               False)
 
     def test_bintray_version_not_found(self):
         load_bintray_credentials_mock = MagicMock(return_value=self.bintray_auth)

--- a/conductr_cli/resolvers/uri_resolver.py
+++ b/conductr_cli/resolvers/uri_resolver.py
@@ -14,7 +14,7 @@ def resolve_bundle(cache_dir, uri, auth=None):
     return resolve_file(cache_dir, uri, auth)
 
 
-def resolve_file(cache_dir, uri, auth=None, require_bundle_conf=True):
+def resolve_file(cache_dir, uri, auth=None, require_bundle_conf=True, raise_error=False):
     log = logging.getLogger(__name__)
 
     if not os.path.exists(cache_dir):
@@ -41,8 +41,11 @@ def resolve_file(cache_dir, uri, auth=None, require_bundle_conf=True):
         os.chmod(tmp_download_path, 0o600)
         shutil.move(tmp_download_path, cached_file)
         return True, file_name, cached_file
-    except URLError:
-        return False, None, None
+    except URLError as e:
+        if raise_error:
+            raise e
+        else:
+            return False, None, None
 
 
 def load_bundle_from_cache(cache_dir, uri):

--- a/conductr_cli/sandbox.py
+++ b/conductr_cli/sandbox.py
@@ -1,4 +1,25 @@
 from conductr_cli import main_handler
+import sys
+import os
+
+
+if getattr(sys, 'frozen', False):
+    # Assume Python's cacert file is included as part of the packaged native executable.
+    # This is because in OSX the OpenSSL from Macports and Homebrew doesn't fallback to CA certs stored in OSX keychain
+    # tool.
+    # The workaround is based on this PyInstaller recipe:
+    # https://github.com/pyinstaller/pyinstaller/wiki/Recipe-OpenSSL-Certificate
+    #
+    # and its corresponding PR:
+    # https://github.com/pyinstaller/pyinstaller/pull/1411/files
+    #
+    # This workaround relies on setting SSL_CERT_FILE environment variable, and this environment variable is applicable
+    # on Python 3.4 and 3.5: https://bugs.python.org/issue22449
+    #
+    # Some further info on how OSX OpenSSL cert validation:
+    # https://hynek.me/articles/apple-openssl-verification-surprises/
+    #
+    os.environ['SSL_CERT_FILE'] = os.path.join(sys._MEIPASS, 'lib', 'cert.pem')
 
 
 def main_method():

--- a/conductr_cli/sandbox_run.py
+++ b/conductr_cli/sandbox_run.py
@@ -12,6 +12,7 @@ import sys
 @validation.handle_http_error
 @validation.handle_instance_count_error
 @validation.handle_bind_address_not_found
+@validation.handle_sandbox_image_fetch_error
 @validation.handle_sandbox_image_not_found_error
 @validation.handle_sandbox_image_not_available_offline_error
 @validation.handle_sandbox_unsupported_os_error

--- a/package-native-zip.sh
+++ b/package-native-zip.sh
@@ -38,25 +38,25 @@ echo "------------------------------------------------"
 echo "Creating single executable for 'conduct' command"
 echo "------------------------------------------------"
 echo ""
-pyinstaller --onefile conductr_cli/conduct.py
+pyinstaller --onefile conduct.spec
 
 echo "------------------------------------------------"
 echo "Creating single executable for 'sandbox' command"
 echo "------------------------------------------------"
 echo ""
-pyinstaller --hidden-import psutil --onefile conductr_cli/sandbox.py
+pyinstaller --onefile sandbox.spec
 
 echo "------------------------------------------------"
 echo "Creating single executable for 'shazar' command"
 echo "------------------------------------------------"
 echo ""
-pyinstaller --onefile conductr_cli/shazar.py
+pyinstaller --onefile shazar.spec
 
 echo "------------------------------------------------"
 echo "Creating single executable for 'bndl' command"
 echo "------------------------------------------------"
 echo ""
-pyinstaller --onefile conductr_cli/bndl.py
+pyinstaller --onefile bndl.spec
 
 
 echo "------------------------------------------------"

--- a/sandbox.spec
+++ b/sandbox.spec
@@ -1,0 +1,53 @@
+# -*- mode: python -*-
+
+from PyInstaller.compat import is_darwin
+import os
+
+
+if is_darwin:
+    # Include Python's cacert file as part of the packaged native executable.
+    # This is because in OSX the OpenSSL from Macports and Homebrew doesn't fallback to CA certs stored in OSX keychain
+    # tool.
+    # The workaround is based on this PyInstaller recipe:
+    # https://github.com/pyinstaller/pyinstaller/wiki/Recipe-OpenSSL-Certificate
+    #
+    # and its corresponding PR:
+    # https://github.com/pyinstaller/pyinstaller/pull/1411/files
+    #
+    # This workaround relies on setting SSL_CERT_FILE environment variable, and this environment variable is applicable
+    # on Python 3.4 and 3.5: https://bugs.python.org/issue22449
+    #
+    # Some further info on how OSX OpenSSL cert validation:
+    # https://hynek.me/articles/apple-openssl-verification-surprises/
+    #
+    import ssl
+    cert_datas = [(ssl.get_default_verify_paths().cafile, 'lib')]
+else:
+    cert_datas = []
+
+block_cipher = None
+
+
+a = Analysis(['conductr_cli/sandbox.py'],
+             pathex=[os.path.abspath(os.getcwd())],
+             binaries=[],
+             datas=cert_datas,
+             hiddenimports=['psutil'],
+             hookspath=[],
+             runtime_hooks=[],
+             excludes=[],
+             win_no_prefer_redirects=False,
+             win_private_assemblies=False,
+             cipher=block_cipher)
+pyz = PYZ(a.pure, a.zipped_data,
+             cipher=block_cipher)
+exe = EXE(pyz,
+          a.scripts,
+          a.binaries,
+          a.zipfiles,
+          a.datas,
+          name='sandbox',
+          debug=False,
+          strip=False,
+          upx=True,
+          console=True )

--- a/shazar.spec
+++ b/shazar.spec
@@ -1,0 +1,29 @@
+# -*- mode: python -*-
+
+import os
+block_cipher = None
+
+
+a = Analysis(['conductr_cli/shazar.py'],
+             pathex=[os.path.abspath(os.getcwd())],
+             binaries=[],
+             datas=[],
+             hiddenimports=[],
+             hookspath=[],
+             runtime_hooks=[],
+             excludes=[],
+             win_no_prefer_redirects=False,
+             win_private_assemblies=False,
+             cipher=block_cipher)
+pyz = PYZ(a.pure, a.zipped_data,
+             cipher=block_cipher)
+exe = EXE(pyz,
+          a.scripts,
+          a.binaries,
+          a.zipfiles,
+          a.datas,
+          name='shazar',
+          debug=False,
+          strip=False,
+          upx=True,
+          console=True )


### PR DESCRIPTION
This is because in OSX the OpenSSL from Macports and Homebrew doesn't fallback to CA certs stored in OSX keychain tool.

The workaround is based on this PyInstaller recipe:
https://github.com/pyinstaller/pyinstaller/wiki/Recipe-OpenSSL-Certificate

and its corresponding PR:
https://github.com/pyinstaller/pyinstaller/pull/1411/files

This workaround relies on setting `SSL_CERT_FILE` environment variable, and this environment variable is applicable on Python 3.4 and 3.5: https://bugs.python.org/issue22449

Some further info on how OSX OpenSSL cert validation works:
https://hynek.me/articles/apple-openssl-verification-surprises/

**Improve error reporting for Sandbox image download**

When sandbox image download encounters `HTTPError` or `URLError`, this now will be reported in the error message.

Only `HTTPError` raised from HTTP status code `404` is displayed with "Sandbox not found" error message.