### PR TITLE
Implement `--env` flag for `bndl` and allow `conduct load` to respect `bndl` arguments

### DIFF
--- a/conductr_cli/bndl_create.py
+++ b/conductr_cli/bndl_create.py
@@ -54,6 +54,7 @@ def bndl_create(args):
     component_dir = os.path.join(temp_dir, component_name)
     mtime = None
     bundle_conf_data = b''
+    runtime_conf_data = b''
 
     try:
         process_oci = False
@@ -137,7 +138,7 @@ def bndl_create(args):
                 return 2
 
             input_dir = find_bundle_conf_dir(temp_dir)
-            bundle_conf_path = os.path.join(input_dir, 'bundle.conf')
+            bundle_conf_path = '' if not input_dir else os.path.join(input_dir, 'bundle.conf')
 
             if not input_dir or not os.path.exists(bundle_conf_path):
                 log.error(
@@ -153,7 +154,23 @@ def bndl_create(args):
 
             os.unlink(bundle_conf_path)
 
-            if not args.name:
+            runtime_conf_path = os.path.join(input_dir, 'runtime-config.sh')
+
+            runtime_conf_str = ''
+
+            if os.path.exists(runtime_conf_path):
+                with open(runtime_conf_path, 'r') as runtime_conf_fileobj:
+                    runtime_conf_str = runtime_conf_fileobj.read()
+
+            for env in args.envs if hasattr(args, 'envs') else []:
+                if runtime_conf_str:
+                    runtime_conf_str += '\n'
+                runtime_conf_str += 'export \'{}\''.format(env.replace('\'', ''))
+
+            if runtime_conf_str:
+                runtime_conf_data = runtime_conf_str.encode('UTF-8')
+
+        if not args.name:
                 try:
                     bundle_conf = ConfigFactory.parse_string(bundle_conf_data.decode('UTF-8'))
 
@@ -208,12 +225,18 @@ def bndl_create(args):
         archive_name = bundle_conf['name'] if 'name' in bundle_conf else 'bundle'
         bundle_conf_name = os.path.join(archive_name, 'bundle.conf')
 
+        if runtime_conf_data:
+            runtime_conf_name = os.path.join(input_dir, 'runtime-config.sh')
+
+            with open(runtime_conf_name, 'wb') as runtime_conf_fileobj:
+                runtime_conf_fileobj.write(runtime_conf_data)
+
         if args.use_shazar:
             with tempfile.NamedTemporaryFile() as zip_file_data:
                 with zipfile.ZipFile(zip_file_data, 'w') as zip_file:
                     bundle_conf_zinfo = zipfile.ZipInfo(filename=bundle_conf_name, date_time=time.localtime(mtime)[:6])
                     zip_file.writestr(bundle_conf_zinfo, bundle_conf_data)
-                    dir_to_zip(input_dir, zip_file, args.name, mtime)
+                    dir_to_zip(input_dir, zip_file, archive_name, mtime)
 
                 zip_file_data.flush()
                 zip_file_data.seek(0)
@@ -229,7 +252,7 @@ def bndl_create(args):
                 for (dir_path, dir_names, file_names) in os.walk(input_dir):
                     for file_name in file_names:
                         path = os.path.join(dir_path, file_name)
-                        name = os.path.join(args.name, os.path.relpath(path, start=input_dir))
+                        name = os.path.join(archive_name, os.path.relpath(path, start=input_dir))
                         os.utime(path, (mtime, mtime))
                         tar.add(path, arcname=name)
 

--- a/conductr_cli/conduct_main.py
+++ b/conductr_cli/conduct_main.py
@@ -1,9 +1,9 @@
 import argcomplete
 import argparse
 from conductr_cli import \
-    conduct_agents, conduct_deploy, conduct_info, conduct_load, conduct_members, conduct_run, conduct_service_names, \
-    conduct_stop, conduct_unload, version, conduct_logs, conduct_events, conduct_acls, conduct_dcos, \
-    conduct_load_license, host, logging_setup, conduct_url, custom_settings
+    bndl_main, conduct_agents, conduct_deploy, conduct_info, conduct_load, conduct_members, conduct_run, \
+    conduct_service_names, conduct_stop, conduct_unload, version, conduct_logs, conduct_events, conduct_acls, \
+    conduct_dcos, conduct_load_license, host, logging_setup, conduct_url, custom_settings
 from conductr_cli.constants import \
     DEFAULT_SCHEME, DEFAULT_PORT, DEFAULT_BASE_PATH, \
     DEFAULT_API_VERSION, DEFAULT_DCOS_SERVICE, DEFAULT_CLI_SETTINGS_DIR, \
@@ -269,6 +269,7 @@ def build_parser(dcos_mode):
     add_configuration_resolve_cache_dir(load_parser)
     add_wait_timeout(load_parser)
     add_no_wait(load_parser)
+    bndl_main.add_conf_arguments(load_parser)
     load_parser.set_defaults(func=conduct_load.load)
 
     # Sub-parser for `run` sub-command
@@ -429,6 +430,7 @@ def build_parser(dcos_mode):
                                      dest='license_download_url',
                                      help=argparse.SUPPRESS,
                                      default=DEFAULT_LICENSE_DOWNLOAD_URL)
+
     load_license_parser.set_defaults(func=conduct_load_license.load_license)
 
     return parser

--- a/conductr_cli/test/test_bndl_main.py
+++ b/conductr_cli/test/test_bndl_main.py
@@ -73,7 +73,9 @@ class TestBndl(CliTestCase):
             '--annotation',
             'com.lightbend.test=hello world',
             '--annotation',
-            'description=this is a test'
+            'description=this is a test',
+            '--env',
+            'MESSAGE=hello world'
         ])
 
         self.assertEqual(args.source, 'oci-image-dir')
@@ -107,6 +109,7 @@ class TestBndl(CliTestCase):
                 'acls': ['http:/subpath']
             }
         ])
+        self.assertEqual(args.envs, ['MESSAGE=hello world'])
 
     def test_parser_no_args(self):
         args = self.parser.parse_args([])

--- a/conductr_cli/test/test_conduct_load_v2.py
+++ b/conductr_cli/test/test_conduct_load_v2.py
@@ -475,7 +475,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
             bndl_mock.call_args_list,
             [
                 call(self.bundle_file),
-                call(config_file, 'bundle')
+                call(config_file, 'bundle', input_args)
             ]
         )
 


### PR DESCRIPTION
- [x] Implementation
- [x] Manual Tests
- [x] More Manual Tests
- [x] New Unit Tests