### PR TITLE
Native executable: use certifi to provide cacert

### DIFF
--- a/conduct.spec
+++ b/conduct.spec
@@ -1,29 +1,7 @@
 # -*- mode: python -*-
 
-from PyInstaller.compat import is_darwin
 import os
 
-
-if is_darwin:
-    # Include Python's cacert file as part of the packaged native executable.
-    # This is because in OSX the OpenSSL from Macports and Homebrew doesn't fallback to CA certs stored in OSX keychain
-    # tool.
-    # The workaround is based on this PyInstaller recipe:
-    # https://github.com/pyinstaller/pyinstaller/wiki/Recipe-OpenSSL-Certificate
-    #
-    # and its corresponding PR:
-    # https://github.com/pyinstaller/pyinstaller/pull/1411/files
-    #
-    # This workaround relies on setting SSL_CERT_FILE environment variable, and this environment variable is applicable
-    # on Python 3.4 and 3.5: https://bugs.python.org/issue22449
-    #
-    # Some further info on how OSX OpenSSL cert validation:
-    # https://hynek.me/articles/apple-openssl-verification-surprises/
-    #
-    import ssl
-    cert_datas = [(ssl.get_default_verify_paths().cafile, 'lib')]
-else:
-    cert_datas = []
 
 block_cipher = None
 
@@ -31,7 +9,7 @@ block_cipher = None
 a = Analysis(['conductr_cli/conduct.py'],
              pathex=[os.path.abspath(os.getcwd())],
              binaries=[],
-             datas=cert_datas,
+             datas=[],
              hiddenimports=[],
              hookspath=[],
              runtime_hooks=[],

--- a/conductr_cli/conduct.py
+++ b/conductr_cli/conduct.py
@@ -1,25 +1,33 @@
 from conductr_cli import main_handler
+import certifi
 import sys
 import os
 
 
 if getattr(sys, 'frozen', False):
-    # Assume Python's cacert file is included as part of the packaged native executable.
-    # This is because in OSX the OpenSSL from Macports and Homebrew doesn't fallback to CA certs stored in OSX keychain
-    # tool.
-    # The workaround is based on this PyInstaller recipe:
-    # https://github.com/pyinstaller/pyinstaller/wiki/Recipe-OpenSSL-Certificate
+    # Use cacert provided by the certifi package when running as native executable.
     #
-    # and its corresponding PR:
-    # https://github.com/pyinstaller/pyinstaller/pull/1411/files
+    # This is to normalize the different ways cacert is being packaged across different platform.
     #
-    # This workaround relies on setting SSL_CERT_FILE environment variable, and this environment variable is applicable
-    # on Python 3.4 and 3.5: https://bugs.python.org/issue22449
+    # Note on OSX
+    # -----------
+    # In OSX the OpenSSL from Macports and Homebrew doesn't fallback to CA certs stored in OSX keychain tool.
     #
     # Some further info on how OSX OpenSSL cert validation:
     # https://hynek.me/articles/apple-openssl-verification-surprises/
     #
-    os.environ['SSL_CERT_FILE'] = os.path.join(sys._MEIPASS, 'lib', 'cert.pem')
+    # Note on Linux
+    # -----------
+    # Also in various flavours of Linux, the cacert is packaged differently.
+    #
+    # In Ubuntu it's installed under /etc/ssl/certs containing various .pem files each from different Root CA.
+    #
+    # In RHEL/Centos, it's installed under /etc/ssl/certs/ca-bundle.crt
+    #
+    # This solution relies on setting SSL_CERT_FILE environment variable, and this environment variable is applicable
+    # on Python 3.4 and 3.5: https://bugs.python.org/issue22449
+    #
+    os.environ['SSL_CERT_FILE'] = os.path.join(certifi.where())
 
 
 def main_method():

--- a/conductr_cli/sandbox.py
+++ b/conductr_cli/sandbox.py
@@ -1,25 +1,33 @@
 from conductr_cli import main_handler
 import sys
 import os
+import certifi
 
 
 if getattr(sys, 'frozen', False):
-    # Assume Python's cacert file is included as part of the packaged native executable.
-    # This is because in OSX the OpenSSL from Macports and Homebrew doesn't fallback to CA certs stored in OSX keychain
-    # tool.
-    # The workaround is based on this PyInstaller recipe:
-    # https://github.com/pyinstaller/pyinstaller/wiki/Recipe-OpenSSL-Certificate
+    # Use cacert provided by the certifi package when running as native executable.
     #
-    # and its corresponding PR:
-    # https://github.com/pyinstaller/pyinstaller/pull/1411/files
+    # This is to normalize the different ways cacert is being packaged across different platform.
     #
-    # This workaround relies on setting SSL_CERT_FILE environment variable, and this environment variable is applicable
-    # on Python 3.4 and 3.5: https://bugs.python.org/issue22449
+    # Note on OSX
+    # -----------
+    # In OSX the OpenSSL from Macports and Homebrew doesn't fallback to CA certs stored in OSX keychain tool.
     #
     # Some further info on how OSX OpenSSL cert validation:
     # https://hynek.me/articles/apple-openssl-verification-surprises/
     #
-    os.environ['SSL_CERT_FILE'] = os.path.join(sys._MEIPASS, 'lib', 'cert.pem')
+    # Note on Linux
+    # -----------
+    # Also in various flavours of Linux, the cacert is packaged differently.
+    #
+    # In Ubuntu it's installed under /etc/ssl/certs containing various .pem files each from different Root CA.
+    #
+    # In RHEL/Centos, it's installed under /etc/ssl/certs/ca-bundle.crt
+    #
+    # This solution relies on setting SSL_CERT_FILE environment variable, and this environment variable is applicable
+    # on Python 3.4 and 3.5: https://bugs.python.org/issue22449
+    #
+    os.environ['SSL_CERT_FILE'] = os.path.join(certifi.where())
 
 
 def main_method():

--- a/sandbox.spec
+++ b/sandbox.spec
@@ -1,29 +1,7 @@
 # -*- mode: python -*-
 
-from PyInstaller.compat import is_darwin
 import os
 
-
-if is_darwin:
-    # Include Python's cacert file as part of the packaged native executable.
-    # This is because in OSX the OpenSSL from Macports and Homebrew doesn't fallback to CA certs stored in OSX keychain
-    # tool.
-    # The workaround is based on this PyInstaller recipe:
-    # https://github.com/pyinstaller/pyinstaller/wiki/Recipe-OpenSSL-Certificate
-    #
-    # and its corresponding PR:
-    # https://github.com/pyinstaller/pyinstaller/pull/1411/files
-    #
-    # This workaround relies on setting SSL_CERT_FILE environment variable, and this environment variable is applicable
-    # on Python 3.4 and 3.5: https://bugs.python.org/issue22449
-    #
-    # Some further info on how OSX OpenSSL cert validation:
-    # https://hynek.me/articles/apple-openssl-verification-surprises/
-    #
-    import ssl
-    cert_datas = [(ssl.get_default_verify_paths().cafile, 'lib')]
-else:
-    cert_datas = []
 
 block_cipher = None
 
@@ -31,7 +9,7 @@ block_cipher = None
 a = Analysis(['conductr_cli/sandbox.py'],
              pathex=[os.path.abspath(os.getcwd())],
              binaries=[],
-             datas=cert_datas,
+             datas=[],
              hiddenimports=['psutil'],
              hookspath=[],
              runtime_hooks=[],

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ install_requires = [
     'colorama>=0.3.7',
     'pyreadline>=2.1',
     'www-authenticate==0.9.2',
+    'certifi>=2017.4.17',
 
     # FIXME: Remove the following dependencies when dcos can be depended on
     'jsonschema>=2.5, <3.0',


### PR DESCRIPTION
This is because when packaging as native executable, the `ssl.get_default_verify_paths().cafile` may return `None` depending on where the platform the packaging is performed on.

On Ubuntu 14 and Ubuntu 16, the `ssl.get_default_verify_paths().cafile` returns `None`, which means there are no cacert package in the Linux CLI executable. When this CLI executable is ran on other flavour of Linux (i.e. CoreOS), the HTTPS url access will fail due to SSL cert validation error.

By importing `certifi`, the cacert will be included as part of the `certifi`, and the `certifi`'s cacert is used when the CLI is ran as native executable.

The pip3 install of the CLI will retain its default behaviour, i.e. rely on the cacert supplied by default on the machine's Python 3.