### PR TITLE
Name bndl component after the OCI image instead of generic "oci-image"

### DIFF
--- a/conductr_cli/bndl_create.py
+++ b/conductr_cli/bndl_create.py
@@ -65,8 +65,6 @@ def bndl_create(args):
 
             return 2
         elif args.format == 'docker':
-            component_name = 'oci-image'
-            component_dir = os.path.join(temp_dir, component_name)
             os.mkdir(component_dir)
 
             if not args.source:
@@ -86,8 +84,6 @@ def bndl_create(args):
 
             process_oci = True
         elif args.format == 'oci-image':
-            component_name = 'oci-image'
-            component_dir = os.path.join(temp_dir, component_name)
             os.mkdir(component_dir)
 
             if not args.source:
@@ -181,6 +177,12 @@ def bndl_create(args):
         mtime = first_mtime(input_dir, SHAZAR_TIMESTAMP_MIN) if mtime is None else mtime
 
         if process_oci:
+            if args.name:
+                old_component_dir = component_dir
+                component_name = args.name
+                component_dir = os.path.join(temp_dir, component_name)
+                os.rename(old_component_dir, component_dir)
+
             has_oci_layout = os.path.isfile(os.path.join(component_dir, 'oci-layout'))
 
             refs_dir = os.path.join(component_dir, 'refs')


### PR DESCRIPTION
This is a cosmetic change but I think it's nicer. Name the component after the image instead of "oci-image".

#### Before this Change
```bash
$ cat oldnames/elasticsearch/bundle.conf 
annotations {
  build-date = "20170406"
  license = "GPLv2"
  maintainer = "Elastic Docker Team <docker@elastic.co>"
  name = "CentOS Base Image"
  vendor = "CentOS"
  com {
    lightbend {
      conductr {
        oci-image-tags {
          oci-image = "5.4.0"
        }
      }
    }
  }
}
compatibilityVersion = "0"
diskSpace = 1073741824
memory = 402653184
name = "elasticsearch"
nrOfCpus = 0.1
roles = [
  "web"
]
system = "elasticsearch"
systemVersion = "1"
tags = [
  "5.4.0"
]
version = "1"
components {
  oci-image {
    description = ""
    file-system-type = "oci-image"
    start-command = []
    endpoints {
      oci-image-tcp-9200 {
        bind-protocol = "tcp"
        bind-port = 9200
        service-name = "oci-image-tcp-9200"
      }
      oci-image-tcp-9300 {
        bind-protocol = "tcp"
        bind-port = 9300
        service-name = "oci-image-tcp-9300"
      }
    }
  }
  bundle-status {
    description = "Status check for the bundle component"
    file-system-type = "universal"
    start-command = [
      "check"
      "--any-address"
      "$OCI_IMAGE_TCP_9200_HOST"
      "$OCI_IMAGE_TCP_9300_HOST"
    ]
    endpoints {}
  }
}-> 0
```

#### After this Change
```bash
$ cat newnames/elasticsearch/bundle.conf 
annotations {
  build-date = "20170406"
  license = "GPLv2"
  maintainer = "Elastic Docker Team <docker@elastic.co>"
  name = "CentOS Base Image"
  vendor = "CentOS"
  com {
    lightbend {
      conductr {
        oci-image-tags {
          elasticsearch = "5.4.0"
        }
      }
    }
  }
}
compatibilityVersion = "0"
diskSpace = 1073741824
memory = 402653184
name = "elasticsearch"
nrOfCpus = 0.1
roles = [
  "web"
]
system = "elasticsearch"
systemVersion = "1"
tags = [
  "5.4.0"
]
version = "1"
components {
  elasticsearch {
    description = ""
    file-system-type = "oci-image"
    start-command = []
    endpoints {
      elasticsearch-tcp-9200 {
        bind-protocol = "tcp"
        bind-port = 9200
        service-name = "elasticsearch-tcp-9200"
      }
      elasticsearch-tcp-9300 {
        bind-protocol = "tcp"
        bind-port = 9300
        service-name = "elasticsearch-tcp-9300"
      }
    }
  }
  bundle-status {
    description = "Status check for the bundle component"
    file-system-type = "universal"
    start-command = [
      "check"
      "--any-address"
      "$ELASTICSEARCH_TCP_9200_HOST"
      "$ELASTICSEARCH_TCP_9300_HOST"
    ]
    endpoints {}
  }
}-> 0
```