### PR TITLE
Add ability to set `start-command` to `bndl`

### DIFF
--- a/conductr_cli/test/test_bndl_create.py
+++ b/conductr_cli/test/test_bndl_create.py
@@ -340,7 +340,17 @@ class TestBndlCreate(CliTestCase):
 
     def test_bundle_conf(self):
         with tempfile.NamedTemporaryFile() as file_in, tempfile.NamedTemporaryFile() as file_out:
-            file_in.write(b'name = "testing"\ndescription = "my test description"\nroles = ["web", "web2"]')
+            file_in.write(b'name = "testing"\n'
+                          b'description = "my test description"\n'
+                          b'roles = ["web", "web2"]\n'
+                          b'components {'
+                          b'  "test1" {'
+                          b'    start-command = []'
+                          b'  }'
+                          b'  "test2": {'
+                          b'    start-command = []'
+                          b'  }'
+                          b'}')
             file_in.flush()
 
             args = create_attributes_object({
@@ -350,7 +360,17 @@ class TestBndlCreate(CliTestCase):
                 'output': file_out.name,
                 'use_shazar': False,
                 'use_default_endpoints': True,
-                'roles': ['test']
+                'roles': ['test'],
+                'start_commands': [
+                    create_attributes_object({
+                        'start_command': '["abc", "test"]',
+                        'component': 'test2'
+                    }),
+                    create_attributes_object({
+                        'start_command': '["xyz", "test"]',
+                        'component': 'test1'
+                    })
+                ]
             })
 
             self.assertEqual(bndl_create.bndl_create(args), 0)
@@ -368,7 +388,21 @@ class TestBndlCreate(CliTestCase):
                                |description = "my test description"
                                |roles = [
                                |  "test"
-                               |]''')
+                               |]
+                               |components {
+                               |  test1 {
+                               |    start-command = [
+                               |      "xyz"
+                               |      "test"
+                               |    ]
+                               |  }
+                               |  test2 {
+                               |    start-command = [
+                               |      "abc"
+                               |      "test"
+                               |    ]
+                               |  }
+                               |}''')
                     )
 
     def test_bundle_arg_no_name(self):


### PR DESCRIPTION
This PR allows you to change the `start-command` of a component using `bndl`.

### Manual Test

#### Description
We'll invoke `bndl` from the command line with a few options to ensure it's working as intended, namely that start-command does get updated and for the correct component.

#### Test: A bundle with only one component does not need to specify `--component`

```bash
$ cat single-bundle.conf 
name = "test"
components {
  test1 {
    start-command = ["basic", "command"]
  }
}
-> 0
$  (bndl single-bundle.conf --no-shazar --start-command '["it", "worked"]' | tar x) && cat test/bundle.conf && rm -r test
name = "test"
components {
  test1 {
    start-command = [
      "it"
      "worked"
    ]
  }
}-> 0
```

#### Test: A bundle with more than one component fails if `--component` isn't specified
```bash
$ cat multi-bundle.conf 
name = "test"
components {
  test1 {
    start-command = []
  }
  test2 {
    start-command = []
  }
}
-> 0
$ (bndl multi-bundle.conf --no-shazar --start-command '["it", "worked"]' | tar x) && cat test/bundle.conf && rm -r test
Error: bndl: Unable to auto-detect the component. Component not specified and bundle.conf contains multiple components: ['test1', 'test2']
tar: This does not look like a tar archive
tar: Exiting with failure status due to previous errors
-> 2
```

#### Test: A bundle with more than one component succeeds if `--component` is specified
```bash
$ cat multi-bundle.conf 
name = "test"
components {
  test1 {
    start-command = []
  }
  test2 {
    start-command = []
  }
}
-> 0
$ (bndl multi-bundle.conf --no-shazar --start-command '["it", "worked"]' --component test1 | tar x) && cat test/bundle.conf && rm -r test
name = "test"
components {
  test1 {
    start-command = [
      "it"
      "worked"
    ]
  }
  test2 {
    start-command = []
  }
}-> 0
$ (bndl multi-bundle.conf --no-shazar --start-command '["it", "worked"]' --component test2 | tar x) && cat test/bundle.conf && rm -r test
name = "test"
components {
  test1 {
    start-command = []
  }
  test2 {
    start-command = [
      "it"
      "worked"
    ]
  }
}-> 0
````