### PR TITLE
OCI-in-Docker feature is now a default feature on Linux

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,6 +114,8 @@ To start a ConductR sandbox cluster with 3 nodes and the `visualization` feature
 
 Pick up the latest ConductR version from https://www.lightbend.com/product/conductr/developer
 
+By default, the sandbox is started with a number of default features: proxying, oci-in-docker, and lite-logging. These features can be disabled by providing the `--no-default-features` flag. Note that due to virtualization requirements, OCI-in-Docker is mandatory on macOS and thus cannot be disabled.
+
 To stop this cluster run:
 
 .. code:: bash

--- a/conductr_cli/sandbox_features.py
+++ b/conductr_cli/sandbox_features.py
@@ -570,18 +570,28 @@ def collect_features(feature_args, no_default_features, image_version, offline_m
         feature = feature_lookup[feature_name](args, image_version, offline_mode)
         features.append(feature)
 
+    # Calculate default and mandatory features. Mandatory features are always enabled whereas default features
+    # are enabled unless a `--no-default-features` argument is provided.
+
+    # Note that OCI-in-Docker is a default feature on linux (thus can be disabled) whereas it is mandatory on macOS
+
     def add_default_features(features):
         names = [feature.name for feature in features]
-
-        def add_proxying(features):
-            if ProxyingFeature.name not in names:
-                features.insert(0, feature_lookup[ProxyingFeature.name]([], image_version, offline_mode))
 
         def add_logging_lite(features):
             if LoggingFeature.name not in names:
                 features.insert(0, feature_lookup[LiteLoggingFeature.name]([], image_version, offline_mode))
 
+        def add_oci_in_docker(features):
+            if OciInDockerFeature.name not in names and host.is_linux():
+                features.insert(0, feature_lookup[OciInDockerFeature.name]([], image_version, offline_mode))
+
+        def add_proxying(features):
+            if ProxyingFeature.name not in names:
+                features.insert(0, feature_lookup[ProxyingFeature.name]([], image_version, offline_mode))
+
         add_logging_lite(features)
+        add_oci_in_docker(features)
         add_proxying(features)
 
     def add_mandatory_features(features):

--- a/conductr_cli/test/test_sandbox_features.py
+++ b/conductr_cli/test/test_sandbox_features.py
@@ -34,36 +34,36 @@ class TestFeatures(TestCase):
         mock_system = MagicMock(return_value='Linux')
         with patch('platform.system', mock_system):
             # default features enabled works
-            self.assertEqual([ProxyingFeature, LiteLoggingFeature],
+            self.assertEqual([ProxyingFeature, OciInDockerFeature, LiteLoggingFeature],
                              [type(f) for f in collect_features([], False, LATEST_CONDUCTR_VERSION, False)])
 
             # default features disabled works
             self.assertEqual([],
                              [type(f) for f in collect_features([], True, LATEST_CONDUCTR_VERSION, False)])
 
-            self.assertEqual([ProxyingFeature, LiteLoggingFeature, VisualizationFeature],
+            self.assertEqual([ProxyingFeature, OciInDockerFeature, LiteLoggingFeature, VisualizationFeature],
                              [type(f) for f in collect_features([['visualization']], False, LATEST_CONDUCTR_VERSION, False)])
 
-            self.assertEqual([ProxyingFeature, LoggingFeature],
+            self.assertEqual([ProxyingFeature, OciInDockerFeature, LoggingFeature],
                              [type(f) for f in collect_features([['logging']], False, LATEST_CONDUCTR_VERSION, False)])
 
             self.assertEqual([LoggingFeature],
                              [type(f) for f in collect_features([['logging']], True, LATEST_CONDUCTR_VERSION, False)])
 
             # enable dependencies
-            self.assertEqual([ProxyingFeature, LoggingFeature, MonitoringFeature],
+            self.assertEqual([ProxyingFeature, OciInDockerFeature, LoggingFeature, MonitoringFeature],
                              [type(f) for f in collect_features([['monitoring']], False, LATEST_CONDUCTR_VERSION, False)])
 
             # allow explicit listing of dependencies
-            self.assertEqual([ProxyingFeature, LoggingFeature, MonitoringFeature],
+            self.assertEqual([ProxyingFeature, OciInDockerFeature, LoggingFeature, MonitoringFeature],
                              [type(f) for f in collect_features([['logging'], ['monitoring']], False, LATEST_CONDUCTR_VERSION, False)])
 
             # topological ordering for dependencies
-            self.assertEqual([ProxyingFeature, LoggingFeature, MonitoringFeature],
+            self.assertEqual([ProxyingFeature, OciInDockerFeature, LoggingFeature, MonitoringFeature],
                              [type(f) for f in collect_features([['monitoring'], ['logging']], False, LATEST_CONDUCTR_VERSION, False)])
 
             # topological ordering and ignore duplicates
-            self.assertEqual([ProxyingFeature, LoggingFeature, MonitoringFeature, VisualizationFeature],
+            self.assertEqual([ProxyingFeature, OciInDockerFeature, LoggingFeature, MonitoringFeature, VisualizationFeature],
                              [type(f) for f in collect_features([['monitoring'], ['visualization'], ['logging'], ['monitoring']],
                                                                 False, LATEST_CONDUCTR_VERSION, False)])
 


### PR DESCRIPTION
This PR ensures that the OCI-in-Docker feature is enabled by default on Linux. We want to minimize friction for running the developer sandbox. Without this change, users of the sandbox would have to make an entry in their `sudoers` file. Additionally, this change ensures the developer experience between macOS and Linux are more similar.

This inverts the logic and allows us to disable via `--no-default-features`. It remains mandatory on macOS; thus `--no-default-features` does not affect OCI-in-Docker on that operating system.

### Manual Test
#### Description
Start the sandbox with default arguments and ensure that the message indicating OCI-in-Docker is printed. Then, start the sandbox with `--no-default-features` and ensure that the message indicating OCI-in-Docker is not printed.

#### Test enabled by default
```bash
$ sandbox run 0.1.0
|------------------------------------------------|
| Stopping ConductR                              |
|------------------------------------------------|
ConductR core pid 28581 stopped
ConductR agent pid 28685 stopped
ConductR has been successfully stopped
|------------------------------------------------|
| Starting ConductR                              |
|------------------------------------------------|
Extracting ConductR core to /home/longshorej/.conductr/images/core
Extracting ConductR agent to /home/longshorej/.conductr/images/agent
Starting ConductR core instance on 192.168.10.1..
Waiting for ConductR to start.
Starting ConductR agent instance on 192.168.10.1..
|------------------------------------------------|
| Starting HAProxy                               |
|------------------------------------------------|
Exposing the following ports [80, 443, 3000, 5601, 8999, 9000, 9200, 9999]
6f9cf54e05838c33f64799c561aed7410b52688e1c4d3511dcb67109baaa9a3c
Deploying bundle conductr-haproxy with configuration conductr-haproxy-dev-mode
Retrieving bundle..
Loading bundle from cache typesafe/bundle/conductr-haproxy
Bintray credentials loaded from /home/longshorej/.lightbend/commercial.credentials
Retrieving from cache /home/longshorej/.conductr/cache/bundle/conductr-haproxy-v2-bdfa43d7ade7456af30a95e9ef4bce863d3029dc58b6824f5783881297d1983b.zip
Retrieving configuration..
Loading bundle configuration from cache typesafe/bundle-configuration/conductr-haproxy-dev-mode
Bintray credentials loaded from /home/longshorej/.lightbend/commercial.credentials
Retrieving from cache /home/longshorej/.conductr/cache/configuration/conductr-haproxy-dev-mode-v2-e5f35046d59c27f4cfeebcc026f3e3b76e027b15223a8961b59d728e559402e2.zip
Loading bundle to ConductR..
[#################################################] 100%
Bundle bdfa43d7ade7456af30a95e9ef4bce86-e5f35046d59c27f4cfeebcc026f3e3b7 is installed
Bundle loaded.
Bundle run request sent.
Bundle bdfa43d7ade7456af30a95e9ef4bce86-e5f35046d59c27f4cfeebcc026f3e3b7 waiting to reach expected scale 1
Bundle bdfa43d7ade7456af30a95e9ef4bce86-e5f35046d59c27f4cfeebcc026f3e3b7 has scale 0, expected 1...
Bundle bdfa43d7ade7456af30a95e9ef4bce86-e5f35046d59c27f4cfeebcc026f3e3b7 expected scale 1 is met
|------------------------------------------------|
| Starting OCI-in-Docker support                 |
|------------------------------------------------|
OCI-in-Docker provided by image lightbend-docker-registry.bintray.io/conductr/oci-in-docker:0.1.0
|------------------------------------------------|
| Starting logging feature based on eslite       |
|------------------------------------------------|
Deploying bundle eslite..
Retrieving bundle..
Loading bundle from cache typesafe/bundle/eslite
Bintray credentials loaded from /home/longshorej/.lightbend/commercial.credentials
Retrieving from cache /home/longshorej/.conductr/cache/bundle/eslite-v1-7dc78f8c80474dc7ff4cabbdf5b5ce386cdebc3bd52693601bd2383dfb4e86be.zip
Loading bundle to ConductR..
[#################################################] 100%
Bundle 7dc78f8c80474dc7ff4cabbdf5b5ce38 is installed
Bundle loaded.
Bundle run request sent.
Bundle 7dc78f8c80474dc7ff4cabbdf5b5ce38 waiting to reach expected scale 1
Bundle 7dc78f8c80474dc7ff4cabbdf5b5ce38 has scale 0, expected 1.
Bundle 7dc78f8c80474dc7ff4cabbdf5b5ce38 expected scale 1 is met
|------------------------------------------------|
| Summary                                        |
|------------------------------------------------|
|- - - - - - - - - - - - - - - - - - - - - - - - |
| ConductR                                       |
|- - - - - - - - - - - - - - - - - - - - - - - - |
ConductR has been started:
  core instance on 192.168.10.1
  agent instance on 192.168.10.1
ConductR service locator has been started on:
  192.168.10.1:9008
|- - - - - - - - - - - - - - - - - - - - - - - - |
| Proxy                                          |
|- - - - - - - - - - - - - - - - - - - - - - - - |
HAProxy has been started
By default, your bundles are accessible on:
  192.168.10.1:9000
|- - - - - - - - - - - - - - - - - - - - - - - - |
| Bundles                                        |
|- - - - - - - - - - - - - - - - - - - - - - - - |
Check latest bundle status with:
  conduct info
Current bundle status:
Licensed To: cc64df31-ec6b-4e08-bb6b-3216721a56b@lightbend
Max ConductR agents: 3
ConductR Version(s): 0.1.0, 2.1.*
Grants: akka-sbr, cinnamon, conductr

ID               NAME              TAG  #REP  #STR  #RUN  ROLES
bdfa43d-e5f3504  conductr-haproxy          1     0     1  haproxy
7dc78f8          eslite                    1     0     1  elasticsearch
-> 0
```
#### Test not enabled with `--no-default-features`
```bash
$ sandbox run 0.1.0 --no-default-features
|------------------------------------------------|
| Stopping HAProxy                               |
|------------------------------------------------|
sandbox-haproxy
HAProxy has been successfully stopped
|------------------------------------------------|
| Stopping ConductR                              |
|------------------------------------------------|
ConductR core pid 30458 stopped
ConductR agent pid 30584 stopped
ConductR has been successfully stopped
|------------------------------------------------|
| Starting ConductR                              |
|------------------------------------------------|
Extracting ConductR core to /home/longshorej/.conductr/images/core
Extracting ConductR agent to /home/longshorej/.conductr/images/agent
Starting ConductR core instance on 192.168.10.1..
Waiting for ConductR to start.
Starting ConductR agent instance on 192.168.10.1..
|------------------------------------------------|
| Summary                                        |
|------------------------------------------------|
|- - - - - - - - - - - - - - - - - - - - - - - - |
| ConductR                                       |
|- - - - - - - - - - - - - - - - - - - - - - - - |
ConductR has been started:
  core instance on 192.168.10.1
  agent instance on 192.168.10.1
ConductR service locator has been started on:
  192.168.10.1:9008
|- - - - - - - - - - - - - - - - - - - - - - - - |
| Proxy                                          |
|- - - - - - - - - - - - - - - - - - - - - - - - |
HAProxy has not been started
To enable proxying ensure Docker is running and restart the sandbox
|- - - - - - - - - - - - - - - - - - - - - - - - |
| Bundles                                        |
|- - - - - - - - - - - - - - - - - - - - - - - - |
Check latest bundle status with:
  conduct info
Current bundle status:
Licensed To: cc64df31-ec6b-4e08-bb6b-3216721a56b@lightbend
Max ConductR agents: 3
ConductR Version(s): 0.1.0, 2.1.*
Grants: akka-sbr, cinnamon, conductr

ID  NAME  TAG  #REP  #STR  #RUN  ROLES
-> 0
```