### PR TITLE
WIP - do not merge - volumes flag.

### DIFF
--- a/conductr_cli/bndl_create.py
+++ b/conductr_cli/bndl_create.py
@@ -8,6 +8,7 @@ from conductr_cli.bndl_utils import \
     detect_format_dir, \
     detect_format_stream, \
     find_bundle_conf_dir, \
+    file_write_bytes, \
     first_mtime, \
     load_bundle_args_into_conf, \
     zip_extract_with_dates
@@ -203,7 +204,48 @@ def bndl_create(args):
 
                 return 2
 
-            oci_manifest, oci_config = bndl_oci.oci_image_extract_manifest_config(component_dir, args.image_tag)
+            current_oci_manifest, current_oci_config = \
+                bndl_oci.oci_image_extract_manifest_config(component_dir, args.image_tag)
+
+            if not args.use_default_volumes or args.volumes:
+                current_oci_config['config']['Volumes'] = {}
+
+                for v in args.volumes:
+                    current_oci_config['config']['Volumes'][v] = {}
+
+            if not args.use_default_ports or args.ports:
+                current_oci_config['config']['ExposedPorts'] = {}
+
+                for p in args.ports:
+                    current_oci_config['config']['ExposedPorts'][p] = {}
+
+            oci_spec = bndl_oci.oci_config_to_image(current_oci_config,
+                                                    current_oci_manifest['layers']
+                                                    if 'layers' in current_oci_manifest else {},
+                                                    current_oci_manifest['annotations']
+                                                    if 'annotations' in current_oci_manifest else {})
+
+            oci_manifest = oci_spec['manifest_obj']
+            oci_config = oci_spec['config_obj']
+
+            os.makedirs(os.path.join(component_dir, 'blobs', 'sha256'), exist_ok=True)
+            os.makedirs(os.path.join(component_dir, 'refs'), exist_ok=True)
+
+            file_write_bytes(
+                os.path.join(component_dir, 'blobs', 'sha256', oci_spec['config_digest']),
+                oci_spec['config']
+            )
+
+            file_write_bytes(
+                os.path.join(component_dir, 'blobs', 'sha256', oci_spec['manifest_digest']),
+                oci_spec['manifest']
+            )
+
+            file_write_bytes(
+                os.path.join(component_dir, 'refs', args.image_tag),
+                oci_spec['refs']
+            )
+
             bundle_conf = oci_image_bundle_conf(args, component_name, oci_manifest, oci_config)
             bundle_conf_data = bundle_conf.encode('UTF-8')
 

--- a/conductr_cli/bndl_main.py
+++ b/conductr_cli/bndl_main.py
@@ -367,6 +367,38 @@ def build_parser():
                         dest='use_default_check',
                         action='store_false')
 
+    parser.add_argument('--no-default-ports',
+                        help='If provided, a bundle will not contain any exposed port declarations\n'
+                             'For use with docker and oci-image formats',
+                        default=True,
+                        dest='use_default_ports',
+                        action='store_false')
+
+    parser.add_argument('--no-default-volumes',
+                        help='If provided, a bundle will not contain any volume declarations\n'
+                             'For use with docker and oci-image formats',
+                        default=True,
+                        dest='use_default_volumes',
+                        action='store_false')
+
+    parser.add_argument('--volume',
+                        dest='volumes',
+                        action='append',
+                        default=[],
+                        help='Declare a volume path. If provided, default volumes are removed\n'
+                             'For use with docker and oci-image formats'
+                             'Defaults to [].',
+                        metavar='')
+
+    parser.add_argument('--port',
+                        dest='ports',
+                        action='append',
+                        default=[],
+                        help='Declare a port to expose. If provided, default ports are removed\n'
+                             'For use with docker and oci-image formats'
+                             'Defaults to [].',
+                        metavar='')
+
     add_conf_arguments(parser)
 
     parser.set_defaults(func=bndl)

--- a/conductr_cli/test/test_bndl_create.py
+++ b/conductr_cli/test/test_bndl_create.py
@@ -107,7 +107,11 @@ class TestBndlCreate(CliTestCase):
                 'component_description': '',
                 'use_shazar': True,
                 'use_default_endpoints': True,
-                'annotations': []
+                'use_default_ports': True,
+                'use_default_volumes': True,
+                'annotations': [],
+                'ports': [],
+                'volumes': []
             })
 
             os.mkdir(os.path.join(tmpdir, 'refs'))
@@ -147,7 +151,11 @@ class TestBndlCreate(CliTestCase):
                 'component_description': '',
                 'use_shazar': False,
                 'use_default_endpoints': True,
-                'annotations': []
+                'use_default_ports': True,
+                'use_default_volumes': True,
+                'annotations': [],
+                'ports': [],
+                'volumes': []
             })
 
             os.mkdir(os.path.join(tmpdir, 'refs'))
@@ -190,7 +198,11 @@ class TestBndlCreate(CliTestCase):
                 'component_description': '',
                 'use_shazar': True,
                 'use_default_endpoints': True,
-                'annotations': []
+                'use_default_ports': True,
+                'use_default_volumes': True,
+                'annotations': [],
+                'ports': [],
+                'volumes': []
             })
 
             os.mkdir(os.path.join(tmpdir, 'refs'))
@@ -210,7 +222,11 @@ class TestBndlCreate(CliTestCase):
                 'component_description': '',
                 'use_shazar': True,
                 'use_default_endpoints': True,
-                'annotations': []
+                'use_default_ports': True,
+                'use_default_volumes': True,
+                'annotations': [],
+                'ports': [],
+                'volumes': []
             })
 
             os.mkdir(os.path.join(tmpdir2, 'refs'))
@@ -252,7 +268,11 @@ class TestBndlCreate(CliTestCase):
                 'component_description': '',
                 'use_shazar': True,
                 'use_default_endpoints': True,
-                'annotations': []
+                'use_default_ports': True,
+                'use_default_volumes': True,
+                'annotations': [],
+                'ports': [],
+                'volumes': []
             })
 
             os.mkdir(os.path.join(tmpdir, 'refs'))
@@ -294,7 +314,11 @@ class TestBndlCreate(CliTestCase):
                 'component_description': '',
                 'use_shazar': False,
                 'use_default_endpoints': True,
-                'annotations': []
+                'use_default_ports': True,
+                'use_default_volumes': True,
+                'annotations': [],
+                'ports': [],
+                'volumes': []
             })
 
             os.mkdir(os.path.join(tmpdir, 'refs'))
@@ -314,7 +338,11 @@ class TestBndlCreate(CliTestCase):
                 'component_description': '',
                 'use_shazar': False,
                 'use_default_endpoints': True,
-                'annotations': []
+                'use_default_ports': True,
+                'use_default_volumes': True,
+                'annotations': [],
+                'ports': [],
+                'volumes': []
             })
 
             os.mkdir(os.path.join(tmpdir2, 'refs'))
@@ -350,6 +378,8 @@ class TestBndlCreate(CliTestCase):
                 'output': file_out.name,
                 'use_shazar': False,
                 'use_default_endpoints': True,
+                'use_default_ports': True,
+                'use_default_volumes': True,
                 'roles': ['test']
             })
 
@@ -382,7 +412,9 @@ class TestBndlCreate(CliTestCase):
                 'source': file_in.name,
                 'output': file_out.name,
                 'use_shazar': False,
-                'use_default_endpoints': True
+                'use_default_endpoints': True,
+                'use_default_ports': True,
+                'use_default_volumes': True,
             })
 
             self.assertEqual(bndl_create.bndl_create(args), 0)
@@ -413,7 +445,9 @@ class TestBndlCreate(CliTestCase):
                 'source': file_in.name,
                 'output': file_out.name,
                 'use_shazar': False,
-                'use_default_endpoints': True
+                'use_default_endpoints': True,
+                'use_default_ports': True,
+                'use_default_volumes': True,
             })
 
             self.assertEqual(bndl_create.bndl_create(args), 0)
@@ -449,6 +483,8 @@ class TestBndlCreate(CliTestCase):
                     'output': file_out.name,
                     'use_shazar': False,
                     'use_default_endpoints': True,
+                    'use_default_ports': True,
+                    'use_default_volumes': True,
                     'roles': ['test'],
                     'annotations': [
                         'my.test=testing'
@@ -495,6 +531,8 @@ class TestBndlCreate(CliTestCase):
                     'output': file_out.name,
                     'use_shazar': False,
                     'use_default_endpoints': True,
+                    'use_default_ports': True,
+                    'use_default_volumes': True,
                     'annotations': [
                         'my.test=testing'
                     ]


### PR DESCRIPTION
This PR modifies `bndl` to allow ports and volumes to be specified. What I'm not sure is if it's the right approach as it only works with `docker` and `oci-image` formats.

Perhaps we, instead of the approach in this PR, use annotations to store this information. Thus it becomes relevant to ConductR and would work well with bundles that have multiple components. The downside would be another ConductR PR is required.

Yet another approach would be for an annotation (perhaps `com.lightbend.conductr.oci-config-transformations.<component name>`) to hold an array of transformations using `jq` syntax. This way the CLI and end user could have a great deal of control over the final `config.json` that is executed without requiring changes to be made to the agent.

I think ultimately we need this functionality to make running third party docker images seamless, docker tooling doesn't really help here when you consider we are going to be using our own resolver code that doesn't require docker to be installed to run docker images.