### PR TITLE
Conduct stop also require similar fail-fast argparse option as Conduct run

### DIFF
--- a/conductr_cli/conduct_main.py
+++ b/conductr_cli/conduct_main.py
@@ -325,6 +325,13 @@ def build_parser(dcos_mode):
     add_default_arguments(stop_parser, dcos_mode)
     add_wait_timeout(stop_parser)
     add_no_wait(stop_parser)
+
+    # These are the arguments to display the bundle events and logs when error occurs during waiting for bundle scale.
+    # As such, the help text for these arguments are not displayed.
+    add_date_args(stop_parser, show_help=False)
+    add_lines_args(stop_parser, show_help=False)
+    add_follow_args(stop_parser, show_help=False)
+
     stop_parser.set_defaults(func=conduct_stop.stop)
 
     # Sub-parser for `unload` sub-command

--- a/conductr_cli/test/test_conduct_main.py
+++ b/conductr_cli/test/test_conduct_main.py
@@ -197,6 +197,10 @@ class TestConduct(TestCase):
         self.assertEqual(args.no_wait, False)
         self.assertEqual(args.wait_timeout, 60)
         self.assertEqual(args.bundle, 'path-to-bundle')
+        # These args are for displaying bundle events and logs when error occurs during scale.
+        self.assertEqual(args.lines, 10)
+        self.assertEqual(args.utc, False)
+        self.assertEqual(args.follow, False)
 
     def test_parser_unload(self):
         args = self.parser.parse_args('unload path-to-bundle'.split())


### PR DESCRIPTION
Conduct stop makes use `bundle_scale.wait_for_scale()` which waits for the bundle scale to reach 0.

The same `bundle_scale.wait_for_scale()` is used for Conduct run to wait for a requested bundle scale to be achieved, which will fail fast when encountering error.

`bundle_scale.wait_for_scale` requires a number of silent argparse options are required to display bundle events and logs when error occurs.

Because of this, conduct stop requires these silent argparse options to be specified