### PR TITLE
Add resource info to conduct agents

### DIFF
--- a/conductr_cli/bytes_util.py
+++ b/conductr_cli/bytes_util.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2010 Jason Moiron and Contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+suffixes = {
+    'decimal': ('kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'),
+    'binary': ('KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'),
+    'gnu': "KMGTPEZY",
+}
+
+
+def natural_size(value, binary=False, gnu=False, _format='%.1f'):
+    """Format a number of byteslike a human readable filesize (eg. 10 kB).  By
+    default, decimal suffixes (kB, MB) are used.  Passing binary=true will use
+    binary suffixes (KiB, MiB) are used and the base will be 2**10 instead of
+    10**3.  If ``gnu`` is True, the binary argument is ignored and GNU-style
+    (ls -sh style) prefixes are used (K, M) with the 2**10 definition.
+    Non-gnu modes are compatible with jinja2's ``filesizeformat`` filter."""
+    if gnu:
+        suffix = suffixes['gnu']
+    elif binary:
+        suffix = suffixes['binary']
+    else:
+        suffix = suffixes['decimal']
+
+    base = 1024 if (gnu or binary) else 1000
+    _bytes = float(value)
+
+    if _bytes == 1 and not gnu:
+        return '1 Byte'
+    elif _bytes < base and not gnu:
+        return '%d Bytes' % _bytes
+    elif _bytes < base and gnu:
+        return '%dB' % _bytes
+
+    for i, s in enumerate(suffix):
+        unit = base ** (i + 2)
+        if _bytes < unit and not gnu:
+            return (_format + ' %s') % ((base * _bytes / unit), s)
+        elif _bytes < unit and gnu:
+            return (_format + '%s') % ((base * _bytes / unit), s)
+    if gnu:
+        return (_format + '%s') % ((base * _bytes / unit), s)
+    return (_format + ' %s') % ((base * _bytes / unit), s)

--- a/conductr_cli/test/test_bytes_util.py
+++ b/conductr_cli/test/test_bytes_util.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2010 Jason Moiron and Contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+from unittest import TestCase
+from conductr_cli import bytes_util
+
+
+class TestBytesUtil(TestCase):
+    def test_natural_size(self):
+        tests_and_expected_results = [
+            (300, '300 Bytes'),
+            (3000, '3.0 kB'),
+            (3000000, '3.0 MB'),
+            (3000000000, '3.0 GB'),
+            (3000000000000, '3.0 TB'),
+            ((300, True), '300 Bytes'),
+            ((3000, True), '2.9 KiB'),
+            ((3000000, True), '2.9 MiB'),
+            ((300, False, True), '300B'),
+            ((3000, False, True), '2.9K'),
+            ((3000000, False, True), '2.9M'),
+            ((1024, False, True), '1.0K'),
+            ((10**26 * 30, False, True), '2481.5Y'),
+            ((10**26 * 30, True), '2481.5 YiB'),
+            (10**26 * 30, '3000.0 YB'),
+            ((3141592, False, False, '%.2f'), '3.14 MB'),
+            ((3000, False, True, '%.3f'), '2.930K'),
+            ((3000000000, False, True, '%.0f'), '3G'),
+            ((10**26 * 30, True, False, '%.3f'), '2481.542 YiB')
+        ]
+        for args, expected_result in tests_and_expected_results:
+            if isinstance(args, tuple):
+                result = bytes_util.natural_size(*args)
+            else:
+                result = bytes_util.natural_size(args)
+            self.assertEqual(expected_result, result)

--- a/conductr_cli/test/test_conduct_agents.py
+++ b/conductr_cli/test/test_conduct_agents.py
@@ -25,7 +25,71 @@ class TestConductAgentsCommand(CliTestCase):
         'role': None
     }
 
-    fake_output = """
+    fake_output_with_resources = """
+        [
+          {
+            "address": "akka.tcp://conductr-agent@192.168.10.1:2552/user/reaper/cluster-client#-596247188",
+            "observedBy": [
+              {
+                "node": {
+                  "address": "akka.tcp://conductr@192.168.10.2:9004",
+                  "uid": "1129598726"
+                }
+              }
+            ],
+            "resourceAvailable": {
+              "diskSpace": 130841165824,
+              "memory": 5028888576,
+              "nrOfCpus": 4
+            },
+            "roles": [
+              "web",
+              "data"
+            ]
+          },
+          {
+            "address": "akka.tcp://conductr-agent@192.168.10.2:2552/user/reaper/cluster-client#-775189131",
+            "observedBy": [
+              {
+                "node": {
+                  "address": "akka.tcp://conductr@192.168.10.2:9004",
+                  "uid": "1129598726"
+                }
+              }
+            ],
+            "resourceAvailable": {
+              "diskSpace": 60841165824,
+              "memory": 3028888576,
+              "nrOfCpus": 8
+            },
+            "roles": [
+              "web"
+            ]
+          },
+          {
+            "address": "akka.tcp://conductr-agent@192.168.10.3:2552/user/reaper/cluster-client#1858099110",
+            "observedBy": [
+              {
+                "node": {
+                  "address": "akka.tcp://conductr@192.168.10.2:9004",
+                  "uid": "1129598726"
+                }
+              }
+            ],
+            "resourceAvailable": {
+              "diskSpace": 160841165824,
+              "memory": 4028888576,
+              "nrOfCpus": 2
+            },
+            "roles": [
+              "web",
+              "data"
+            ]
+          }
+        ]
+    """
+
+    fake_output_without_resources = """
         [
           {
             "address": "akka.tcp://conductr-agent@192.168.10.1:2552/user/reaper/cluster-client#-596247188",
@@ -74,10 +138,10 @@ class TestConductAgentsCommand(CliTestCase):
         ]
     """
 
-    def test_basic_usage(self):
+    def test_basic_usage_without_resources(self):
         self.maxDiff = None
 
-        http_method = self.respond_with(text=self.fake_output)
+        http_method = self.respond_with(text=self.fake_output_without_resources)
 
         stdout = MagicMock()
 
@@ -91,10 +155,34 @@ class TestConductAgentsCommand(CliTestCase):
                                        timeout=DEFAULT_HTTP_TIMEOUT, headers={'Host': '127.0.0.1'})
 
         self.assertEqual(
-            strip_margin("""|ADDRESS                                                                            ROLES                               OBSERVED BY
+            strip_margin("""|ADDRESS                                                                            ROLES     OBSERVED BY
                             |akka.tcp://conductr-agent@192.168.10.1:2552/user/reaper/cluster-client#-596247188  web,data  akka.tcp://conductr@192.168.10.2:9004
                             |akka.tcp://conductr-agent@192.168.10.2:2552/user/reaper/cluster-client#-775189131  web       akka.tcp://conductr@192.168.10.2:9004
                             |akka.tcp://conductr-agent@192.168.10.3:2552/user/reaper/cluster-client#1858099110  web,data  akka.tcp://conductr@192.168.10.2:9004
+                            |"""),
+            self.output(stdout))
+
+    def test_basic_usage_with_resources(self):
+        self.maxDiff = None
+
+        http_method = self.respond_with(text=self.fake_output_with_resources)
+
+        stdout = MagicMock()
+
+        input_args = MagicMock(**self.default_args)
+        with patch('requests.get', http_method):
+            logging_setup.configure_logging(input_args, stdout)
+            result = conduct_agents.agents(input_args)
+            self.assertTrue(result)
+
+        http_method.assert_called_with(self.default_url, auth=self.conductr_auth, verify=self.server_verification_file,
+                                       timeout=DEFAULT_HTTP_TIMEOUT, headers={'Host': '127.0.0.1'})
+
+        self.assertEqual(
+            strip_margin("""|ADDRESS                                                                                DISK      MEM  CPUS  ROLES     OBSERVED BY
+                            |akka.tcp://conductr-agent@192.168.10.1:2552/user/reaper/cluster-client#-596247188  130.8 GB  4.7 GiB     4  web,data  akka.tcp://conductr@192.168.10.2:9004
+                            |akka.tcp://conductr-agent@192.168.10.2:2552/user/reaper/cluster-client#-775189131   60.8 GB  2.8 GiB     8  web       akka.tcp://conductr@192.168.10.2:9004
+                            |akka.tcp://conductr-agent@192.168.10.3:2552/user/reaper/cluster-client#1858099110  160.8 GB  3.8 GiB     2  web,data  akka.tcp://conductr@192.168.10.2:9004
                             |"""),
             self.output(stdout))
 
@@ -103,7 +191,7 @@ class TestConductAgentsCommand(CliTestCase):
 
         filtered_by_role_asdf_args = self.default_args.copy()
         filtered_by_role_asdf_args.update({'role': 'asdf'})
-        http_method = self.respond_with(text=self.fake_output)
+        http_method = self.respond_with(text=self.fake_output_with_resources)
 
         stdout = MagicMock()
 
@@ -116,7 +204,7 @@ class TestConductAgentsCommand(CliTestCase):
         http_method.assert_called_with(self.default_url, auth=self.conductr_auth, verify=self.server_verification_file,
                                        timeout=DEFAULT_HTTP_TIMEOUT, headers={'Host': '127.0.0.1'})
         self.assertEqual(
-            strip_margin("""|ADDRESS  ROLES  OBSERVED BY
+            strip_margin("""|ADDRESS  DISK  MEM  CPUS  ROLES  OBSERVED BY
                             |"""),
             self.output(stdout))
 
@@ -126,7 +214,7 @@ class TestConductAgentsCommand(CliTestCase):
         filtered_by_role_web_args = self.default_args.copy()
         filtered_by_role_web_args.update({'role': 'web'})
 
-        http_method = self.respond_with(text=self.fake_output)
+        http_method = self.respond_with(text=self.fake_output_with_resources)
 
         stdout = MagicMock()
 
@@ -139,10 +227,10 @@ class TestConductAgentsCommand(CliTestCase):
         http_method.assert_called_with(self.default_url, auth=self.conductr_auth, verify=self.server_verification_file,
                                        timeout=DEFAULT_HTTP_TIMEOUT, headers={'Host': '127.0.0.1'})
         self.assertEqual(
-            strip_margin("""|ADDRESS                                                                            ROLES                               OBSERVED BY
-                            |akka.tcp://conductr-agent@192.168.10.1:2552/user/reaper/cluster-client#-596247188  web,data  akka.tcp://conductr@192.168.10.2:9004
-                            |akka.tcp://conductr-agent@192.168.10.2:2552/user/reaper/cluster-client#-775189131  web       akka.tcp://conductr@192.168.10.2:9004
-                            |akka.tcp://conductr-agent@192.168.10.3:2552/user/reaper/cluster-client#1858099110  web,data  akka.tcp://conductr@192.168.10.2:9004
+            strip_margin("""|ADDRESS                                                                                DISK      MEM  CPUS  ROLES     OBSERVED BY
+                            |akka.tcp://conductr-agent@192.168.10.1:2552/user/reaper/cluster-client#-596247188  130.8 GB  4.7 GiB     4  web,data  akka.tcp://conductr@192.168.10.2:9004
+                            |akka.tcp://conductr-agent@192.168.10.2:2552/user/reaper/cluster-client#-775189131   60.8 GB  2.8 GiB     8  web       akka.tcp://conductr@192.168.10.2:9004
+                            |akka.tcp://conductr-agent@192.168.10.3:2552/user/reaper/cluster-client#1858099110  160.8 GB  3.8 GiB     2  web,data  akka.tcp://conductr@192.168.10.2:9004
                             |"""),
             self.output(stdout))
 
@@ -152,7 +240,7 @@ class TestConductAgentsCommand(CliTestCase):
         filtered_by_role_web_args = self.default_args.copy()
         filtered_by_role_web_args.update({'role': 'data'})
 
-        http_method = self.respond_with(text=self.fake_output)
+        http_method = self.respond_with(text=self.fake_output_with_resources)
 
         stdout = MagicMock()
 
@@ -165,8 +253,8 @@ class TestConductAgentsCommand(CliTestCase):
         http_method.assert_called_with(self.default_url, auth=self.conductr_auth, verify=self.server_verification_file,
                                        timeout=DEFAULT_HTTP_TIMEOUT, headers={'Host': '127.0.0.1'})
         self.assertEqual(
-            strip_margin("""|ADDRESS                                                                            ROLES                               OBSERVED BY
-                            |akka.tcp://conductr-agent@192.168.10.1:2552/user/reaper/cluster-client#-596247188  web,data  akka.tcp://conductr@192.168.10.2:9004
-                            |akka.tcp://conductr-agent@192.168.10.3:2552/user/reaper/cluster-client#1858099110  web,data  akka.tcp://conductr@192.168.10.2:9004
+            strip_margin("""|ADDRESS                                                                                DISK      MEM  CPUS  ROLES     OBSERVED BY
+                            |akka.tcp://conductr-agent@192.168.10.1:2552/user/reaper/cluster-client#-596247188  130.8 GB  4.7 GiB     4  web,data  akka.tcp://conductr@192.168.10.2:9004
+                            |akka.tcp://conductr-agent@192.168.10.3:2552/user/reaper/cluster-client#1858099110  160.8 GB  3.8 GiB     2  web,data  akka.tcp://conductr@192.168.10.2:9004
                             |"""),
             self.output(stdout))


### PR DESCRIPTION
Adding the following resource information to the `conduct agents` output for a given ConductR agent node:
- Disk space
- Memory
- Nr of CPUS

`conduct agents` decides based on the ConductR JSON response if the resource information are displayed or not. For newer ConductR versions it will display the information, for older ConductR versions not - depending if the information is part of the JSON response.

```
$ conduct agents
ADDRESS                                                                                DISK      MEM  CPUS  ROLES     OBSERVED BY
akka.tcp://conductr-agent@192.168.10.1:2552/user/reaper/cluster-client#-596247188  130.8 GB  4.7 GiB     4  web,data  akka.tcp://conductr@192.168.10.2:9004
akka.tcp://conductr-agent@192.168.10.2:2552/user/reaper/cluster-client#-775189131   60.8 GB  2.8 GiB     8  web       akka.tcp://conductr@192.168.10.2:9004
akka.tcp://conductr-agent@192.168.10.3:2552/user/reaper/cluster-client#1858099110  160.8 GB  3.8 GiB     2  web,data  akka.tcp://conductr@192.168.10.2:9004
```

The disk space is displayed as human-readable decimal size, e.g. GB. The memory is displayed as human readable binary size, e.g. GiB. The formatting logic has been copied from https://github.com/jmoiron/humanize/blob/master/humanize/filesize.py. Therefore, this new python module contains the license information of the [humanize](https://github.com/jmoiron/humanize/blob/master/LICENCE) license.

This PR is based on the conductr PR https://github.com/typesafehub/conductr/pull/1799