### PR TITLE
Allow variable substitutions in `--env` arguments for `bndl` tool

### DIFF
--- a/conductr_cli/bndl_create.py
+++ b/conductr_cli/bndl_create.py
@@ -9,6 +9,7 @@ from conductr_cli.bndl_utils import \
     data_is_zip, \
     detect_format_dir, \
     detect_format_stream, \
+    escape_bash_double_quotes, \
     find_bundle_conf_dir, \
     first_mtime, \
     load_bundle_args_into_conf, \
@@ -170,7 +171,7 @@ def bndl_create(args):
         for env in args.envs if hasattr(args, 'envs') else []:
             if runtime_conf_str:
                 runtime_conf_str += '\n'
-            runtime_conf_str += 'export \'{}\''.format(env.replace('\'', ''))
+            runtime_conf_str += 'export "{}"'.format(escape_bash_double_quotes(env))
 
         if runtime_conf_str:
             runtime_conf_data = runtime_conf_str.encode('UTF-8')

--- a/conductr_cli/bndl_utils.py
+++ b/conductr_cli/bndl_utils.py
@@ -160,6 +160,19 @@ def data_is_zip(data):
     return any(data.startswith(number) for number in MAGIC_NUMBERS_ZIP)
 
 
+def escape_bash_double_quotes(input):
+    """
+    Given a string, escapes it according to bash rules while still allowing variable substitutions.
+    https://www.gnu.org/software/bash/manual/html_node/Double-Quotes.html#Double-Quotes
+    :param input:
+    :return: escaped value (unquoted)
+    """
+    return input \
+        .replace('\\', '\\\\') \
+        .replace('`', '\\`') \
+        .replace('"', '\\"')
+
+
 def load_bundle_args_into_conf(config, args, application_type):
     # this is unrolled because it's actually pretty complicated to get the order
     # correct given that some attributes need special handling and defaults

--- a/conductr_cli/test/test_bndl_create.py
+++ b/conductr_cli/test/test_bndl_create.py
@@ -800,7 +800,9 @@ class TestBndlCreate(CliTestCase):
                     'use_shazar': False,
                     'envs': [
                         'ENV1=123',
-                        'ENV2=456'
+                        'ENV2=456',
+                        'ENV3=$BUNDLE_HOST_IP',
+                        'ENV4=`escapes properly`'
                     ],
                     'with_defaults': None
                 })
@@ -822,8 +824,10 @@ class TestBndlCreate(CliTestCase):
                             self.assertEqual(
                                 tar.extractfile(entry).read().decode('UTF-8'),
                                 strip_margin(
-                                    '''|export 'ENV1=123'
-                                       |export 'ENV2=456\'''')
+                                    '''|export "ENV1=123"
+                                       |export "ENV2=456"
+                                       |export "ENV3=$BUNDLE_HOST_IP"
+                                       |export "ENV4=\\`escapes properly\\`"''')
                             )
 
                     self.assertTrue(saw_bundle)
@@ -874,8 +878,8 @@ class TestBndlCreate(CliTestCase):
                                 tar.extractfile(entry).read().decode('UTF-8'),
                                 strip_margin(
                                     '''|export MY_ENV=hello
-                                       |export 'ENV1=123'
-                                       |export 'ENV2=456\'''')
+                                       |export "ENV1=123"
+                                       |export "ENV2=456"''')
                             )
 
                     self.assertTrue(saw_bundle)
@@ -930,7 +934,7 @@ class TestBndlCreate(CliTestCase):
 
             self.assertEqual(
                 files['test/runtime-config.sh'],
-                b'export \'ENV1=123\'\nexport \'ENV2=456\''
+                b'export "ENV1=123"\nexport "ENV2=456"'
             )
         finally:
             shutil.rmtree(tmpdir)

--- a/conductr_cli/test/test_bndl_utils.py
+++ b/conductr_cli/test/test_bndl_utils.py
@@ -10,6 +10,12 @@ import tempfile
 
 
 class TestBndlUtils(CliTestCase):
+    def test_escape_bash_double_quotes(self):
+        self.assertEqual(bndl_utils.escape_bash_double_quotes('hello'), 'hello')
+        self.assertEqual(bndl_utils.escape_bash_double_quotes('"hello"'), '\\"hello\\"')
+        self.assertEqual(bndl_utils.escape_bash_double_quotes('$hello'), '$hello')
+        self.assertEqual(bndl_utils.escape_bash_double_quotes('echo `whoami`'), 'echo \\`whoami\\`')
+
     def test_detect_format_stream(self):
         # empty stream is none
         self.assertEqual(


### PR DESCRIPTION
This PR changes the format for generated `export` statements when running `bndl --env`. Whereas we previously enclosed values in single-quotes (thus preserving literal values), we now enclose in double quotes to allow variable substitution.

This allows syntax like the following to work as expected:

```bash
conduct load confluentinc/cp-kafka:3.2.1--env 'KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://$BUNDLE_HOST_IP:9092'
```