### PR TITLE
Add `--no-default-check` to `bndl`

### DIFF
--- a/conductr_cli/bndl_main.py
+++ b/conductr_cli/bndl_main.py
@@ -121,6 +121,13 @@ def build_parser():
                         dest='use_default_endpoints',
                         action='store_false')
 
+    parser.add_argument('--no-default-check',
+                        help='If provided, a bundle will not contain a default check command\n'
+                             'For use with docker and oci-image formats',
+                        default=True,
+                        dest='use_default_check',
+                        action='store_false')
+
     endpoint_args = parser.add_argument_group('endpoints')
     endpoint_args.add_argument('-e', '--endpoint',
                                help='Endpoints that are added to the bundle\n'

--- a/conductr_cli/bndl_oci.py
+++ b/conductr_cli/bndl_oci.py
@@ -46,7 +46,7 @@ def oci_image_bundle_conf(args, component_name, oci_manifest, oci_config):
 
             endpoints_tree.put(name, entry_tree)
 
-        if check_arguments:
+        if args.use_default_check and check_arguments:
             oci_check_tree = create_check_hocon(check_arguments)
 
             components_tree = ConfigTree()

--- a/conductr_cli/test/test_bndl_oci.py
+++ b/conductr_cli/test/test_bndl_oci.py
@@ -196,6 +196,7 @@ class TestBndlOci(CliTestCase):
             'component_description': 'testing desc 1',
             'image_tag': 'testing',
             'use_default_endpoints': True,
+            'use_default_check': True,
             'annotations': []
         })
 
@@ -301,6 +302,7 @@ class TestBndlOci(CliTestCase):
             'component_description': 'testing desc 1',
             'image_tag': 'testing',
             'use_default_endpoints': True,
+            'use_default_check': True,
             'annotations': {}
         })
 
@@ -361,6 +363,63 @@ class TestBndlOci(CliTestCase):
                             |}''')
         )
 
+    def test_oci_image_with_default_endpoints_no_check(self):
+        base_args = create_attributes_object({
+            'name': 'world',
+            'component_description': 'testing desc 1',
+            'image_tag': 'testing',
+            'use_default_endpoints': True,
+            'use_default_check': False,
+            'annotations': {}
+        })
+
+        config = {
+            'config': {
+                'ExposedPorts': {'80/tcp': {}, '8080/udp': {}}
+            }
+        }
+
+        self.assertEqual(
+            bndl_oci.oci_image_bundle_conf(base_args, 'my-component', {}, config),
+            strip_margin('''|annotations {}
+                            |compatibilityVersion = "0"
+                            |diskSpace = 1073741824
+                            |memory = 402653184
+                            |name = "world"
+                            |nrOfCpus = 0.1
+                            |roles = [
+                            |  "web"
+                            |]
+                            |system = "world"
+                            |systemVersion = "1"
+                            |tags = [
+                            |  "testing"
+                            |]
+                            |version = "1"
+                            |components {
+                            |  my-component {
+                            |    description = "testing desc 1"
+                            |    file-system-type = "oci-image"
+                            |    start-command = [
+                            |      "ociImageTag"
+                            |      "testing"
+                            |    ]
+                            |    endpoints {
+                            |      my-component-tcp-80 {
+                            |        bind-protocol = "tcp"
+                            |        bind-port = 80
+                            |        service-name = "my-component-tcp-80"
+                            |      }
+                            |      my-component-udp-8080 {
+                            |        bind-protocol = "udp"
+                            |        bind-port = 8080
+                            |        service-name = "my-component-udp-8080"
+                            |      }
+                            |    }
+                            |  }
+                            |}''')
+        )
+
     def test_oci_image_annotations(self):
         self.maxDiff = None
 
@@ -369,6 +428,7 @@ class TestBndlOci(CliTestCase):
             'component_description': 'testing desc 1',
             'image_tag': 'testing',
             'use_default_endpoints': True,
+            'use_default_check': True,
             'annotations': []
         })
 


### PR DESCRIPTION
This PR adds a flag, `--no-default-check` to `bndl`. The use-case would be a docker/oci image that uses `conductr-lib` and exposes ports. The user may want the default endpoints but not the default check command so with this flag we can support that case.