### PR TITLE
Ensure PyInstaller path is cleaned up from ConductR Agent environment variables

### DIFF
--- a/conductr_cli/pyinstaller_info.py
+++ b/conductr_cli/pyinstaller_info.py
@@ -1,0 +1,10 @@
+import sys
+
+
+def sys_meipass():
+    """
+    A safe way to obtain sys._MEIPASS by performing a check whether `frozen` attribute in the `sys` is present and has
+    the value of True.
+    :return: sys._MEIPASS if ran within PyInstaller, else None
+    """
+    return sys._MEIPASS if getattr(sys, 'frozen', False) else None

--- a/conductr_cli/test/test_pyinstaller_info.py
+++ b/conductr_cli/test/test_pyinstaller_info.py
@@ -1,0 +1,22 @@
+from conductr_cli.test.cli_test_case import CliTestCase
+from conductr_cli import pyinstaller_info
+
+from unittest.mock import patch, MagicMock
+
+
+class TestPyInstallerInfo(CliTestCase):
+    def test_return_sys_meipass(self):
+        mock_sys_meipass = '/tmp/path'
+        mock_sys = MagicMock(**{
+            'frozen': True,
+            '_MEIPASS': mock_sys_meipass
+        })
+        with patch('conductr_cli.pyinstaller_info.sys', mock_sys):
+            self.assertEqual(mock_sys_meipass, pyinstaller_info.sys_meipass())
+
+    def test_return_none(self):
+        mock_sys = MagicMock(**{
+            'frozen': False
+        })
+        with patch('conductr_cli.pyinstaller_info.sys', mock_sys):
+            self.assertIsNone(pyinstaller_info.sys_meipass())


### PR DESCRIPTION
Remove PyInstaller path from `PATH` and `LD_LIBRARY_PATH` when starting ConductR Agent.

Failing to do this may cause incompatible version of `.so` being loaded when starting a bundle, causing bundle startup script to fail.