### PR TITLE
Improve reporting for resolver related errors

### DIFF
--- a/conductr_cli/exceptions.py
+++ b/conductr_cli/exceptions.py
@@ -30,8 +30,10 @@ class MalformedBundleError(Exception):
 
 
 class BundleResolutionError(Exception):
-    def __init__(self, value):
+    def __init__(self, value, cache_resolution_errors, bundle_resolution_errors):
         self.value = value
+        self.cache_resolution_errors = cache_resolution_errors
+        self.bundle_resolution_errors = bundle_resolution_errors
 
     def __str__(self):
         return repr(self.value)

--- a/conductr_cli/resolvers/bintray_resolver.py
+++ b/conductr_cli/resolvers/bintray_resolver.py
@@ -31,18 +31,18 @@ def resolve_bundle(cache_dir, uri):
         bintray_auth = load_bintray_credentials(raise_error=False)
         resolved_version = bintray_resolve_version(bintray_auth, org, repo, package_name, tag, digest)
         return bintray_download_artefact(cache_dir, resolved_version, bintray_auth)
-    except MalformedBundleUriError:
-        return False, None, None
-    except HTTPError as http_error:
-        return handle_http_error(http_error, org, repo)
-    except ConnectionError:
-        return False, None, None
+    except MalformedBundleUriError as e:
+        return False, None, None, e
+    except HTTPError as e:
+        return False, None, None, e
+    except ConnectionError as e:
+        return False, None, None, e
 
 
 def load_bundle_from_cache(cache_dir, uri):
     # When the supplied uri points to a local file, don't load from cache so file can be used as is.
     if is_local_file(uri, require_bundle_conf=True):
-        return False, None, None
+        return False, None, None, None
     else:
         log = logging.getLogger(__name__)
         try:
@@ -53,13 +53,13 @@ def load_bundle_from_cache(cache_dir, uri):
             if resolved_version:
                 return uri_resolver.load_bundle_from_cache(cache_dir, resolved_version['download_url'])
             else:
-                return False, None, None
-        except MalformedBundleUriError:
-            return False, None, None
-        except HTTPError as http_error:
-            return handle_http_error(http_error, org, repo)
-        except ConnectionError:
-            return False, None, None
+                return False, None, None, None
+        except MalformedBundleUriError as e:
+            return False, None, None, e
+        except HTTPError as e:
+            return False, None, None, e
+        except ConnectionError as e:
+            return False, None, None, e
 
 
 def resolve_bundle_configuration(cache_dir, uri):
@@ -70,18 +70,18 @@ def resolve_bundle_configuration(cache_dir, uri):
         bintray_auth = load_bintray_credentials(raise_error=False)
         resolved_version = bintray_resolve_version(bintray_auth, org, repo, package_name, tag, digest)
         return bintray_download_artefact(cache_dir, resolved_version, bintray_auth)
-    except MalformedBundleUriError:
-        return False, None, None
-    except HTTPError as http_error:
-        return handle_http_error(http_error, org, repo)
-    except ConnectionError:
-        return False, None, None
+    except MalformedBundleUriError as e:
+        return False, None, None, e
+    except HTTPError as e:
+        return False, None, None, e
+    except ConnectionError as e:
+        return False, None, None, e
 
 
 def load_bundle_configuration_from_cache(cache_dir, uri):
     # When the supplied uri points to a local file, don't load from cache so file can be used as is.
     if is_local_file(uri, require_bundle_conf=False):
-        return False, None, None
+        return False, None, None, None
     else:
         log = logging.getLogger(__name__)
         try:
@@ -94,13 +94,13 @@ def load_bundle_configuration_from_cache(cache_dir, uri):
             if resolved_version:
                 return uri_resolver.load_bundle_from_cache(cache_dir, resolved_version['download_url'])
             else:
-                return False, None, None
-        except MalformedBundleUriError:
-            return False, None, None
-        except HTTPError as http_error:
-            return handle_http_error(http_error, org, repo)
-        except ConnectionError:
-            return False, None, None
+                return False, None, None, None
+        except MalformedBundleUriError as e:
+            return False, None, None, e
+        except HTTPError as e:
+            return False, None, None, e
+        except ConnectionError as e:
+            return False, None, None, e
 
 
 def handle_http_error(http_error, org, repo):
@@ -123,13 +123,13 @@ def resolve_bundle_version(uri):
         urn, org, repo, package_name, tag, digest = bundle_shorthand.parse_bundle(uri)
         log.info(log_message('Resolving bundle version', org, repo, package_name, tag, digest))
         resolved_version = bintray_resolve_version(bintray_auth, org, repo, package_name, tag=tag, digest=digest)
-        return resolved_version if resolved_version else None
-    except MalformedBundleUriError:
-        return None
-    except HTTPError:
-        return None
-    except ConnectionError:
-        return None
+        return (resolved_version, None) if resolved_version else (None, None)
+    except MalformedBundleUriError as e:
+        return None, e
+    except HTTPError as e:
+        return None, e
+    except ConnectionError as e:
+        return None, e
 
 
 def continuous_delivery_uri(resolved_version):
@@ -147,7 +147,7 @@ def bintray_download_artefact(cache_dir, artefact, auth, raise_error=False):
     if artefact:
         return uri_resolver.resolve_file(cache_dir, artefact['download_url'], auth, raise_error)
     else:
-        return False, None, None
+        return False, None, None, None
 
 
 def load_bintray_credentials(raise_error=True, disable_instructions=False):

--- a/conductr_cli/resolvers/docker_offline_resolver.py
+++ b/conductr_cli/resolvers/docker_offline_resolver.py
@@ -6,23 +6,23 @@ def resolve_bundle(cache_dir, uri, auth=None):
 
 
 def resolve_file(cache_dir, uri, auth=None):
-    return False, None, None
+    return False, None, None, None
 
 
 def load_bundle_from_cache(cache_dir, uri):
-    return False, None, None
+    return False, None, None, None
 
 
 def resolve_bundle_configuration(cache_dir, uri, auth=None):
-    return False, None, None
+    return False, None, None, None
 
 
 def load_bundle_configuration_from_cache(cache_dir, uri):
-    return False, None, None
+    return False, None, None, None
 
 
 def resolve_bundle_version(uri):
-    return None
+    return None, None
 
 
 def continuous_delivery_uri(resolved_version):

--- a/conductr_cli/resolvers/docker_resolver.py
+++ b/conductr_cli/resolvers/docker_resolver.py
@@ -168,10 +168,8 @@ def resolve_bundle(cache_dir, uri, auth=None):
 
 
 def do_resolve_bundle(cache_dir, uri, auth, offline_mode):
-    log = logging.getLogger(__name__)
-
     if is_local_file(uri, require_bundle_conf=True):
-        return False, None, None
+        return False, None, None, None
 
     (provided_url, url), (provided_ns, ns), (provided_image, image), (provided_tag, tag) = parse_uri(uri)
 
@@ -181,12 +179,12 @@ def do_resolve_bundle(cache_dir, uri, auth, offline_mode):
         manifest = fetch_manifest(cache_dir, url, ns, image, tag, offline_mode)
 
         if manifest is None:
-            return False, None, None
+            return False, None, None, None
 
         files = fetch_blobs(cache_dir, url, ns, image, [manifest['config']] + manifest['layers'], offline_mode)
 
         if files is None:
-            return False, None, None
+            return False, None, None, None
 
         shutil.copyfile(
             files[manifest['config']['digest']],
@@ -249,26 +247,25 @@ def do_resolve_bundle(cache_dir, uri, auth, offline_mode):
         with open(os.path.join(temp_dir, 'repositories'), 'w', encoding="utf-8") as repositories_fileobj:
             repositories_fileobj.write(json.dumps(repositories))
 
-        return True, None, temp_dir
+        return True, None, temp_dir, None
     except Exception as e:
-        log.debug(e, exc_info=1)
-        return False, None, None
+        return False, None, None, e
 
 
 def load_bundle_from_cache(cache_dir, uri):
-    return False, None, None
+    return False, None, None, None
 
 
 def resolve_bundle_configuration(cache_dir, uri, auth=None):
-    return False, None, None
+    return False, None, None, None
 
 
 def load_bundle_configuration_from_cache(cache_dir, uri):
-    return False, None, None
+    return False, None, None, None
 
 
 def resolve_bundle_version(uri):
-    return None
+    return None, None
 
 
 def continuous_delivery_uri(resolved_version):

--- a/conductr_cli/resolvers/offline_resolver.py
+++ b/conductr_cli/resolvers/offline_resolver.py
@@ -13,9 +13,9 @@ def resolve_file(cache_dir, uri, auth=None):
     if os.path.exists(uri):
         abs_path = os.path.abspath(uri)
         log.info('Retrieving {}'.format(abs_path))
-        return True, os.path.basename(abs_path), abs_path
+        return True, os.path.basename(abs_path), abs_path, None
     else:
-        return False, None, None
+        return False, None, None, None
 
 
 def load_bundle_from_cache(cache_dir, uri):
@@ -37,9 +37,9 @@ def load_bundle_from_cache(cache_dir, uri):
             latest_bundle_file = max(cached_bundles, key=os.path.getctime)
             bundle_name = os.path.basename(latest_bundle_file)
             log.info('Retrieving from cache {}'.format(latest_bundle_file))
-            return True, bundle_name, latest_bundle_file
+            return True, bundle_name, latest_bundle_file, None
 
-    return False, None, None
+    return False, None, None, None
 
 
 def resolve_bundle_configuration(cache_dir, uri, auth=None):
@@ -51,7 +51,7 @@ def load_bundle_configuration_from_cache(cache_dir, uri):
 
 
 def resolve_bundle_version(uri):
-    return None
+    return None, None
 
 
 def continuous_delivery_uri(resolved_version):

--- a/conductr_cli/resolvers/stdin_resolver.py
+++ b/conductr_cli/resolvers/stdin_resolver.py
@@ -7,7 +7,7 @@ ALLOCATED_FILES = []
 
 def resolve_bundle(cache_dir, uri, auth=None):
     if sys.stdin.isatty() or uri != '-':
-        return False, None, None
+        return False, None, None, None
     else:
         temp = tempfile.NamedTemporaryFile(delete=False)
 
@@ -28,23 +28,23 @@ def resolve_bundle(cache_dir, uri, auth=None):
 
         ALLOCATED_FILES.append(temp)
 
-        return True, None, temp.name
+        return True, None, temp.name, None
 
 
 def load_bundle_from_cache(cache_dir, uri):
-    return False, None, None
+    return False, None, None, None
 
 
 def resolve_bundle_configuration(cache_dir, uri, auth=None):
-    return False, None, None
+    return False, None, None, None
 
 
 def load_bundle_configuration_from_cache(cache_dir, uri):
-    return False, None, None
+    return False, None, None, None
 
 
 def resolve_bundle_version(uri):
-    return None
+    return None, None
 
 
 def continuous_delivery_uri(resolved_version):

--- a/conductr_cli/resolvers/test/test_docker_resolver.py
+++ b/conductr_cli/resolvers/test/test_docker_resolver.py
@@ -1,0 +1,105 @@
+from conductr_cli.resolvers import docker_resolver
+from unittest import TestCase
+from unittest.mock import call, patch, MagicMock
+import tempfile
+
+
+class TestResolverDocker(TestCase):
+    def test_parse_uri(self):
+        self.assertEqual(docker_resolver.parse_uri('alpine'), (
+            (None, 'registry.hub.docker.com'),
+            (None, 'library'),
+            ('alpine', 'alpine'),
+            (None, 'latest')
+        ))
+
+        self.assertEqual(docker_resolver.parse_uri('alpine:3.5'), (
+            (None, 'registry.hub.docker.com'),
+            (None, 'library'),
+            ('alpine', 'alpine'),
+            ('3.5', '3.5')
+        ))
+
+        self.assertEqual(docker_resolver.parse_uri('lightbend-docker.registry.bintray.io/conductr/oci-in-docker'), (
+            ('lightbend-docker.registry.bintray.io', 'lightbend-docker.registry.bintray.io'),
+            ('conductr', 'conductr'),
+            ('oci-in-docker', 'oci-in-docker'),
+            (None, 'latest')
+        ))
+
+        self.assertEqual(docker_resolver.parse_uri('lightbend-docker.registry.bintray.io/conductr/oci-in-docker:0.1'), (
+            ('lightbend-docker.registry.bintray.io', 'lightbend-docker.registry.bintray.io'),
+            ('conductr', 'conductr'),
+            ('oci-in-docker', 'oci-in-docker'),
+            ('0.1', '0.1')
+        ))
+
+    def test_offline_mode(self):
+        mock_is_file = MagicMock(return_value=True)
+        mock_json_load = MagicMock(return_value='1234')
+        mock_open = MagicMock(return_value=MagicMock())
+
+        with \
+                patch('os.path.isfile', mock_is_file), \
+                patch('json.load', mock_json_load), \
+                patch('builtins.open', mock_open):
+            self.assertEqual(
+                docker_resolver.fetch_manifest('/tmp', 'registry.hub.docker.com', 'library', 'alpine', '3.5', True),
+                '1234'
+            )
+
+        mock_is_file.assert_called_once_with('/tmp/docker-manifest-624ab327c0f6bb1039ca62'
+                                             '9a2c1ec806514b9194c30491c02e9800254c73d998')
+
+    def test_load_docker_credentials(self):
+        with \
+                tempfile.NamedTemporaryFile('w') as one, \
+                tempfile.NamedTemporaryFile('w') as two, \
+                tempfile.NamedTemporaryFile('w') as three:
+            one.write('user=one\npassword=one-password')
+            one.flush()
+            two.write('username=two\npassword=two-password')
+            two.flush()
+            three.write('hello')
+            three.flush()
+
+            with \
+                    open(one.name, 'r') as one_in, \
+                    patch('os.path.exists', MagicMock(return_value=True)), \
+                    patch('builtins.open', MagicMock(return_value=one_in)):
+                self.assertEqual(
+                    docker_resolver.load_docker_credentials('test'),
+                    ('one', 'one-password')
+                )
+
+            with \
+                    open(two.name, 'r') as two_in, \
+                    patch('os.path.exists', MagicMock(return_value=True)), \
+                    patch('builtins.open', MagicMock(return_value=two_in)):
+                self.assertEqual(
+                    docker_resolver.load_docker_credentials('test'),
+                    ('two', 'two-password')
+                )
+
+            with \
+                    open(three.name, 'r') as three_in, \
+                    patch('os.path.exists', MagicMock(return_value=True)), \
+                    patch('builtins.open', MagicMock(return_value=three_in)):
+                self.assertEqual(
+                    docker_resolver.load_docker_credentials('test'),
+                    None
+                )
+
+            path_exists_mock = MagicMock(side_effect=[False, True])
+
+            with \
+                    open(one.name, 'r') as one_in, \
+                    patch('os.path.exists', path_exists_mock), \
+                    MagicMock(return_value=one_in) as open_mock, \
+                    patch('builtins.open', open_mock):
+                docker_resolver.load_docker_credentials('test')
+
+                path_exists_mock.assert_has_calls([
+                    call('{}-{}'.format(docker_resolver.DOCKER_CREDENTIAL_FILE_PATH, 'test')),
+                    call(docker_resolver.DOCKER_CREDENTIAL_FILE_PATH)
+                ])

--- a/conductr_cli/resolvers/test/test_offline_resolver.py
+++ b/conductr_cli/resolvers/test/test_offline_resolver.py
@@ -20,7 +20,7 @@ class TestResolveBundle(CliTestCase):
         with patch('os.path.exists', mock_exists), \
                 patch('os.path.abspath', mock_abspath):
             logging_setup.configure_logging(args, stdout)
-            self.assertEqual((True, 'bundle.zip', self.abspath),
+            self.assertEqual((True, 'bundle.zip', self.abspath, None),
                              offline_resolver.resolve_bundle(self.cache_dir, self.abspath))
 
         mock_exists.assert_called_once_with(self.abspath)
@@ -39,7 +39,7 @@ class TestResolveBundle(CliTestCase):
 
         with patch('os.path.exists', mock_exists):
             logging_setup.configure_logging(args, stdout)
-            self.assertEqual((False, None, None),
+            self.assertEqual((False, None, None, None),
                              offline_resolver.resolve_bundle(self.cache_dir, self.abspath))
 
         mock_exists.assert_called_once_with(self.abspath)
@@ -63,7 +63,7 @@ class TestResolveBundleConfiguration(CliTestCase):
         with patch('os.path.exists', mock_exists), \
                 patch('os.path.abspath', mock_abspath):
             logging_setup.configure_logging(args, stdout)
-            self.assertEqual((True, 'bundle-configuration.zip', self.abspath),
+            self.assertEqual((True, 'bundle-configuration.zip', self.abspath, None),
                              offline_resolver.resolve_bundle_configuration(self.cache_dir, self.abspath))
 
         mock_exists.assert_called_once_with(self.abspath)
@@ -82,7 +82,7 @@ class TestResolveBundleConfiguration(CliTestCase):
 
         with patch('os.path.exists', mock_exists):
             logging_setup.configure_logging(args, stdout)
-            self.assertEqual((False, None, None),
+            self.assertEqual((False, None, None, None),
                              offline_resolver.resolve_bundle_configuration(self.cache_dir, self.abspath))
 
         mock_exists.assert_called_once_with(self.abspath)
@@ -110,7 +110,7 @@ class TestLoadBundleFromCache(CliTestCase):
         with patch('glob.glob', mock_glob), \
                 patch('os.path.getctime', mock_getctime):
             logging_setup.configure_logging(args, stdout)
-            self.assertEqual((True, 'path-2.zip', '~/.conductr/cache/path-2.zip'),
+            self.assertEqual((True, 'path-2.zip', '~/.conductr/cache/path-2.zip', None),
                              offline_resolver.load_bundle_from_cache(self.cache_dir, 'visualizer'))
 
         mock_glob.assert_called_once_with('~/.conductr/cache/visualizer*')
@@ -133,7 +133,7 @@ class TestLoadBundleFromCache(CliTestCase):
 
         with patch('glob.glob', mock_glob):
             logging_setup.configure_logging(args, stdout)
-            self.assertEqual((False, None, None),
+            self.assertEqual((False, None, None, None),
                              offline_resolver.load_bundle_from_cache(self.cache_dir, 'visualizer'))
 
         mock_glob.assert_called_once_with('~/.conductr/cache/visualizer*')
@@ -141,9 +141,9 @@ class TestLoadBundleFromCache(CliTestCase):
         self.assertEqual('', self.output(stdout))
 
     def test_not_bundle_name(self):
-        self.assertEqual((False, None, None),
+        self.assertEqual((False, None, None, None),
                          offline_resolver.load_bundle_from_cache(self.cache_dir, '/tmp/visualizer.zip'))
-        self.assertEqual((False, None, None),
+        self.assertEqual((False, None, None, None),
                          offline_resolver.load_bundle_from_cache(self.cache_dir, 'visualizer.zip'))
 
 
@@ -167,7 +167,7 @@ class TestLoadBundleConfigurationFromCache(CliTestCase):
         with patch('glob.glob', mock_glob), \
                 patch('os.path.getctime', mock_getctime):
             logging_setup.configure_logging(args, stdout)
-            self.assertEqual((True, 'path-2.zip', '~/.conductr/cache/path-2.zip'),
+            self.assertEqual((True, 'path-2.zip', '~/.conductr/cache/path-2.zip', None),
                              offline_resolver.load_bundle_configuration_from_cache(self.cache_dir,
                                                                                    'conductr-haproxy-dev-mode'))
 
@@ -191,7 +191,7 @@ class TestLoadBundleConfigurationFromCache(CliTestCase):
 
         with patch('glob.glob', mock_glob):
             logging_setup.configure_logging(args, stdout)
-            self.assertEqual((False, None, None),
+            self.assertEqual((False, None, None, None),
                              offline_resolver.load_bundle_configuration_from_cache(self.cache_dir,
                                                                                    'conductr-haproxy-dev-mode'))
 
@@ -200,17 +200,17 @@ class TestLoadBundleConfigurationFromCache(CliTestCase):
         self.assertEqual('', self.output(stdout))
 
     def test_not_bundle_name(self):
-        self.assertEqual((False, None, None),
+        self.assertEqual((False, None, None, None),
                          offline_resolver.load_bundle_configuration_from_cache(self.cache_dir,
                                                                                '/tmp/conductr-haproxy-dev-mode.zip'))
-        self.assertEqual((False, None, None),
+        self.assertEqual((False, None, None, None),
                          offline_resolver.load_bundle_configuration_from_cache(self.cache_dir,
                                                                                'conductr-haproxy-dev-mode.zip'))
 
 
 class TestResolveBundleVersion(CliTestCase):
     def test_return_none(self):
-        self.assertIsNone(offline_resolver.resolve_bundle_version('visualizer'))
+        self.assertEqual((None, None), offline_resolver.resolve_bundle_version('visualizer'))
 
 
 class TestContinuousDeliveryUri(CliTestCase):

--- a/conductr_cli/resolvers/test/test_stdin_resolver.py
+++ b/conductr_cli/resolvers/test/test_stdin_resolver.py
@@ -1,0 +1,74 @@
+from conductr_cli.resolver import stdin_resolver
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+import tempfile
+
+
+class TestResolverStdIn(TestCase):
+    def test_resolve_bundle_tty_in(self):
+        with patch('sys.stdin.isatty', lambda: True):
+            self.assertEqual(
+                stdin_resolver.resolve_bundle('/some/cache/dir', None, None),
+                (False, None, None, None)
+            )
+
+    def test_resolve_bundle_not_used_for_given_file(self):
+        with patch('sys.stdin.isatty', lambda: False):
+            self.assertEqual(
+                stdin_resolver.resolve_bundle('/some/cache/dir', 'somefile.zip', None),
+                (False, None, None, None)
+            )
+
+    def test_resolve_bundle_file_in(self):
+        read_mock = MagicMock(side_effect=[b'hello', b''])
+
+        file = tempfile.NamedTemporaryFile()
+
+        with patch('sys.stdin.isatty', lambda: False), \
+                patch('sys.stdin.buffer.read', read_mock), \
+                patch('tempfile.NamedTemporaryFile', MagicMock(return_value=file)):
+            self.assertEqual(
+                stdin_resolver.resolve_bundle('/some/cache/dir', '-', None),
+                (True, None, file.name, None)
+            )
+
+            file.seek(0)
+
+            self.assertEqual(file.read(), b'hello')
+
+    def test_load_bundle_from_cache(self):
+        mock_cache_dir = MagicMock()
+        mock_uri = MagicMock()
+
+        self.assertEqual(stdin_resolver.load_bundle_from_cache(mock_cache_dir, mock_uri),
+                         (False, None, None, None))
+
+    def test_resolve_bundle_configuration(self):
+        mock_cache_dir = MagicMock()
+        mock_uri = MagicMock()
+        mock_auth = MagicMock()
+
+        self.assertEqual(stdin_resolver.resolve_bundle_configuration(mock_cache_dir, mock_uri, mock_auth),
+                         (False, None, None, None))
+
+    def test_load_bundle_configuration_from_cache(self):
+        mock_cache_dir = MagicMock()
+        mock_uri = MagicMock()
+
+        self.assertEqual(stdin_resolver.load_bundle_configuration_from_cache(mock_cache_dir, mock_uri),
+                         (False, None, None, None))
+
+    def test_resolve_bundle_version(self):
+        mock_uri = MagicMock()
+
+        self.assertEqual(stdin_resolver.resolve_bundle_version(mock_uri),
+                         (None, None))
+
+    def test_continuous_delivery_uri(self):
+        mock_resolved_version = MagicMock()
+
+        self.assertIsNone(stdin_resolver.continuous_delivery_uri(mock_resolved_version))
+
+    def test_is_bundle_name(self):
+        self.assertTrue(stdin_resolver.is_bundle_name('visualizer'))
+        self.assertFalse(stdin_resolver.is_bundle_name('/tmp/foo.zip'))

--- a/conductr_cli/resolvers/test/test_uri_resolver.py
+++ b/conductr_cli/resolvers/test/test_uri_resolver.py
@@ -27,10 +27,8 @@ class TestResolveBundle(TestCase):
                 patch('conductr_cli.resolvers.uri_resolver.get_url', get_url_mock), \
                 patch('conductr_cli.resolvers.uri_resolver.urlretrieve', urlretrieve_mock), \
                 patch('logging.getLogger', get_logger_mock):
-            is_resolved, bundle_name, bundle_file = uri_resolver.resolve_bundle('/cache-dir', '/bundle-url')
-            self.assertTrue(is_resolved)
-            self.assertEqual('bundle-name', bundle_name)
-            self.assertEqual('/bundle-cached-path', bundle_file)
+            result = uri_resolver.resolve_bundle('/cache-dir', '/bundle-url')
+            self.assertEqual((True, 'bundle-name', '/bundle-cached-path', None), result)
 
         self.assertEqual([
             call('/cache-dir'),
@@ -64,10 +62,8 @@ class TestResolveBundle(TestCase):
                 patch('conductr_cli.resolvers.uri_resolver.get_url', get_url_mock), \
                 patch('conductr_cli.resolvers.uri_resolver.urlretrieve', urlretrieve_mock), \
                 patch('logging.getLogger', get_logger_mock):
-            is_resolved, bundle_name, bundle_file = uri_resolver.resolve_bundle('/cache-dir', '/bundle-url')
-            self.assertTrue(is_resolved)
-            self.assertEqual('bundle-name', bundle_name)
-            self.assertEqual('/bundle-cached-path', bundle_file)
+            result = uri_resolver.resolve_bundle('/cache-dir', '/bundle-url')
+            self.assertEqual((True, 'bundle-name', '/bundle-cached-path', None), result)
 
         self.assertEqual([
             call('/cache-dir'),
@@ -85,7 +81,8 @@ class TestResolveBundle(TestCase):
     def test_resolve_not_found(self):
         os_path_exists_mock = MagicMock(side_effect=[True, False])
         cache_path_mock = MagicMock(return_value='/bundle-cached-path')
-        urlretrieve_mock = MagicMock(side_effect=URLError('no_such.bundle'))
+        error = URLError('no_such.bundle')
+        urlretrieve_mock = MagicMock(side_effect=error)
         get_url_mock = MagicMock(return_value=('bundle-name', '/bundle-url-resolved'))
 
         get_logger_mock, log_mock = create_mock_logger()
@@ -95,10 +92,8 @@ class TestResolveBundle(TestCase):
                 patch('conductr_cli.resolvers.uri_resolver.get_url', get_url_mock), \
                 patch('conductr_cli.resolvers.uri_resolver.urlretrieve', urlretrieve_mock), \
                 patch('logging.getLogger', get_logger_mock):
-            is_resolved, bundle_name, bundle_file = uri_resolver.resolve_bundle('/cache-dir', '/bundle-url')
-            self.assertFalse(is_resolved)
-            self.assertIsNone(bundle_name)
-            self.assertIsNone(bundle_file)
+            result = uri_resolver.resolve_bundle('/cache-dir', '/bundle-url')
+            self.assertEqual((False, None, None, error), result)
 
         self.assertEqual([
             call('/cache-dir'),
@@ -132,11 +127,8 @@ class TestResolveBundleConfiguration(TestCase):
                 patch('conductr_cli.resolvers.uri_resolver.get_url', get_url_mock), \
                 patch('conductr_cli.resolvers.uri_resolver.urlretrieve', urlretrieve_mock), \
                 patch('logging.getLogger', get_logger_mock):
-            is_resolved, bundle_name, bundle_file = uri_resolver.resolve_bundle_configuration('/cache-dir',
-                                                                                              '/bundle-url')
-            self.assertTrue(is_resolved)
-            self.assertEqual('bundle-name', bundle_name)
-            self.assertEqual('/bundle-cached-path', bundle_file)
+            result = uri_resolver.resolve_bundle_configuration('/cache-dir', '/bundle-url')
+            self.assertEqual((True, 'bundle-name', '/bundle-cached-path', None), result)
 
         self.assertEqual([
             call('/cache-dir'),
@@ -170,11 +162,8 @@ class TestResolveBundleConfiguration(TestCase):
                 patch('conductr_cli.resolvers.uri_resolver.get_url', get_url_mock), \
                 patch('conductr_cli.resolvers.uri_resolver.urlretrieve', urlretrieve_mock), \
                 patch('logging.getLogger', get_logger_mock):
-            is_resolved, bundle_name, bundle_file = uri_resolver.resolve_bundle_configuration('/cache-dir',
-                                                                                              '/bundle-url')
-            self.assertTrue(is_resolved)
-            self.assertEqual('bundle-name', bundle_name)
-            self.assertEqual('/bundle-cached-path', bundle_file)
+            result = uri_resolver.resolve_bundle_configuration('/cache-dir', '/bundle-url')
+            self.assertEqual((True, 'bundle-name', '/bundle-cached-path', None), result)
 
         self.assertEqual([
             call('/cache-dir'),
@@ -192,7 +181,8 @@ class TestResolveBundleConfiguration(TestCase):
     def test_resolve_not_found(self):
         os_path_exists_mock = MagicMock(side_effect=[True, False])
         cache_path_mock = MagicMock(return_value='/bundle-cached-path')
-        urlretrieve_mock = MagicMock(side_effect=URLError('no_such.bundle'))
+        error = URLError('no_such.bundle')
+        urlretrieve_mock = MagicMock(side_effect=error)
         get_url_mock = MagicMock(return_value=('bundle-name', '/bundle-url-resolved'))
 
         get_logger_mock, log_mock = create_mock_logger()
@@ -202,11 +192,8 @@ class TestResolveBundleConfiguration(TestCase):
                 patch('conductr_cli.resolvers.uri_resolver.get_url', get_url_mock), \
                 patch('conductr_cli.resolvers.uri_resolver.urlretrieve', urlretrieve_mock), \
                 patch('logging.getLogger', get_logger_mock):
-            is_resolved, bundle_name, bundle_file = uri_resolver.resolve_bundle_configuration('/cache-dir',
-                                                                                              '/bundle-url')
-            self.assertFalse(is_resolved)
-            self.assertIsNone(bundle_name)
-            self.assertIsNone(bundle_file)
+            result = uri_resolver.resolve_bundle_configuration('/cache-dir', '/bundle-url')
+            self.assertEqual((False, None, None, error), result)
 
         self.assertEqual([
             call('/cache-dir'),
@@ -240,10 +227,8 @@ class TestResolveConductrBinary(TestCase):
                 patch('conductr_cli.resolvers.uri_resolver.get_url', get_url_mock), \
                 patch('conductr_cli.resolvers.uri_resolver.urlretrieve', urlretrieve_mock), \
                 patch('logging.getLogger', get_logger_mock):
-            is_resolved, file_name, cached_file = uri_resolver.resolve_file('/images', 'conductr-binary-uri')
-            self.assertTrue(is_resolved)
-            self.assertEqual('conductr-1.0.0.tgz', file_name)
-            self.assertEqual('/images/conductr-1.0.0.tgz', cached_file)
+            result = uri_resolver.resolve_file('/images', 'conductr-binary-uri')
+            self.assertEqual((True, 'conductr-1.0.0.tgz', '/images/conductr-1.0.0.tgz', None), result)
 
         self.assertEqual([
             call('/images'),
@@ -280,8 +265,8 @@ class TestResolveConductrBinary(TestCase):
                 patch('logging.getLogger', get_logger_mock),\
                 self.assertRaises(URLError) as e:
             uri_resolver.resolve_file('/images', 'conductr-binary-uri', raise_error=True)
-            self.assertEqual(e.cause, url_error)
 
+        self.assertEqual(e.exception, url_error)
         self.assertEqual([
             call('/images'),
             call('/images/conductr-1.0.0.tgz.tmp')
@@ -301,8 +286,8 @@ class TestResolveConductrBinary(TestCase):
         os_chmod_mock = MagicMock()
         file_move_mock = MagicMock()
         cache_path_mock = MagicMock(return_value='/images/conductr-1.0.0.tgz')
-        url_error = URLError('test')
         get_url_mock = MagicMock(return_value=('conductr-1.0.0.tgz', 'conductr-binary-uri'))
+        url_error = URLError('test')
         urlretrieve_mock = MagicMock(side_effect=url_error)
 
         get_logger_mock, log_mock = create_mock_logger()
@@ -315,10 +300,8 @@ class TestResolveConductrBinary(TestCase):
                 patch('conductr_cli.resolvers.uri_resolver.get_url', get_url_mock), \
                 patch('conductr_cli.resolvers.uri_resolver.urlretrieve', urlretrieve_mock), \
                 patch('logging.getLogger', get_logger_mock):
-            is_resolved, file_name, cached_file = uri_resolver.resolve_file('/images', 'conductr-binary-uri')
-            self.assertFalse(is_resolved)
-            self.assertIsNone(file_name)
-            self.assertIsNone(cached_file)
+            result = uri_resolver.resolve_file('/images', 'conductr-binary-uri')
+            self.assertEqual((False, None, None, url_error), result)
 
         self.assertEqual([
             call('/images'),
@@ -339,10 +322,8 @@ class TestLoadBundleFromCache(TestCase):
         exists_mock = MagicMock()
 
         with patch('os.path.exists', exists_mock):
-            is_resolved, bundle_name, bundle_file = uri_resolver.load_bundle_from_cache('/cache-dir', '/tmp/bundle.zip')
-            self.assertFalse(is_resolved)
-            self.assertIsNone(bundle_name)
-            self.assertIsNone(bundle_file)
+            result = uri_resolver.load_bundle_from_cache('/cache-dir', '/tmp/bundle.zip')
+            self.assertEqual((False, None, None, None), result)
 
         exists_mock.assert_not_called()
 
@@ -353,12 +334,8 @@ class TestLoadBundleFromCache(TestCase):
 
         with patch('os.path.exists', exists_mock), \
                 patch('logging.getLogger', get_logger_mock):
-            is_resolved, bundle_name, bundle_file = uri_resolver.load_bundle_from_cache(
-                '/cache-dir',
-                'http://site.com/path/bundle-file.zip')
-            self.assertTrue(is_resolved)
-            self.assertEqual('bundle-file.zip', bundle_name)
-            self.assertEqual('/cache-dir/bundle-file.zip', bundle_file)
+            result = uri_resolver.load_bundle_from_cache('/cache-dir', 'http://site.com/path/bundle-file.zip')
+            self.assertEqual((True, 'bundle-file.zip', '/cache-dir/bundle-file.zip', None), result)
 
         exists_mock.assert_called_with('/cache-dir/bundle-file.zip')
 
@@ -369,12 +346,8 @@ class TestLoadBundleFromCache(TestCase):
         exists_mock = MagicMock(return_value=False)
 
         with patch('os.path.exists', exists_mock):
-            is_resolved, bundle_name, bundle_file = uri_resolver.load_bundle_from_cache(
-                '/cache-dir',
-                'http://site.com/path/bundle-file.zip')
-            self.assertFalse(is_resolved)
-            self.assertIsNone(bundle_name)
-            self.assertIsNone(bundle_file)
+            result = uri_resolver.load_bundle_from_cache('/cache-dir', 'http://site.com/path/bundle-file.zip')
+            self.assertEqual((False, None, None, None), result)
 
         exists_mock.assert_called_with('/cache-dir/bundle-file.zip')
 
@@ -384,11 +357,8 @@ class TestLoadBundleConfigurationFromCache(TestCase):
         exists_mock = MagicMock()
 
         with patch('os.path.exists', exists_mock):
-            is_resolved, bundle_name, bundle_file = uri_resolver.load_bundle_configuration_from_cache(
-                '/cache-dir', '/tmp/bundle.zip')
-            self.assertFalse(is_resolved)
-            self.assertIsNone(bundle_name)
-            self.assertIsNone(bundle_file)
+            result = uri_resolver.load_bundle_configuration_from_cache('/cache-dir', '/tmp/bundle.zip')
+            self.assertEqual((False, None, None, None), result)
 
         exists_mock.assert_not_called()
 
@@ -399,12 +369,9 @@ class TestLoadBundleConfigurationFromCache(TestCase):
 
         with patch('os.path.exists', exists_mock), \
                 patch('logging.getLogger', get_logger_mock):
-            is_resolved, bundle_name, bundle_file = uri_resolver.load_bundle_configuration_from_cache(
-                '/cache-dir',
-                'http://site.com/path/bundle-file.zip')
-            self.assertTrue(is_resolved)
-            self.assertEqual('bundle-file.zip', bundle_name)
-            self.assertEqual('/cache-dir/bundle-file.zip', bundle_file)
+            result = uri_resolver.load_bundle_configuration_from_cache('/cache-dir',
+                                                                       'http://site.com/path/bundle-file.zip')
+            self.assertEqual((True, 'bundle-file.zip', '/cache-dir/bundle-file.zip', None), result)
 
         exists_mock.assert_called_with('/cache-dir/bundle-file.zip')
 
@@ -415,12 +382,9 @@ class TestLoadBundleConfigurationFromCache(TestCase):
         exists_mock = MagicMock(return_value=False)
 
         with patch('os.path.exists', exists_mock):
-            is_resolved, bundle_name, bundle_file = uri_resolver.load_bundle_configuration_from_cache(
-                '/cache-dir',
-                'http://site.com/path/bundle-file.zip')
-            self.assertFalse(is_resolved)
-            self.assertIsNone(bundle_name)
-            self.assertIsNone(bundle_file)
+            result = uri_resolver.load_bundle_configuration_from_cache('/cache-dir',
+                                                                       'http://site.com/path/bundle-file.zip')
+            self.assertEqual((False, None, None, None), result)
 
         exists_mock.assert_called_with('/cache-dir/bundle-file.zip')
 
@@ -493,11 +457,8 @@ class TestProgressBar(TestCase):
                 patch('conductr_cli.resolvers.uri_resolver.urlretrieve', urlretrieve_mock), \
                 patch('conductr_cli.resolvers.uri_resolver.show_progress', show_progress_mock), \
                 patch('logging.getLogger', get_logger_mock):
-            is_resolved, bundle_name, bundle_file = uri_resolver.resolve_bundle('/cache-dir',
-                                                                                'http://site.com/bundle-url')
-            self.assertTrue(is_resolved)
-            self.assertEqual('bundle-name', bundle_name)
-            self.assertEqual('/bundle-cached-path', bundle_file)
+            result = uri_resolver.resolve_bundle('/cache-dir', 'http://site.com/bundle-url')
+            self.assertEqual((True, 'bundle-name', '/bundle-cached-path', None), result)
 
         self.assertEqual([
             call('/cache-dir'),
@@ -533,11 +494,8 @@ class TestProgressBar(TestCase):
                 patch('conductr_cli.resolvers.uri_resolver.get_url', get_url_mock), \
                 patch('conductr_cli.resolvers.uri_resolver.urlretrieve', urlretrieve_mock), \
                 patch('logging.getLogger', get_logger_mock):
-            is_resolved, bundle_name, bundle_file = uri_resolver.resolve_bundle('/cache-dir',
-                                                                                'http://site.com/bundle-url')
-            self.assertTrue(is_resolved)
-            self.assertEqual('bundle-name', bundle_name)
-            self.assertEqual('/bundle-cached-path', bundle_file)
+            result = uri_resolver.resolve_bundle('/cache-dir', 'http://site.com/bundle-url')
+            self.assertEqual((True, 'bundle-name', '/bundle-cached-path', None), result)
 
         self.assertEqual([
             call('/cache-dir'),

--- a/conductr_cli/resolvers/uri_resolver.py
+++ b/conductr_cli/resolvers/uri_resolver.py
@@ -28,7 +28,7 @@ def resolve_file(cache_dir, uri, auth=None, require_bundle_conf=True, raise_erro
             file_path = file_url[len(file_protocol):]
 
             if is_local_file(file_path, require_bundle_conf=require_bundle_conf):
-                return True, file_name, file_path
+                return True, file_name, file_path, None
 
         cached_file = cache_path(cache_dir, uri)
         tmp_download_path = '{}.tmp'.format(cached_file)
@@ -40,19 +40,19 @@ def resolve_file(cache_dir, uri, auth=None, require_bundle_conf=True, raise_erro
 
         os.chmod(tmp_download_path, 0o600)
         shutil.move(tmp_download_path, cached_file)
-        return True, file_name, cached_file
+        return True, file_name, cached_file, None
     except URLError as e:
         if raise_error:
             raise e
         else:
-            return False, None, None
+            return False, None, None, e
 
 
 def load_bundle_from_cache(cache_dir, uri):
     # When the supplied uri is a local filesystem, don't load from cache so file can be used as is
     parsed = urlparse(uri, scheme='file')
     if parsed.scheme == 'file':
-        return False, None, None
+        return False, None, None, None
     else:
         log = logging.getLogger(__name__)
 
@@ -60,9 +60,9 @@ def load_bundle_from_cache(cache_dir, uri):
         if os.path.exists(cached_file):
             bundle_name = os.path.basename(cached_file)
             log.info('Retrieving from cache {}'.format(cached_file))
-            return True, bundle_name, cached_file
+            return True, bundle_name, cached_file, None
         else:
-            return False, None, None
+            return False, None, None, None
 
 
 def resolve_bundle_configuration(cache_dir, uri, auth=None):

--- a/conductr_cli/sandbox_run_jvm.py
+++ b/conductr_cli/sandbox_run_jvm.py
@@ -500,10 +500,10 @@ def download_sandbox_image(image_dir, package_name, artefact_type, image_version
             if is_matching_artefact(artefact['download_url'])
         ]
         if len(artefacts) == 1:
-            is_success, _, download_path = bintray_resolver.bintray_download_artefact(image_dir,
-                                                                                      artefacts[0],
-                                                                                      bintray_auth,
-                                                                                      raise_error=True)
+            is_success, _, download_path, _ = bintray_resolver.bintray_download_artefact(image_dir,
+                                                                                         artefacts[0],
+                                                                                         bintray_auth,
+                                                                                         raise_error=True)
 
             if is_success:
                 return download_path

--- a/conductr_cli/test/conduct_load_test_base.py
+++ b/conductr_cli/test/conduct_load_test_base.py
@@ -563,7 +563,9 @@ class ConductLoadTestBase(CliTestCase):
             self.output(stderr))
 
     def base_test_failure_no_bundle(self):
-        resolve_bundle_mock = MagicMock(side_effect=BundleResolutionError('some message'))
+        resolve_bundle_mock = MagicMock(side_effect=BundleResolutionError('some message',
+                                                                          cache_resolution_errors=[],
+                                                                          bundle_resolution_errors=[]))
         stdout = MagicMock()
         stderr = MagicMock()
 
@@ -578,13 +580,15 @@ class ConductLoadTestBase(CliTestCase):
                                                'no_such.bundle', self.offline_mode)
 
         self.assertEqual(
-            as_error(strip_margin("""|Error: Bundle not found: some message
+            as_error(strip_margin("""|Error: some message
                                      |""")),
             self.output(stderr))
 
     def base_test_failure_no_configuration(self):
         resolve_bundle_mock = MagicMock(return_value=(self.bundle_file_name, self.bundle_file))
-        resolve_bundle_configuration_mock = MagicMock(side_effect=BundleResolutionError('some message'))
+        resolve_bundle_configuration_mock = MagicMock(side_effect=BundleResolutionError('some message',
+                                                                                        cache_resolution_errors=[],
+                                                                                        bundle_resolution_errors=[]))
         stdout = MagicMock()
         stderr = MagicMock()
 
@@ -602,7 +606,7 @@ class ConductLoadTestBase(CliTestCase):
                                                              'no_such.conf', self.offline_mode)
 
         self.assertEqual(
-            as_error(strip_margin("""|Error: Bundle not found: some message
+            as_error(strip_margin("""|Error: some message
                                      |""")),
             self.output(stderr))
 

--- a/conductr_cli/test/test_bundle_scale.py
+++ b/conductr_cli/test/test_bundle_scale.py
@@ -908,6 +908,6 @@ class TestIsConsolidatedLoggingEnabled(CliTestCase):
         with patch('conductr_cli.conduct_events.get_bundle_events', mock_get_bundle_events), \
                 self.assertRaises(HTTPError) as e:
             self.assertFalse(bundle_scale.is_consolidated_logging_enabled(self.args))
-            self.assertEqual(e.cause, http_error)
 
+        self.assertEqual(e.exception, http_error)
         mock_get_bundle_events.assert_called_once_with(self.args, count=1)

--- a/conductr_cli/test/test_sandbox_run_jvm.py
+++ b/conductr_cli/test/test_sandbox_run_jvm.py
@@ -1803,7 +1803,8 @@ class TestDownloadSandboxImage(CliTestCase):
 
         mock_bintray_download_artefact = MagicMock(return_value=(True,
                                                                  'conductr-2.1.0-alpha.1-Mac_OS_X-x86_64.tgz',
-                                                                 '~/.conductr/images/conductr-2.1.0-alpha.1-Mac_OS_X-x86_64.tgz'))
+                                                                 '~/.conductr/images/conductr-2.1.0-alpha.1-Mac_OS_X-x86_64.tgz',
+                                                                 None))
 
         with patch('conductr_cli.sandbox_run_jvm.artefact_os_name', mock_artefact_os_name), \
                 patch('conductr_cli.resolvers.bintray_resolver.load_bintray_credentials',
@@ -1839,7 +1840,8 @@ class TestDownloadSandboxImage(CliTestCase):
 
         mock_bintray_download_artefact = MagicMock(return_value=(True,
                                                                  'conductr-2.1.0-alpha.1-Mac_OS_X-x86_64.tgz',
-                                                                 '~/.conductr/images/conductr-2.1.0-alpha.1-Mac_OS_X-x86_64.tgz'))
+                                                                 '~/.conductr/images/conductr-2.1.0-alpha.1-Mac_OS_X-x86_64.tgz',
+                                                                 None))
 
         with patch('conductr_cli.sandbox_run_jvm.artefact_os_name', mock_artefact_os_name), \
                 patch('conductr_cli.resolvers.bintray_resolver.load_bintray_credentials',
@@ -1888,7 +1890,8 @@ class TestDownloadSandboxImage(CliTestCase):
 
         mock_bintray_download_artefact = MagicMock(return_value=(True,
                                                                  'conductr-2.0.5-Mac_OS_X-x86_64.tgz',
-                                                                 '~/.conductr/images/conductr-2.0.5-Mac_OS_X-x86_64.tgz'))
+                                                                 '~/.conductr/images/conductr-2.0.5-Mac_OS_X-x86_64.tgz',
+                                                                 None))
 
         with patch('conductr_cli.sandbox_run_jvm.artefact_os_name', mock_artefact_os_name), \
                 patch('conductr_cli.resolvers.bintray_resolver.load_bintray_credentials',
@@ -1923,7 +1926,8 @@ class TestDownloadSandboxImage(CliTestCase):
 
         mock_bintray_download_artefact = MagicMock(return_value=(True,
                                                                  'conductr-agent-2.1.0-alpha.1-Mac_OS_X-x86_64.tgz',
-                                                                 '~/.conductr/images/conductr-agent-2.1.0-alpha.1-Mac_OS_X-x86_64.tgz'))
+                                                                 '~/.conductr/images/conductr-agent-2.1.0-alpha.1-Mac_OS_X-x86_64.tgz',
+                                                                 None))
 
         with patch('conductr_cli.sandbox_run_jvm.artefact_os_name', mock_artefact_os_name), \
                 patch('conductr_cli.resolvers.bintray_resolver.load_bintray_credentials',
@@ -1959,7 +1963,8 @@ class TestDownloadSandboxImage(CliTestCase):
 
         mock_bintray_download_artefact = MagicMock(return_value=(True,
                                                                  'conductr-agent-2.1.0-alpha.1-Mac_OS_X-x86_64.tgz',
-                                                                 '~/.conductr/images/conductr-agent-2.1.0-alpha.1-Mac_OS_X-x86_64.tgz'))
+                                                                 '~/.conductr/images/conductr-agent-2.1.0-alpha.1-Mac_OS_X-x86_64.tgz',
+                                                                 None))
 
         with patch('conductr_cli.sandbox_run_jvm.artefact_os_name', mock_artefact_os_name), \
                 patch('conductr_cli.resolvers.bintray_resolver.load_bintray_credentials',
@@ -2009,7 +2014,8 @@ class TestDownloadSandboxImage(CliTestCase):
 
         mock_bintray_download_artefact = MagicMock(return_value=(True,
                                                                  'conductr-agent-2.0.5-Mac_OS_X-x86_64.tgz',
-                                                                 '~/.conductr/images/conductr-agent-2.0.5-Mac_OS_X-x86_64.tgz'))
+                                                                 '~/.conductr/images/conductr-agent-2.0.5-Mac_OS_X-x86_64.tgz',
+                                                                 None))
 
         with patch('conductr_cli.sandbox_run_jvm.artefact_os_name', mock_artefact_os_name), \
                 patch('conductr_cli.resolvers.bintray_resolver.load_bintray_credentials',
@@ -2067,10 +2073,9 @@ class TestDownloadSandboxImage(CliTestCase):
         with patch('conductr_cli.resolvers.bintray_resolver.load_bintray_credentials', mock_load_bintray_credentials), \
                 patch('conductr_cli.resolvers.bintray_resolver.bintray_artefacts_by_version',
                       mock_bintray_artefacts_by_version), \
-                self.assertRaises(SandboxImageNotFoundError) as err:
+                self.assertRaises(SandboxImageNotFoundError):
                     sandbox_run_jvm.download_sandbox_image(self.image_dir, self.core_package_name,
                                                            self.core_artefact_type, self.image_version)
-                    self.assertEqual(err.cause, error)
 
         mock_load_bintray_credentials.assert_called_once_with(raise_error=False)
         mock_bintray_artefacts_by_version.assert_called_once_with(self.bintray_auth,
@@ -2092,8 +2097,8 @@ class TestDownloadSandboxImage(CliTestCase):
                 self.assertRaises(SandboxImageFetchError) as err:
                     sandbox_run_jvm.download_sandbox_image(self.image_dir, self.core_package_name,
                                                            self.core_artefact_type, self.image_version)
-                    self.assertEqual(err.cause, error)
 
+        self.assertEqual(err.exception.cause, error)
         mock_load_bintray_credentials.assert_called_once_with(raise_error=False)
         mock_bintray_artefacts_by_version.assert_called_once_with(self.bintray_auth,
                                                                   'lightbend',
@@ -2113,8 +2118,8 @@ class TestDownloadSandboxImage(CliTestCase):
                 self.assertRaises(SandboxImageFetchError) as err:
                     sandbox_run_jvm.download_sandbox_image(self.image_dir, self.core_package_name,
                                                            self.core_artefact_type, self.image_version)
-                    self.assertEqual(err.cause, error)
 
+        self.assertEqual(err.exception.cause, error)
         mock_load_bintray_credentials.assert_called_once_with(raise_error=False)
         mock_bintray_artefacts_by_version.assert_called_once_with(self.bintray_auth,
                                                                   'lightbend',

--- a/conductr_cli/test/test_validation.py
+++ b/conductr_cli/test/test_validation.py
@@ -1,5 +1,7 @@
 from argparse import ArgumentTypeError
 from conductr_cli import logging_setup, validation
+from conductr_cli.exceptions import BundleResolutionError
+from conductr_cli.resolvers import bintray_resolver
 from conductr_cli.validation import argparse_version, HostnameLookupError
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin, as_error
 from unittest.mock import patch, MagicMock
@@ -63,3 +65,111 @@ class TestErrorHandler(CliTestCase):
                                                    |Error: ::1         localhost MagicBox
                                                    |"""))
         self.assertEqual(self.output(stderr), expected_output)
+
+    def test_handle_bundle_resolution_error_with_bundle_errors(self):
+        error1 = Exception('error 1')
+        error2 = Exception('error 2')
+
+        mock_resolver_name = 'mock resolver 2'
+        mock_resolver = MagicMock(name=mock_resolver_name)
+        mock_resolver.__name__ = mock_resolver_name
+
+        def raise_error():
+            raise BundleResolutionError('test error',
+                                        cache_resolution_errors=[],
+                                        bundle_resolution_errors=[
+                                            (bintray_resolver, error1),
+                                            (mock_resolver, error2),
+                                        ])
+
+        args = MagicMock(**{})
+        stdout = MagicMock()
+        stderr = MagicMock()
+        logging_setup.configure_logging(args, stdout, stderr)
+
+        function_to_call = validation.handle_bundle_resolution_error(raise_error)
+        function_to_call()
+
+        self.assertEqual('', self.output(stdout))
+
+        expected_error = as_error(strip_margin(
+            """|Error: test error
+               |Error: RESOLVER         ERROR
+               |Error: Bintray          error 1
+               |Error: mock resolver 2  error 2
+               |"""
+        ))
+        self.assertEqual(expected_error, self.output(stderr))
+
+    def test_handle_bundle_resolution_error_with_cache_errors(self):
+        error1 = Exception('error 1')
+        error2 = Exception('error 2')
+
+        mock_resolver_name = 'mock resolver 2'
+        mock_resolver = MagicMock(name=mock_resolver_name)
+        mock_resolver.__name__ = mock_resolver_name
+
+        def raise_error():
+            raise BundleResolutionError('test error',
+                                        cache_resolution_errors=[
+                                            (bintray_resolver, error1),
+                                            (mock_resolver, error2),
+                                        ],
+                                        bundle_resolution_errors=[])
+
+        args = MagicMock(**{})
+        stdout = MagicMock()
+        stderr = MagicMock()
+        logging_setup.configure_logging(args, stdout, stderr)
+
+        function_to_call = validation.handle_bundle_resolution_error(raise_error)
+        function_to_call()
+
+        self.assertEqual('', self.output(stdout))
+
+        expected_error = as_error(strip_margin(
+            """|Error: test error
+               |Error: RESOLVER         ERROR
+               |Error: Bintray          error 1
+               |Error: mock resolver 2  error 2
+               |"""
+        ))
+        self.assertEqual(expected_error, self.output(stderr))
+
+    def test_handle_bundle_resolution_error_with_bundle_and_cache_errors(self):
+        error1 = Exception('error 1')
+        error2 = Exception('error 2')
+        error3 = Exception('error 2')
+
+        mock_resolver_name = 'mock resolver 2'
+        mock_resolver = MagicMock(name=mock_resolver_name)
+        mock_resolver.__name__ = mock_resolver_name
+
+        def raise_error():
+            raise BundleResolutionError('test error',
+                                        cache_resolution_errors=[
+                                            (mock_resolver, error3)
+                                        ],
+                                        bundle_resolution_errors=[
+                                            (bintray_resolver, error1),
+                                            (mock_resolver, error2),
+                                        ])
+
+        args = MagicMock(**{})
+        stdout = MagicMock()
+        stderr = MagicMock()
+        logging_setup.configure_logging(args, stdout, stderr)
+
+        function_to_call = validation.handle_bundle_resolution_error(raise_error)
+        function_to_call()
+
+        self.assertEqual('', self.output(stdout))
+
+        expected_error = as_error(strip_margin(
+            """|Error: test error
+               |Error: RESOLVER         ERROR
+               |Error: Bintray          error 1
+               |Error: mock resolver 2  error 2
+               |"""
+        ))
+        self.assertEqual(expected_error, self.output(stderr))


### PR DESCRIPTION
Each resolver (i.e. `bintray_resolver`, `docker_resolver`, `uri_resolver`, etc) is modified to return additional tuple element which can be an instance of `Error` encountered by the resolver, or `None` if there's no error encountered.

These errors are collected into `BundleResolutionError`, which is then displayed accordingly by the validation handler.

