### PR TITLE
Correct permissions when creating bundle.conf

### DIFF
--- a/conductr_cli/bndl_create.py
+++ b/conductr_cli/bndl_create.py
@@ -212,6 +212,7 @@ def bndl_create(args):
             with tempfile.NamedTemporaryFile() as zip_file_data:
                 with zipfile.ZipFile(zip_file_data, 'w') as zip_file:
                     bundle_conf_zinfo = zipfile.ZipInfo(filename=bundle_conf_name, date_time=time.localtime(mtime)[:6])
+                    bundle_conf_zinfo.external_attr = 0o644 << 16
                     zip_file.writestr(bundle_conf_zinfo, bundle_conf_data)
                     dir_to_zip(input_dir, zip_file, args.name, mtime)
 


### PR DESCRIPTION
Currently, when the `bndl` command creates a `bundle.conf`, e.g. from a Dockerfile, it creates the file without any permission (at least on macOS):

```
$ docker pull hello-world | docker save hello-world | bndl -o ~/.conductr/cache/bundle/hello-world.zip
$ zipinfo ~/.conductr/cache/bundle/hello-world.zip | grep "bundle.conf"
?---------  2.0 unx      375 b- stor 17-Jan-13 23:50 hello-world/bundle.conf
```

With this change, the `bundle.conf` is created with `644` permissions inside of the zip file:

```
$ docker pull hello-world | docker save hello-world | bndl -o ~/.conductr/cache/bundle/hello-world.zip
$ zipinfo ~/.conductr/cache/bundle/hello-world.zip | grep "bundle.conf"
?rw-r--r--  2.0 unx      375 b- stor 17-Jan-13 23:50 hello-world/bundle.conf
```