### PR TITLE
Explicitly encode/decode text files to UTF-8

### DIFF
--- a/conductr_cli/license.py
+++ b/conductr_cli/license.py
@@ -64,7 +64,7 @@ def save_license_data(license_data, save_to):
     :param save_to: the file where the license will be saved to
     """
     os.makedirs(os.path.dirname(save_to), exist_ok=True)
-    with open(save_to, 'w') as f:
+    with open(save_to, 'w', encoding="utf-8") as f:
         f.write(license_data)
 
 

--- a/conductr_cli/license_auth.py
+++ b/conductr_cli/license_auth.py
@@ -19,7 +19,7 @@ def get_cached_auth_token():
     :return: cached token
     """
     if os.path.exists(DEFAULT_AUTH_TOKEN_FILE):
-        with open(DEFAULT_AUTH_TOKEN_FILE, 'r') as f:
+        with open(DEFAULT_AUTH_TOKEN_FILE, 'r', encoding="utf-8") as f:
             auth_token = f.readline()
     else:
         auth_token = None
@@ -58,5 +58,5 @@ def save_auth_token(auth_token):
     """
     os.makedirs(os.path.dirname(DEFAULT_AUTH_TOKEN_FILE), exist_ok=True)
 
-    with open(DEFAULT_AUTH_TOKEN_FILE, 'w') as f:
+    with open(DEFAULT_AUTH_TOKEN_FILE, 'w', encoding="utf-8") as f:
         f.write(auth_token)

--- a/conductr_cli/resolvers/docker_resolver.py
+++ b/conductr_cli/resolvers/docker_resolver.py
@@ -131,7 +131,7 @@ def fetch_manifest(cache_dir, url, ns, image, manifest, offline_mode):
                                   headers={'Accept': 'application/vnd.docker.distribution.manifest.v2+json'})
         response.raise_for_status()
 
-        with open(cache_file, 'w') as cache_fileobj:
+        with open(cache_file, 'w', encoding="utf-8") as cache_fileobj:
             cache_fileobj.write(response.text)
 
         return json.loads(response.text)
@@ -243,10 +243,10 @@ def do_resolve_bundle(cache_dir, uri, auth, offline_mode):
             ('Layers', layers)
         ])]
 
-        with open(os.path.join(temp_dir, 'manifest.json'), 'w') as manifest_fileobj:
+        with open(os.path.join(temp_dir, 'manifest.json'), 'w', encoding="utf-8") as manifest_fileobj:
             manifest_fileobj.write(json.dumps(manifests))
 
-        with open(os.path.join(temp_dir, 'repositories'), 'w') as repositories_fileobj:
+        with open(os.path.join(temp_dir, 'repositories'), 'w', encoding="utf-8") as repositories_fileobj:
             repositories_fileobj.write(json.dumps(repositories))
 
         return True, None, temp_dir

--- a/conductr_cli/test/cli_test_case.py
+++ b/conductr_cli/test/cli_test_case.py
@@ -98,7 +98,7 @@ def create_temp_bundle_with_contents(contents):
     os.makedirs(basedir)
 
     for name, content in contents.items():
-        with open(os.path.join(basedir, name), 'w') as file:
+        with open(os.path.join(basedir, name), 'w', encoding="utf-8") as file:
             file.write(content)
 
     return tmpdir, shutil.make_archive(os.path.join(tmpdir, 'bundle'), 'zip', unpacked, 'bundle-1.0.0')

--- a/conductr_cli/test/test_license_auth.py
+++ b/conductr_cli/test/test_license_auth.py
@@ -17,7 +17,7 @@ class TestGetCachedAuthToken(TestCase):
             license_auth.get_cached_auth_token()
 
         mock_exists.assert_called_once_with(DEFAULT_AUTH_TOKEN_FILE)
-        mock_open.assert_called_once_with(DEFAULT_AUTH_TOKEN_FILE, 'r')
+        mock_open.assert_called_once_with(DEFAULT_AUTH_TOKEN_FILE, 'r', encoding="utf-8")
 
     def test_cached_token_missing(self):
         mock_exists = MagicMock(return_value=False)
@@ -94,7 +94,7 @@ class TestSaveAuthToken(TestCase):
             with patch('builtins.open', mock_open):
                 license_auth.save_auth_token(auth_token)
 
-            mock_open.assert_called_once_with(DEFAULT_AUTH_TOKEN_FILE, 'w')
+            mock_open.assert_called_once_with(DEFAULT_AUTH_TOKEN_FILE, 'w', encoding="utf-8")
 
             with open(f.name, 'r') as d:
                 self.assertEqual([auth_token], d.readlines())


### PR DESCRIPTION
We need to be explicit about the encoding of text files otherwise the platform's locale will determine it, and potentially cause issues.