### PR TITLE
`bndl` volume enhancements

### DIFF
--- a/conductr_cli/bndl_create.py
+++ b/conductr_cli/bndl_create.py
@@ -223,7 +223,7 @@ def bndl_create(args):
         else:
             bundle_conf = ConfigFactory.parse_string('')
 
-        load_bundle_args_into_conf(bundle_conf, args, with_defaults=False, validate_components=True)
+        load_bundle_args_into_conf(bundle_conf, args, with_defaults=False)
 
         if bundle_conf:
             validation_excludes = set(args.validation_excludes)

--- a/conductr_cli/bndl_oci.py
+++ b/conductr_cli/bndl_oci.py
@@ -9,7 +9,7 @@ import tempfile
 
 def oci_image_bundle_conf(args, component_name, oci_manifest, oci_config):
     conf = ConfigFactory.parse_string('')
-    load_bundle_args_into_conf(conf, args, with_defaults=True, validate_components=False)
+    load_bundle_args_into_conf(conf, args, with_defaults=True)
 
     annotations_tree = conf.get('annotations')
 
@@ -54,6 +54,13 @@ def oci_image_bundle_conf(args, component_name, oci_manifest, oci_config):
             components_tree = ConfigTree()
             components_tree.put(component_name, oci_tree)
             components_tree.put('bundle-status', oci_check_tree)
+
+    if args.use_default_volumes and 'config' in oci_config and 'Volumes' in oci_config['config']:
+        volumes = ConfigTree()
+        for vol_path in sorted(oci_config['config']['Volumes'].keys()):
+            key = 'volume{}'.format(re.sub(r'\W+', '-', vol_path))
+            volumes.put(key, vol_path)
+        oci_tree.put('volumes', volumes)
 
     conf.put('components', components_tree)
 

--- a/conductr_cli/test/test_bndl_create.py
+++ b/conductr_cli/test/test_bndl_create.py
@@ -109,7 +109,8 @@ class TestBndlCreate(CliTestCase):
                 'use_shazar': True,
                 'use_default_endpoints': True,
                 'annotations': [],
-                'validation_excludes': []
+                'validation_excludes': [],
+                'use_default_volumes': True
             })
 
             os.mkdir(os.path.join(tmpdir, 'refs'))
@@ -150,7 +151,8 @@ class TestBndlCreate(CliTestCase):
                 'use_shazar': False,
                 'use_default_endpoints': True,
                 'annotations': [],
-                'validation_excludes': []
+                'validation_excludes': [],
+                'use_default_volumes': True
             })
 
             os.mkdir(os.path.join(tmpdir, 'refs'))
@@ -194,7 +196,8 @@ class TestBndlCreate(CliTestCase):
                 'use_shazar': True,
                 'use_default_endpoints': True,
                 'annotations': [],
-                'validation_excludes': []
+                'validation_excludes': [],
+                'use_default_volumes': True
             })
 
             os.mkdir(os.path.join(tmpdir, 'refs'))
@@ -215,7 +218,8 @@ class TestBndlCreate(CliTestCase):
                 'use_shazar': True,
                 'use_default_endpoints': True,
                 'annotations': [],
-                'validation_excludes': []
+                'validation_excludes': [],
+                'use_default_volumes': True
             })
 
             os.mkdir(os.path.join(tmpdir2, 'refs'))
@@ -258,7 +262,8 @@ class TestBndlCreate(CliTestCase):
                 'use_shazar': True,
                 'use_default_endpoints': True,
                 'annotations': [],
-                'validation_excludes': []
+                'validation_excludes': [],
+                'use_default_volumes': True
             })
 
             os.mkdir(os.path.join(tmpdir, 'refs'))
@@ -301,7 +306,8 @@ class TestBndlCreate(CliTestCase):
                 'use_shazar': False,
                 'use_default_endpoints': True,
                 'annotations': [],
-                'validation_excludes': []
+                'validation_excludes': [],
+                'use_default_volumes': True
             })
 
             os.mkdir(os.path.join(tmpdir, 'refs'))
@@ -322,7 +328,8 @@ class TestBndlCreate(CliTestCase):
                 'use_shazar': False,
                 'use_default_endpoints': True,
                 'annotations': [],
-                'validation_excludes': []
+                'validation_excludes': [],
+                'use_default_volumes': True
             })
 
             os.mkdir(os.path.join(tmpdir2, 'refs'))
@@ -432,6 +439,7 @@ class TestBndlCreate(CliTestCase):
                 'output': file_out.name,
                 'use_shazar': False,
                 'use_default_endpoints': True,
+                'use_default_volumes': True,
                 'roles': ['test'],
                 'start_commands': [
                     create_attributes_object({
@@ -443,7 +451,19 @@ class TestBndlCreate(CliTestCase):
                         'component': 'test1'
                     })
                 ],
-                'validation_excludes': []
+                'validation_excludes': [],
+                'volumes': [
+                    create_attributes_object({
+                        'name': 'my-vol',
+                        'mount_point': '/data',
+                        'component': 'test2'
+                    }),
+                    create_attributes_object({
+                        'name': 'my-vol',
+                        'mount_point': '/other-data',
+                        'component': 'test1'
+                    })
+                ]
             })
 
             self.assertEqual(bndl_create.bndl_create(args), 0)
@@ -467,12 +487,18 @@ class TestBndlCreate(CliTestCase):
                                |      "xyz"
                                |      "test"
                                |    ]
+                               |    volumes {
+                               |      my-vol = "/other-data"
+                               |    }
                                |  }
                                |  test2 {
                                |    start-command = [
                                |      "abc"
                                |      "test"
                                |    ]
+                               |    volumes {
+                               |      my-vol = "/data"
+                               |    }
                                |  }
                                |}''')
                     )
@@ -797,6 +823,7 @@ class TestBndlCreate(CliTestCase):
                 'component_description': '',
                 'use_shazar': True,
                 'use_default_endpoints': True,
+                'use_default_volumes': True,
                 'annotations': [],
                 'envs': [
                     'ENV1=123',

--- a/conductr_cli/test/test_bndl_main.py
+++ b/conductr_cli/test/test_bndl_main.py
@@ -75,7 +75,13 @@ class TestBndl(CliTestCase):
             '--annotation',
             'description=this is a test',
             '--env',
-            'MESSAGE=hello world'
+            'MESSAGE=hello world',
+            '--volume',
+            'test:/data',
+            '--component',
+            'web-component',
+            '--volume',
+            'test2:/data2'
         ])
 
         self.assertEqual(args.source, 'oci-image-dir')
@@ -116,6 +122,10 @@ class TestBndl(CliTestCase):
             }
         ])
         self.assertEqual(args.envs, ['MESSAGE=hello world'])
+        self.assertEqual(args.volume_dicts, [
+            {'component': 'web-component', 'volume': 'test:/data'},
+            {'volume': 'test2:/data2'}
+        ])
 
     def test_parser_acl_params(self):
         parser = bndl_main.build_parser()

--- a/conductr_cli/test/test_bndl_oci.py
+++ b/conductr_cli/test/test_bndl_oci.py
@@ -109,6 +109,7 @@ class TestBndlOci(CliTestCase):
             'component_description': 'testing desc 1',
             'image_tag': 'testing',
             'use_default_endpoints': True,
+            'use_default_volumes': True,
             'annotations': []
         })
 
@@ -127,6 +128,7 @@ class TestBndlOci(CliTestCase):
             'roles': ['web', 'backend'],
             'image_tag': 'latest',
             'use_default_endpoints': True,
+            'use_default_volumes': True
         })
 
         self.assertEqual(
@@ -211,6 +213,7 @@ class TestBndlOci(CliTestCase):
             'image_tag': 'testing',
             'use_default_endpoints': True,
             'use_default_check': True,
+            'use_default_volumes': True,
             'annotations': []
         })
 
@@ -279,6 +282,7 @@ class TestBndlOci(CliTestCase):
             'component_description': 'testing desc 1',
             'image_tag': 'testing',
             'use_default_endpoints': False,
+            'use_default_volumes': True,
             'annotations': []
         })
 
@@ -332,6 +336,7 @@ class TestBndlOci(CliTestCase):
             'image_tag': 'testing',
             'use_default_endpoints': True,
             'use_default_check': True,
+            'use_default_volumes': True,
             'annotations': {}
         })
 
@@ -407,6 +412,7 @@ class TestBndlOci(CliTestCase):
             'image_tag': 'testing',
             'use_default_endpoints': True,
             'use_default_check': False,
+            'use_default_volumes': True,
             'annotations': {}
         })
 
@@ -464,7 +470,7 @@ class TestBndlOci(CliTestCase):
                             |}''')
         )
 
-    def test_oci_image_annotations(self):
+    def test_oci_params(self):
         self.maxDiff = None
 
         base_args = create_attributes_object({
@@ -473,12 +479,14 @@ class TestBndlOci(CliTestCase):
             'image_tag': 'testing',
             'use_default_endpoints': True,
             'use_default_check': True,
+            'use_default_volumes': True,
             'annotations': []
         })
 
         config = {
             'config': {
-                'ExposedPorts': {'80/tcp': {}, '8080/udp': {}}
+                'ExposedPorts': {'80/tcp': {}, '8080/udp': {}},
+                'Volumes': {'/data': {}, '/var/lib/cassandra': {}}
             }
         }
 
@@ -534,6 +542,10 @@ class TestBndlOci(CliTestCase):
                             |        bind-port = 8080
                             |        service-name = "my-component-udp-8080"
                             |      }
+                            |    }
+                            |    volumes {
+                            |      volume-data = "/data"
+                            |      volume-var-lib-cassandra = "/var/lib/cassandra"
                             |    }
                             |  }
                             |  bundle-status {

--- a/conductr_cli/test/test_conduct_load_v2.py
+++ b/conductr_cli/test/test_conduct_load_v2.py
@@ -479,7 +479,7 @@ class TestConductLoadCommand(ConductLoadTestBase):
             bndl_mock.call_args_list,
             [
                 call(self.bundle_file),
-                call(config_file, BndlFormat.CONFIGURATION, input_args)
+                call(config_file, BndlFormat.CONFIGURATION.value, input_args, 'mock bundle.conf')
             ]
         )
 


### PR DESCRIPTION
This PR enhances `bndl` to allow volumes to be set for a component given a `--volume` flag. It also prepopulates the `volumes` key of a component for OCI images that declare volumes.

It also modifies some the arguments so that we don't care anymore if a component doesn't exist. As we may be building up a configuration overlay there is no need to validate in argument parsing. Additionally, the work in #469 will validate components so this layer of validation has become redundant.

Example usages:

`bndl --volume my-vol:/data`
`docker save ... | bndl --no-default-volumes`
`bndl --volume my-vol:/data --component web2`