### PR TITLE
Ensure that `--env` arguments are processed for all bundle formats

### DIFF
--- a/conductr_cli/bndl_create.py
+++ b/conductr_cli/bndl_create.py
@@ -55,6 +55,7 @@ def bndl_create(args):
     mtime = None
     bundle_conf_data = b''
     runtime_conf_data = b''
+    runtime_conf_str = ''
 
     try:
         process_oci = False
@@ -156,19 +157,17 @@ def bndl_create(args):
 
             runtime_conf_path = os.path.join(input_dir, 'runtime-config.sh')
 
-            runtime_conf_str = ''
-
             if os.path.exists(runtime_conf_path):
                 with open(runtime_conf_path, 'r') as runtime_conf_fileobj:
                     runtime_conf_str = runtime_conf_fileobj.read()
 
-            for env in args.envs if hasattr(args, 'envs') else []:
-                if runtime_conf_str:
-                    runtime_conf_str += '\n'
-                runtime_conf_str += 'export \'{}\''.format(env.replace('\'', ''))
-
+        for env in args.envs if hasattr(args, 'envs') else []:
             if runtime_conf_str:
-                runtime_conf_data = runtime_conf_str.encode('UTF-8')
+                runtime_conf_str += '\n'
+            runtime_conf_str += 'export \'{}\''.format(env.replace('\'', ''))
+
+        if runtime_conf_str:
+            runtime_conf_data = runtime_conf_str.encode('UTF-8')
 
         if not args.name:
                 try:

--- a/conductr_cli/test/test_bndl_create.py
+++ b/conductr_cli/test/test_bndl_create.py
@@ -623,3 +623,52 @@ class TestBndlCreate(CliTestCase):
                     self.assertTrue(saw_config)
         finally:
             shutil.rmtree(temp_dir)
+
+    def test_oci_env(self):
+        stdout_mock = MagicMock()
+        tmpdir = tempfile.mkdtemp()
+        tmpfile = os.path.join(tmpdir, 'output')
+
+        try:
+            attributes = create_attributes_object({
+                'name': 'test',
+                'source': tmpdir,
+                'format': 'oci-image',
+                'image_tag': 'latest',
+                'output': tmpfile,
+                'component_description': '',
+                'use_shazar': True,
+                'use_default_endpoints': True,
+                'annotations': [],
+                'envs': [
+                    'ENV1=123',
+                    'ENV2=456'
+                ]
+            })
+
+            os.mkdir(os.path.join(tmpdir, 'refs'))
+            open(os.path.join(tmpdir, 'oci-layout'), 'w').close()
+            refs = open(os.path.join(tmpdir, 'refs/latest'), 'w')
+            refs.write('{}')
+            refs.close()
+
+            with \
+                    patch('sys.stdin', MagicMock(**{'buffer': BytesIO(b'')})), \
+                    patch('sys.stdout.buffer.write', stdout_mock):
+                self.assertEqual(bndl_create.bndl_create(attributes), 0)
+
+            self.assertTrue(zipfile.is_zipfile(tmpfile))
+
+            files = {}
+
+            with zipfile.ZipFile(tmpfile) as zip:
+                infos = zip.infolist()
+                for info in infos:
+                    files[info.filename] = zip.read(info.filename)
+
+            self.assertEqual(
+                files['test/runtime-config.sh'],
+                b'export \'ENV1=123\'\nexport \'ENV2=456\''
+            )
+        finally:
+            shutil.rmtree(tmpdir)


### PR DESCRIPTION
This ensures that usage such as the following creates a `runtime-config.sh`. Previously, we only processed these attributes for ConductR bundles.

`docker save dockercloud/hello-world | bndl --env TEST==123`

Fixes #461