### PR TITLE
Check for bundle-status component

### DIFF
--- a/conductr_cli/bndl_oci.py
+++ b/conductr_cli/bndl_oci.py
@@ -51,7 +51,7 @@ def oci_image_bundle_conf(args, component_name, oci_manifest, oci_config):
 
             components_tree = ConfigTree()
             components_tree.put(component_name, oci_tree)
-            components_tree.put('{}-status'.format(component_name), oci_check_tree)
+            components_tree.put('bundle-status', oci_check_tree)
 
     conf.put('components', components_tree)
 

--- a/conductr_cli/bndl_utils.py
+++ b/conductr_cli/bndl_utils.py
@@ -166,18 +166,11 @@ def load_bundle_args_into_conf(config, args, with_defaults, validate_components)
         check_args += args_check_addresses
 
         if 'components' in config:
-            status_component_names = [component for component in config.get('components')
-                                      if component.endswith('-status')]
-            if not status_component_names:
-                first_component_name = [component for component in config.get('components')][0]
-                check_tree = create_check_hocon(check_args)
-                config.put('components.{}-status'.format(first_component_name), check_tree)
-            elif len(status_component_names) == 1:
-                config.put('components.{}.start-command'.format(status_component_names[0]), ['check'] + check_args)
+            if 'bundle-status' in config.get('components'):
+                config.put('components.bundle-status.start-command', ['check'] + check_args)
             else:
-                raise SyntaxError('Unable to add check command. '
-                                  'bundle.conf contains multiple components that are ending with -status: {}'
-                                  .format(status_component_names))
+                check_tree = create_check_hocon(check_args)
+                config.put('components.bundle-status', check_tree)
         elif validate_components:
             raise SyntaxError('Unable to add check command. bundle.conf does not contain any components')
 
@@ -279,7 +272,7 @@ def detect_endpoint_component(config, endpoint):
                              .format(endpoint.component, component_names))
     else:
         non_status_component_names = [component for component in config.get('components')
-                                      if not component.endswith('-status')]
+                                      if component != 'bundle-status']
         if len(non_status_component_names) == 1:
             return non_status_component_names[0]
         else:

--- a/conductr_cli/test/test_bndl_oci.py
+++ b/conductr_cli/test/test_bndl_oci.py
@@ -239,7 +239,7 @@ class TestBndlOci(CliTestCase):
                             |      }
                             |    }
                             |  }
-                            |  my-component-status {
+                            |  bundle-status {
                             |    description = "Status check for the bundle component"
                             |    file-system-type = "universal"
                             |    start-command = [
@@ -350,7 +350,7 @@ class TestBndlOci(CliTestCase):
                             |      }
                             |    }
                             |  }
-                            |  my-component-status {
+                            |  bundle-status {
                             |    description = "Status check for the bundle component"
                             |    file-system-type = "universal"
                             |    start-command = [
@@ -490,7 +490,7 @@ class TestBndlOci(CliTestCase):
                             |      }
                             |    }
                             |  }
-                            |  my-component-status {
+                            |  bundle-status {
                             |    description = "Status check for the bundle component"
                             |    file-system-type = "universal"
                             |    start-command = [

--- a/conductr_cli/test/test_bndl_utils.py
+++ b/conductr_cli/test/test_bndl_utils.py
@@ -576,28 +576,3 @@ class TestBndlUtils(CliTestCase):
         no_components_config = ConfigFactory.parse_string(strip_margin("""|{}"""))
         self.assertRaises(SyntaxError, bndl_utils.load_bundle_args_into_conf, no_components_config, check_args,
                           False, True)
-
-        # test that check component cannot be added because multiple status components were found
-        multiple_check_config = ConfigFactory.parse_string(strip_margin(
-            """|{
-               |  components {
-               |    bundle-status {
-               |      description = "bundle-status"
-               |      file-system-type = "universal"
-               |      start-command = [
-               |        "check",
-               |        "$SOME_BUNDLE_HOST"
-               |      ]
-               |    },
-               |    my-status {
-               |      description = "my-status"
-               |      file-system-type = "universal"
-               |      start-command = [
-               |        "check",
-               |        "$MY_BUNDLE_HOST"
-               |      ]
-               |    }
-               |  }
-               |}"""))
-        self.assertRaises(SyntaxError, bndl_utils.load_bundle_args_into_conf, multiple_check_config, check_args,
-                          False, True)


### PR DESCRIPTION
The status check component is now named `bundle-status` in the newest `sbt-conductr` version. In the `conductr-cli`, we now detecting the status check component by this name instead of searching for the substring `-status`. This change makes the detection more bulletproof, e.g. we also detect the correct status check component if the `bundle.conf` contains additional components that contain `-status` in the name.