### PR TITLE
Progress bar for `conduct load` made more efficient

### DIFF
--- a/conductr_cli/conduct_load.py
+++ b/conductr_cli/conduct_load.py
@@ -366,15 +366,19 @@ def conduct_load_progress_monitor(log):
     # Without this flag, the scrollbar will progress until 100% as expected, and when it hits 100% the same scrollbar
     # will be printed twice.
     upload_completed = False
+    progress = 0
 
     def continue_logging(monitor):
-        nonlocal upload_completed
+        nonlocal upload_completed, progress
         if not upload_completed:
             uploaded_progress = monitor.bytes_read
             total_size = monitor.len
             upload_completed = monitor.encoder.finished
-            progress_bar_text = screen_utils.progress_bar(uploaded_progress, total_size)
-            log.progress(progress_bar_text, flush=upload_completed)
+            now_progress = round(uploaded_progress * 1.0 / total_size, 2)
+            if now_progress != progress:
+                progress = now_progress
+                progress_bar_text = screen_utils.progress_bar(uploaded_progress, total_size)
+                log.progress(progress_bar_text, flush=upload_completed)
 
     return continue_logging
 

--- a/conductr_cli/screen_utils.py
+++ b/conductr_cli/screen_utils.py
@@ -19,9 +19,9 @@ def calc_column_widths(data):
     return column_widths
 
 
-def progress_bar(current_size, total_size, bar_length=50):
+def progress_bar(current_size, total_size, bar_length=DEFAULT_BAR_LENGTH):
     if current_size <= total_size:
-        percent = int(current_size * 100 / total_size)
+        percent = round(current_size * 100.0 / total_size)
     else:
         percent = 100
 


### PR DESCRIPTION
Believe it or not, the progress bar for `conduct load` was actually taking a lot of CPU. This PR modifies it to only print to the screen when percentage (whole number) has been incremented, instead of on every chunk of bytes uploaded.

See below for performance increase (was about 50% on my laptop, more like 25% on more powerful desktop)

**Before**
```bash
$ time conduct load visualizer
Retrieving bundle..
Loading bundle from cache typesafe/bundle/visualizer
Bintray credentials loaded from /home/longshorej/.lightbend/commercial.credentials
Retrieving from cache /home/longshorej/.conductr/cache/bundle/visualizer-v2-6cc7dbcf3b655b1942edf50a5574d62f5bbb12ef37db5b3990dc3fa80078b827.zip
Loading bundle to ConductR..
[#################################################] 100%
Bundle 6cc7dbcf3b655b1942edf50a5574d62f is installed
Bundle loaded.
Start bundle with:        conduct run 6cc7dbc
Unload bundle with:       conduct unload 6cc7dbc
Print ConductR info with: conduct info
Print bundle info with:   conduct info 6cc7dbc

real	0m2.069s
user	0m0.836s
sys	0m0.104s
-> 0
```

**After**
```bash
$ time conduct load visualizer
Retrieving bundle..
Loading bundle from cache typesafe/bundle/visualizer
Bintray credentials loaded from /home/longshorej/.lightbend/commercial.credentials
Retrieving from cache /home/longshorej/.conductr/cache/bundle/visualizer-v2-6cc7dbcf3b655b1942edf50a5574d62f5bbb12ef37db5b3990dc3fa80078b827.zip
Loading bundle to ConductR..
Bundle 6cc7dbcf3b655b1942edf50a5574d62f is installed100%
Bundle loaded.
Start bundle with:        conduct run 6cc7dbc
Unload bundle with:       conduct unload 6cc7dbc
Print ConductR info with: conduct info
Print bundle info with:   conduct info 6cc7dbc

real	0m1.548s
user	0m0.484s
sys	0m0.056s
-> 0
```