### PR TITLE
use `path-beg` instead of `path` for bndl ACLs

### DIFF
--- a/conductr_cli/endpoint.py
+++ b/conductr_cli/endpoint.py
@@ -112,7 +112,7 @@ class HttpRequest:
 
     def hocon(self):
         request_tree = ConfigTree()
-        request_tree.put(self.match if self.match else 'path', self.value)
+        request_tree.put(self.match if self.match else 'path-beg', self.value)
         if self.method:
             request_tree.put('method', self.method)
         if self.rewrite:

--- a/conductr_cli/test/test_bndl_utils.py
+++ b/conductr_cli/test/test_bndl_utils.py
@@ -434,7 +434,7 @@ class TestBndlUtils(CliTestCase):
                |      http {
                |        requests = [
                |          {
-               |            path = "/"
+               |            path-beg = "/"
                |          }
                |        ]
                |      }


### PR DESCRIPTION
This PR modifies the CLI so that by default ACLs are specified as `path-beg` instead of `path` as this is a more common scenario.

Fixes #483 