### PR TITLE
Increase retry times for check component added by `bndl`

### DIFF
--- a/conductr_cli/bndl_oci.py
+++ b/conductr_cli/bndl_oci.py
@@ -1,5 +1,6 @@
 from pyhocon import HOCONConverter, ConfigFactory, ConfigTree
 from conductr_cli.bndl_utils import load_bundle_args_into_conf, create_check_hocon
+from conductr_cli.constants import BNDL_DEFAULT_CHECK_RETRY_COUNT, BNDL_DEFAULT_CHECK_RETRY_DELAY
 import json
 import os
 import re
@@ -39,7 +40,13 @@ def oci_image_bundle_conf(args, component_name, oci_manifest, oci_config):
             port = int(type_parts[0])
             protocol = type_parts[1] if len(type_parts) > 1 else 'tcp'
             name = '{}-{}-{}'.format(component_name, protocol, port)
-            check_arguments.append('${}_HOST'.format(re.sub('\\W', '_', name.upper())))
+            check_arguments.append(
+                '${}_HOST?retry-delay={}&retry-count={}'.format(
+                    re.sub('\\W', '_', name.upper()),
+                    BNDL_DEFAULT_CHECK_RETRY_DELAY,
+                    BNDL_DEFAULT_CHECK_RETRY_COUNT
+                )
+            )
 
             entry_tree = ConfigTree()
             entry_tree.put('bind-protocol', protocol)

--- a/conductr_cli/constants.py
+++ b/conductr_cli/constants.py
@@ -1,5 +1,9 @@
 import os
 
+BNDL_DEFAULT_CHECK_RETRY_DELAY = 10
+
+BNDL_DEFAULT_CHECK_RETRY_COUNT = 6
+
 # Preload this much data in the bndl tool to determine input type of a stream. Since we use this to determine
 # if a stream is a plain bundle conf, this should be set to hold the maximum size of a reasonable bundle.conf
 # or else auto-detection will fail.

--- a/conductr_cli/test/test_bndl_oci.py
+++ b/conductr_cli/test/test_bndl_oci.py
@@ -278,7 +278,7 @@ class TestBndlOci(CliTestCase):
                             |    start-command = [
                             |      "check"
                             |      "--any-address"
-                            |      "$MY_COMPONENT_UDP_80_HOST"
+                            |      "$MY_COMPONENT_UDP_80_HOST?retry-delay=10&retry-count=6"
                             |    ]
                             |    endpoints {}
                             |  }
@@ -410,8 +410,8 @@ class TestBndlOci(CliTestCase):
                             |    start-command = [
                             |      "check"
                             |      "--any-address"
-                            |      "$MY_COMPONENT_TCP_80_HOST"
-                            |      "$MY_COMPONENT_UDP_8080_HOST"
+                            |      "$MY_COMPONENT_TCP_80_HOST?retry-delay=10&retry-count=6"
+                            |      "$MY_COMPONENT_UDP_8080_HOST?retry-delay=10&retry-count=6"
                             |    ]
                             |    endpoints {}
                             |  }
@@ -571,8 +571,8 @@ class TestBndlOci(CliTestCase):
                             |    start-command = [
                             |      "check"
                             |      "--any-address"
-                            |      "$MY_COMPONENT_TCP_80_HOST"
-                            |      "$MY_COMPONENT_UDP_8080_HOST"
+                            |      "$MY_COMPONENT_TCP_80_HOST?retry-delay=10&retry-count=6"
+                            |      "$MY_COMPONENT_UDP_8080_HOST?retry-delay=10&retry-count=6"
                             |    ]
                             |    endpoints {}
                             |  }


### PR DESCRIPTION
This PR ensures that `check` has roughly a minute to complete when added automatically for OCI images. This complements most docker images out there that take longer than the default time to startup, such as Kafka.

Manual test was performed, without this change `conduct load confluentinc/cp-kafka --env KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://0.0.0.0:9092 --env KAFKA_ZOOKEEPER_CONNECT=192.168.10.1:2181` would fail due to `check` timing out. After this change, it no longer fails.