### PR TITLE
Use check --any-address flag for OCI bundles

### DIFF
--- a/conductr_cli/bndl_oci.py
+++ b/conductr_cli/bndl_oci.py
@@ -29,7 +29,7 @@ def oci_image_bundle_conf(args, component_name, oci_manifest, oci_config):
     components_tree.put(component_name, oci_tree)
 
     if args.use_default_endpoints and 'config' in oci_config and 'ExposedPorts' in oci_config['config']:
-        check_arguments = []
+        check_arguments = ['--any-address']
 
         for exposed_port in sorted(oci_config['config']['ExposedPorts']):
             type_parts = exposed_port.split('/', 1)

--- a/conductr_cli/test/test_bndl_oci.py
+++ b/conductr_cli/test/test_bndl_oci.py
@@ -244,6 +244,7 @@ class TestBndlOci(CliTestCase):
                             |    file-system-type = "universal"
                             |    start-command = [
                             |      "check"
+                            |      "--any-address"
                             |      "$MY_COMPONENT_UDP_80_HOST"
                             |    ]
                             |    endpoints {}
@@ -355,6 +356,7 @@ class TestBndlOci(CliTestCase):
                             |    file-system-type = "universal"
                             |    start-command = [
                             |      "check"
+                            |      "--any-address"
                             |      "$MY_COMPONENT_TCP_80_HOST"
                             |      "$MY_COMPONENT_UDP_8080_HOST"
                             |    ]
@@ -495,6 +497,7 @@ class TestBndlOci(CliTestCase):
                             |    file-system-type = "universal"
                             |    start-command = [
                             |      "check"
+                            |      "--any-address"
                             |      "$MY_COMPONENT_TCP_80_HOST"
                             |      "$MY_COMPONENT_UDP_8080_HOST"
                             |    ]


### PR DESCRIPTION
When creating a bundle based on a given Docker image we create a check component if the `Dockerfile` exposes at least one port. If multiple ports are exposed then each address is checked for reachability in the check command. It is quite common that not all ports that are exposes are reachable. Therefore, for OCI bundles we use the check flag `--any-address` so that only one of the exposed ports needs to be reachable.

The `--any-address` flag got introduced in ConductR 2.1.0 with PR https://github.com/typesafehub/conductr/pull/1777.