### PR TITLE
Introduce S3 Resolver

### DIFF
--- a/conduct.spec
+++ b/conduct.spec
@@ -2,6 +2,14 @@
 
 import os
 
+# FIXME: Remove once we have PyInstaller 3.3
+# Temporary workaround until PyInstaller's boto hook imports the correct method
+# https://github.com/pyinstaller/pyinstaller/issues/2384
+# Fix is scheduled for PyInstaller 3.3
+from PyInstaller.utils.hooks import is_module_satisfies
+import PyInstaller.compat
+PyInstaller.compat.is_module_satisfies = is_module_satisfies
+
 
 block_cipher = None
 
@@ -10,7 +18,7 @@ a = Analysis(['conductr_cli/conduct.py'],
              pathex=[os.path.abspath(os.getcwd())],
              binaries=[],
              datas=[],
-             hiddenimports=[],
+             hiddenimports=['configparser'],
              hookspath=[],
              runtime_hooks=[],
              excludes=[],

--- a/conductr_cli/bundle_shorthand.py
+++ b/conductr_cli/bundle_shorthand.py
@@ -1,9 +1,11 @@
 from conductr_cli.exceptions import MalformedBundleUriError
+from conductr_cli.resolvers.schemes import SCHEME_BUNDLE
 
 
 DEFAULT_ORG = 'typesafe'
 DEFAULT_REPO_BUNDLE = 'bundle'
 DEFAULT_REPO_BUNDLE_CONFIGURATION = 'bundle-configuration'
+URN_BUNDLE = '{}:'.format(SCHEME_BUNDLE)
 
 
 def parse_bundle(uri):
@@ -21,17 +23,27 @@ def parse_bundle_configuration(uri):
 
 
 def split_to_urn_and_rest(uri):
+    if len(uri.strip()) < 1:
+        raise MalformedBundleUriError('{} is not a valid bundle uri'.format(uri))
+
     if uri.startswith('urn:'):
-        if uri.startswith('urn:x-bundle:'):
-            return 'urn:x-bundle:', uri.replace('urn:x-bundle:', '')
+        if uri.startswith(URN_BUNDLE):
+            return URN_BUNDLE, uri.replace(URN_BUNDLE, '')
         else:
             raise MalformedBundleUriError('{} is not a valid bundle uri'.format(uri))
     else:
-        return 'urn:x-bundle:', uri
+        return URN_BUNDLE, uri
 
 
 def split_to_org_repo_package(uri, default_repo):
+    if len(uri.strip()) < 1:
+        raise MalformedBundleUriError('{} is not a valid bundle uri'.format(uri))
+
     parts = uri.split('/')
+    empty_parts = [part for part in parts if not part]
+    if len(empty_parts) > 0:
+        raise MalformedBundleUriError('{} is not a valid bundle uri'.format(uri))
+
     if len(parts) == 3:
         return parts
     elif len(parts) == 2:

--- a/conductr_cli/exceptions.py
+++ b/conductr_cli/exceptions.py
@@ -242,3 +242,27 @@ class LicenseDownloadError(Exception):
 
     def __str(self):
         return repr(os.linesep.join(self.messages))
+
+
+class S3InvalidArtefactError(Exception):
+    def __init__(self, message):
+        self.message = message
+
+    def __str__(self):
+        return repr(self.message)
+
+
+class S3MalformedUrlError(Exception):
+    def __init__(self, message):
+        self.message = message
+
+    def __str__(self):
+        return repr(self.message)
+
+
+class DockerImageMalformedError(Exception):
+    def __init__(self, message):
+        self.message = message
+
+    def __str__(self):
+        return repr(self.message)

--- a/conductr_cli/resolver.py
+++ b/conductr_cli/resolver.py
@@ -1,37 +1,44 @@
 from conductr_cli.exceptions import BundleResolutionError, ContinuousDeliveryError
 from conductr_cli.resolvers import \
-    bintray_resolver, docker_offline_resolver, docker_resolver, stdin_resolver, uri_resolver, offline_resolver
+    bintray_resolver, docker_offline_resolver, docker_resolver, stdin_resolver, uri_resolver, offline_resolver, \
+    resolvers_util, s3_resolver
 import importlib
 import logging
 
 
 # Try to resolve from local file system before we attempting resolution using bintray
-DEFAULT_RESOLVERS = [stdin_resolver, uri_resolver, bintray_resolver, docker_resolver]
+DEFAULT_RESOLVERS = [stdin_resolver, uri_resolver, bintray_resolver, docker_resolver, s3_resolver]
 OFFLINE_RESOLVERS = [stdin_resolver, offline_resolver, docker_offline_resolver]
 
 
 def resolve_bundle(custom_settings, cache_dir, uri, offline_mode=False):
-    all_resolvers = resolver_chain(custom_settings, offline_mode)
+    log = logging.getLogger(__name__)
 
     cache_resolution_errors = []
-    for resolver in all_resolvers:
-        is_cached, bundle_file_name, cached_bundle, error = resolver.load_bundle_from_cache(cache_dir, uri)
-
-        if error:
-            cache_resolution_errors.append((resolver, error))
-
-        if is_cached:
-            return bundle_file_name, cached_bundle
-
     bundle_resolution_errors = []
-    for resolver in all_resolvers:
-        is_resolved, bundle_file_name, bundle_file, error = resolver.resolve_bundle(cache_dir, uri)
 
-        if error:
-            bundle_resolution_errors.append((resolver, error))
+    all_resolvers = resolver_chain(custom_settings, offline_mode)
+    supported_resolvers = filter_for_supported_resolvers(all_resolvers, uri)
+    if supported_resolvers:
+        log.info('Resolving bundle using [{}]'.format(get_resolver_names(supported_resolvers)))
 
-        if is_resolved:
-            return bundle_file_name, bundle_file
+        for resolver in supported_resolvers:
+            is_cached, bundle_file_name, cached_bundle, error = resolver.load_bundle_from_cache(cache_dir, uri)
+
+            if error:
+                cache_resolution_errors.append((resolver, error))
+
+            if is_cached:
+                return bundle_file_name, cached_bundle
+
+        for resolver in supported_resolvers:
+            is_resolved, bundle_file_name, bundle_file, error = resolver.resolve_bundle(cache_dir, uri)
+
+            if error:
+                bundle_resolution_errors.append((resolver, error))
+
+            if is_resolved:
+                return bundle_file_name, bundle_file
 
     raise BundleResolutionError('Unable to resolve bundle using {}'.format(uri),
                                 cache_resolution_errors,
@@ -39,29 +46,35 @@ def resolve_bundle(custom_settings, cache_dir, uri, offline_mode=False):
 
 
 def resolve_bundle_configuration(custom_settings, cache_dir, uri, offline_mode=False):
-    all_resolvers = resolver_chain(custom_settings, offline_mode)
+    log = logging.getLogger(__name__)
 
     cache_resolution_errors = []
-    for resolver in all_resolvers:
-        is_cached, bundle_configuration_file_name, cached_bundle, error = \
-            resolver.load_bundle_configuration_from_cache(cache_dir, uri)
-
-        if error:
-            cache_resolution_errors.append((resolver, error))
-
-        if is_cached:
-            return bundle_configuration_file_name, cached_bundle
-
     bundle_resolution_errors = []
-    for resolver in all_resolvers:
-        is_resolved, bundle_configuration_file_name, bundle_configuration_file, error = \
-            resolver.resolve_bundle_configuration(cache_dir, uri)
 
-        if error:
-            bundle_resolution_errors.append((resolver, error))
+    all_resolvers = resolver_chain(custom_settings, offline_mode)
+    supported_resolvers = filter_for_supported_resolvers(all_resolvers, uri)
+    if supported_resolvers:
+        log.info('Resolving bundle configuration using [{}]'.format(get_resolver_names(supported_resolvers)))
 
-        if is_resolved:
-            return bundle_configuration_file_name, bundle_configuration_file
+        for resolver in supported_resolvers:
+            is_cached, bundle_configuration_file_name, cached_bundle, error = \
+                resolver.load_bundle_configuration_from_cache(cache_dir, uri)
+
+            if error:
+                cache_resolution_errors.append((resolver, error))
+
+            if is_cached:
+                return bundle_configuration_file_name, cached_bundle
+
+        for resolver in supported_resolvers:
+            is_resolved, bundle_configuration_file_name, bundle_configuration_file, error = \
+                resolver.resolve_bundle_configuration(cache_dir, uri)
+
+            if error:
+                bundle_resolution_errors.append((resolver, error))
+
+            if is_resolved:
+                return bundle_configuration_file_name, bundle_configuration_file
 
     raise BundleResolutionError('Unable to resolve bundle using {}'.format(uri),
                                 cache_resolution_errors,
@@ -69,17 +82,23 @@ def resolve_bundle_configuration(custom_settings, cache_dir, uri, offline_mode=F
 
 
 def resolve_bundle_version(custom_settings, uri, offline_mode=False):
-    all_resolvers = resolver_chain(custom_settings, offline_mode)
+    log = logging.getLogger(__name__)
 
     bundle_resolution_errors = []
-    for resolver in all_resolvers:
-        resolved_version, error = resolver.resolve_bundle_version(uri)
 
-        if error:
-            bundle_resolution_errors.append((resolver, error))
+    all_resolvers = resolver_chain(custom_settings, offline_mode)
+    supported_resolvers = filter_for_supported_resolvers(all_resolvers, uri)
+    if supported_resolvers:
+        log.info('Resolving bundle version using [{}]'.format(get_resolver_names(supported_resolvers)))
 
-        if resolved_version:
-            return resolved_version
+        for resolver in supported_resolvers:
+            resolved_version, error = resolver.resolve_bundle_version(uri)
+
+            if error:
+                bundle_resolution_errors.append((resolver, error))
+
+            if resolved_version:
+                return resolved_version
 
     raise BundleResolutionError('Unable to resolve bundle using {}'.format(uri),
                                 cache_resolution_errors=[],
@@ -107,3 +126,62 @@ def resolver_chain(custom_settings, offline_mode):
             return custom_resolver_chain
     else:
         return OFFLINE_RESOLVERS if offline_mode else DEFAULT_RESOLVERS
+
+
+def filter_for_supported_resolvers(resolvers, uri):
+    """
+    Filter a list of resolver which can resolve a given URI.
+
+    For example, if URI is a S3 URL, the resolver chain will only contain S3 resolver as it's the only resolver
+    capable of resolving a S3 URL.
+
+    Filtering the supported resolver beforehand will allow a more efficient resolution process, i.e. there's no need
+    to resolve from Bintray if S3 URL is provided as input.
+
+    Each resolver is expected to provide `supported_schemes()` method which returns list of schemes supported by the
+    resolver.
+
+    A list of possible schemes is deduced from the `uri`. This list is then compared with the list supported by each
+    resolver. If one of the possible schemes deduced from the `uri` is in the list supported by a particular resolver,
+    this resolver is added in the supported resolver chain.
+
+    However, since it's possible to specify custom resolver outside of the CLI codebase, for backward compatibility
+    purposes, the resolver without `supported_schemes()` method will be added into the supported resolver chain so it
+    has a chance to resolve the input URI.
+
+    :param resolvers: the resolver chain
+    :param uri: the uri to be resolved
+    :return: list of resolvers which can be used to resolve the uri
+    """
+    log = logging.getLogger(__name__)
+
+    uri_schemes = resolvers_util.detect_schemes(uri)
+
+    supported_resolvers = []
+    for resolver in resolvers:
+        try:
+            resolver_schemes = resolver.supported_schemes()
+            if [scheme for scheme in uri_schemes if scheme in resolver_schemes]:
+                supported_resolvers.append(resolver)
+        except AttributeError as e:
+            error_message = '{}'.format(e)
+            if error_message.endswith('has no attribute \'supported_schemes\''):
+                # If Resolver doesn't provide `supported_schemes` method, add the resolver to the list of supported
+                # resolvers.
+                # This is to support backward compatibility with custom resolver.
+                log.warning('The resolver {} does not provide `supported_schemes()` method.'.format(resolver.__name__))
+                supported_resolvers.append(resolver)
+            else:
+                # Other attribute error, continue and raise this
+                raise e
+
+    return supported_resolvers
+
+
+def get_resolver_names(resolvers):
+    def get_resolver_name(resolver):
+        resolver_name = resolver.__name__
+        return resolver_name.split('.')[-1] if '.' in resolver_name else resolver_name
+
+    resolver_names = [get_resolver_name(resolver) for resolver in resolvers]
+    return ', '.join(resolver_names)

--- a/conductr_cli/resolvers/bintray_resolver.py
+++ b/conductr_cli/resolvers/bintray_resolver.py
@@ -2,6 +2,7 @@ from conductr_cli.exceptions import MalformedBundleUriError, BintrayResolutionEr
     BintrayCredentialsNotFoundError, MalformedBintrayCredentialsError
 from conductr_cli.resolvers import uri_resolver
 from conductr_cli.resolvers.resolvers_util import is_local_file
+from conductr_cli.resolvers.schemes import SCHEME_BUNDLE
 from conductr_cli import bundle_shorthand
 from requests.exceptions import HTTPError, ConnectionError
 import json
@@ -22,8 +23,13 @@ BINTRAY_CONDUCTR_CORE_PACKAGE_NAME = 'ConductR-Universal'
 BINTRAY_CONDUCTR_AGENT_PACKAGE_NAME = 'ConductR-Agent-Universal'
 
 
+def supported_schemes():
+    return [SCHEME_BUNDLE]
+
+
 def resolve_bundle(cache_dir, uri):
     log = logging.getLogger(__name__)
+
     try:
         urn, org, repo, package_name, tag, digest = bundle_shorthand.parse_bundle(uri)
         log.info(log_message('Resolving bundle', org, repo, package_name, tag, digest))
@@ -64,6 +70,7 @@ def load_bundle_from_cache(cache_dir, uri):
 
 def resolve_bundle_configuration(cache_dir, uri):
     log = logging.getLogger(__name__)
+
     try:
         urn, org, repo, package_name, tag, digest = bundle_shorthand.parse_bundle_configuration(uri)
         log.info(log_message('Resolving bundle configuration', org, repo, package_name, tag, digest))

--- a/conductr_cli/resolvers/docker_offline_resolver.py
+++ b/conductr_cli/resolvers/docker_offline_resolver.py
@@ -1,6 +1,10 @@
 from conductr_cli.resolvers import docker_resolver
 
 
+def supported_schemes():
+    return docker_resolver.supported_schemes()
+
+
 def resolve_bundle(cache_dir, uri, auth=None):
     return docker_resolver.do_resolve_bundle(cache_dir, uri, auth, offline_mode=True)
 

--- a/conductr_cli/resolvers/offline_resolver.py
+++ b/conductr_cli/resolvers/offline_resolver.py
@@ -1,6 +1,11 @@
+from conductr_cli.resolvers.schemes import SCHEME_BUNDLE, SCHEME_FILE
 import os
 import glob
 import logging
+
+
+def supported_schemes():
+    return [SCHEME_BUNDLE, SCHEME_FILE]
 
 
 def resolve_bundle(cache_dir, uri, auth=None):

--- a/conductr_cli/resolvers/resolvers_util.py
+++ b/conductr_cli/resolvers/resolvers_util.py
@@ -1,5 +1,9 @@
 from urllib.parse import urlparse
+from conductr_cli import bundle_shorthand
+from conductr_cli.exceptions import MalformedBundleUriError
+from conductr_cli.resolvers.schemes import SCHEME_BUNDLE, SCHEME_FILE, SCHEME_STDIN
 import os
+import sys
 
 
 def is_local_file(uri, require_bundle_conf):
@@ -11,3 +15,86 @@ def is_local_file(uri, require_bundle_conf):
             (not require_bundle_conf or os.path.exists(os.path.join(parsed.path, 'bundle.conf')))
         )
     )
+
+
+def detect_schemes(uri):
+    """
+    Detects one or more scheme applicable for a given URI. Returns one or more scheme, because it's possible to apply
+    one or more scheme given a URI.
+
+    For example, if the `uri` is `my-bundle`, this is a valid reference to a bundle (indicated by `urn:x-bundle`
+    scheme) which can be resolved via `bintray_resolver` or `docker_resolver`.
+
+    However, it is also possible for the local path `my-bundle` to be present also. If the path is present, then the
+    `file` scheme is applicable, and therefore in this case both `urn:x-bundle` and `file` are applicable.
+
+    :param uri: input URI
+    :return: one or more applicable scheme for the given input URI
+    """
+
+    stdin_scheme = detect_stdin(uri)
+    if stdin_scheme:
+        # No other schemes is possible when accepting input from stdin.
+        return [stdin_scheme]
+
+    result = []
+
+    bundle_scheme = detect_bundle_scheme(uri)
+    if bundle_scheme:
+        result.append(bundle_scheme)
+
+    parsed_scheme = detect_scheme_from_parsed_uri(uri)
+    if parsed_scheme:
+        result.append(parsed_scheme)
+
+    if SCHEME_FILE not in result:
+        local_file_scene = detect_scheme_from_path(uri)
+        if local_file_scene:
+            result.append(local_file_scene)
+
+    return result
+
+
+def detect_bundle_scheme(uri):
+    """
+    Detects if bundle scheme is applicable for the given `uri`.
+
+    :param uri:
+    :return: bundle scheme if it's a valid bundle URI, otherwise `None`.
+    """
+    try:
+        bundle_shorthand.parse_bundle(uri)
+        return SCHEME_BUNDLE
+    except MalformedBundleUriError:
+        return None
+
+
+def detect_scheme_from_parsed_uri(uri):
+    """
+    Parse the input `uri` using Python's built-in `urlparse`, and then obtains the `scheme` from the parsed result.
+
+    :param uri:
+    :return: the scheme from the parsed `uri` result.
+    """
+    parsed = urlparse(uri)
+    return parsed.scheme
+
+
+def detect_stdin(uri):
+    """
+    Detects for stdin input.
+
+    :param uri:
+    :return: stdin scheme if stdin input is present, otherwise `None`.
+    """
+    return SCHEME_STDIN if not sys.stdin.isatty() and uri == '-' else None
+
+
+def detect_scheme_from_path(uri):
+    """
+    Detects if the `uri` is present on the local file system.
+
+    :param uri:
+    :return: file scheme if uri is present on the local file system, otherwise `None`
+    """
+    return SCHEME_FILE if os.path.exists(uri) else None

--- a/conductr_cli/resolvers/s3_resolver.py
+++ b/conductr_cli/resolvers/s3_resolver.py
@@ -1,0 +1,173 @@
+from conductr_cli import screen_utils
+from conductr_cli.exceptions import S3InvalidArtefactError, S3MalformedUrlError
+from conductr_cli.resolvers.schemes import SCHEME_S3
+from botocore.exceptions import ClientError, NoCredentialsError, ProfileNotFound
+from urllib.parse import urlparse
+import boto3
+import logging
+import os
+import shutil
+import time
+
+
+DATA_READ_CHUNK_SIZE = 128
+
+
+def supported_schemes():
+    return [SCHEME_S3]
+
+
+def resolve_bundle(cache_dir, uri):
+    return resolve_s3_object(cache_dir, uri)
+
+
+def load_bundle_from_cache(cache_dir, uri):
+    return resolve_s3_object_from_cache(cache_dir, uri)
+
+
+def resolve_bundle_configuration(cache_dir, uri):
+    return resolve_s3_object(cache_dir, uri)
+
+
+def load_bundle_configuration_from_cache(cache_dir, uri):
+    return resolve_s3_object_from_cache(cache_dir, uri)
+
+
+def resolve_bundle_version(uri):
+    return None
+
+
+def continuous_delivery_uri(resolved_version):
+    return None
+
+
+def resolve_s3_object(cache_dir, uri):
+    if not is_s3_url(uri):
+        return False, None, None, None
+
+    try:
+        bucket_name, s3_key_name = s3_bucket_and_key_from_uri(uri)
+        if bucket_name and s3_key_name:
+            return download_from_s3(cache_dir, bucket_name, s3_key_name)
+        else:
+            error = S3MalformedUrlError('Unable to derive S3 bucket and key from {}'.format(uri))
+            return False, None, None, error
+    except NoCredentialsError as e:
+        return False, None, None, e
+
+
+def resolve_s3_object_from_cache(cache_dir, uri):
+    log = logging.getLogger(__name__)
+
+    if not is_s3_url(uri):
+        return False, None, None, None
+
+    bucket_name, s3_key_name = s3_bucket_and_key_from_uri(uri)
+    if s3_key_name:
+        artefact_name = os.path.basename(s3_key_name)
+        cached_artefact = os.path.join(cache_dir, artefact_name)
+        if os.path.exists(cached_artefact):
+            log.info('Retrieving from cache {}'.format(cached_artefact))
+            return True, artefact_name, cached_artefact, None
+
+    return False, None, None, None
+
+
+def s3_bucket_and_key_from_uri(uri):
+    if is_s3_url(uri):
+        parsed = urlparse(uri)
+        bucket_name = parsed.netloc
+        uri_parts = [path for path in parsed.path.split('/') if path]
+        if len(uri_parts) > 0:
+            s3_key = '/'.join(uri_parts)
+            return bucket_name, s3_key
+
+    return None, None
+
+
+def is_s3_url(uri):
+    return urlparse(uri).scheme == SCHEME_S3
+
+
+def download_from_s3(cache_dir, bucket_name, s3_key_name):
+    log = logging.getLogger(__name__)
+    client = create_s3_client()
+    try:
+        artefact = client.get_object(Bucket=bucket_name, Key=s3_key_name)
+
+        validate_artefact(artefact)
+
+        artefact_file_name = os.path.basename(s3_key_name)
+        cached_file = os.path.join(cache_dir, artefact_file_name)
+        cached_file_tmp = '{}.tmp'.format(cached_file)
+
+        artefact_size = artefact['ContentLength']
+        artefact_data = artefact['Body']
+
+        log.info('Retrieving {}://{}{}'.format(SCHEME_S3, bucket_name, s3_key_name))
+        save_artefact_data_to_file(artefact_size, artefact_data, cached_file_tmp)
+        shutil.move(cached_file_tmp, cached_file)
+
+        return True, artefact_file_name, cached_file, None
+    except (ClientError, S3InvalidArtefactError) as e:
+        return False, None, None, e
+
+
+def validate_artefact(artefact):
+    if 'ContentLength' not in artefact:
+        raise S3InvalidArtefactError('Unable to find \'ContentLength\' in the S3 artefact metadata')
+    elif artefact['ContentLength'] <= 0:
+        raise S3InvalidArtefactError('Artefact ContentLength must not be zero')
+    elif 'ContentType' not in artefact:
+        raise S3InvalidArtefactError('Unable to find \'ContentType\' in the S3 artefact metadata')
+    elif artefact['ContentType'] != 'application/zip':
+        raise S3InvalidArtefactError('Invalid content type \'{}\''.format(artefact['ContentType']))
+    elif 'Body' not in artefact:
+        raise S3InvalidArtefactError('Unable to find artefact data')
+
+
+def save_artefact_data_to_file(artefact_size, artefact_data, file_path):
+    try:
+        log = logging.getLogger(__name__)
+
+        parent_dir = os.path.abspath(os.path.join(file_path, os.pardir))
+        if not os.path.exists(parent_dir):
+            os.makedirs(parent_dir, mode=0o700)
+
+        if os.path.exists(file_path):
+            os.remove(file_path)
+
+        with open(file_path, mode='bw') as f:
+            downloaded_size = 0
+            prev_time = time.time()
+
+            while downloaded_size < artefact_size:
+                chunk = artefact_data.read(DATA_READ_CHUNK_SIZE)
+                chunk_length = len(chunk)
+                downloaded_size += chunk_length
+                if chunk_length > 0:
+                    f.write(chunk)
+
+                now_time = time.time()
+                upload_complete = downloaded_size >= artefact_size
+                if upload_complete or now_time - prev_time >= 0.1:
+                    percent = 1.0 if upload_complete else downloaded_size * 1.0 / artefact_size
+                    progress_bar_text = screen_utils.progress_bar(percent)
+                    log.progress(progress_bar_text, flush=upload_complete)
+                    prev_time = now_time
+
+        return file_path
+    finally:
+        artefact_data.close()
+
+
+def create_s3_client():
+    log = logging.getLogger(__name__)
+    try:
+        session = boto3.Session(profile_name='conductr')
+        log.info('Using S3 \'conductr\' profile')
+        return session.client('s3')
+    except ProfileNotFound:
+        session = boto3.Session()
+        log.info('Using S3 \'default\' profile')
+        return session.client('s3')

--- a/conductr_cli/resolvers/schemes.py
+++ b/conductr_cli/resolvers/schemes.py
@@ -1,0 +1,6 @@
+SCHEME_BUNDLE = 'urn:x-bundle'
+SCHEME_STDIN = 'stdin'
+SCHEME_FILE = 'file'
+SCHEME_HTTP = 'http'
+SCHEME_HTTPS = 'https'
+SCHEME_S3 = 's3'

--- a/conductr_cli/resolvers/stdin_resolver.py
+++ b/conductr_cli/resolvers/stdin_resolver.py
@@ -1,8 +1,13 @@
 from conductr_cli.constants import IO_CHUNK_SIZE
+from conductr_cli.resolvers.schemes import SCHEME_STDIN
 import sys
 import tempfile
 
 ALLOCATED_FILES = []
+
+
+def supported_schemes():
+    return [SCHEME_STDIN]
 
 
 def resolve_bundle(cache_dir, uri, auth=None):

--- a/conductr_cli/resolvers/test/test_bintray_resolver.py
+++ b/conductr_cli/resolvers/test/test_bintray_resolver.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 from conductr_cli.test.cli_test_case import strip_margin
 from conductr_cli.resolvers import bintray_resolver
+from conductr_cli.resolvers.schemes import SCHEME_BUNDLE
 from conductr_cli.exceptions import MalformedBundleUriError, BintrayResolutionError, MalformedBintrayCredentialsError, \
     BintrayCredentialsNotFoundError
 from requests.exceptions import HTTPError, ConnectionError
@@ -220,7 +221,7 @@ class TestResolveBundleConfiguration(TestCase):
                                                         'bundle-name', 'v1', 'digest')
 
     def test_failure_connection_error(self):
-        load_bintray_credentials_mock = MagicMock(return_value=(self.bintray_auth))
+        load_bintray_credentials_mock = MagicMock(return_value=self.bintray_auth)
         parse_bundle_configuration_mock = MagicMock(return_value=('urn:x-bundle:', 'typesafe', 'bundle-configuration',
                                                                   'bundle-name', 'v1', 'digest'))
         error = ConnectionError('test only')
@@ -1080,3 +1081,8 @@ class TestGetJson(TestCase):
 
         requests_get_mock.assert_called_with('http://site.com')
         response_raise_for_status_mock.assert_called_with()
+
+
+class TestSupportedSchemes(TestCase):
+    def test_supported_schemes(self):
+        self.assertEqual([SCHEME_BUNDLE], bintray_resolver.supported_schemes())

--- a/conductr_cli/resolvers/test/test_docker_resolver.py
+++ b/conductr_cli/resolvers/test/test_docker_resolver.py
@@ -1,11 +1,12 @@
 from conductr_cli.resolvers import docker_resolver
+from conductr_cli.resolvers.schemes import SCHEME_BUNDLE
 from unittest import TestCase
 from unittest.mock import call, patch, MagicMock
 import tempfile
 
 
-class TestResolverDocker(TestCase):
-    def test_parse_uri(self):
+class TestParseUri(TestCase):
+    def test_success(self):
         self.assertEqual(docker_resolver.parse_uri('alpine'), (
             (None, 'registry.hub.docker.com'),
             (None, 'library'),
@@ -34,6 +35,56 @@ class TestResolverDocker(TestCase):
             ('0.1', '0.1')
         ))
 
+
+class TestLoadCredentials(TestCase):
+    def test_load_docker_credentials(self):
+        with tempfile.NamedTemporaryFile('w') as one,\
+                tempfile.NamedTemporaryFile('w') as two, \
+                tempfile.NamedTemporaryFile('w') as three:
+            one.write('user=one\npassword=one-password')
+            one.flush()
+            two.write('username=two\npassword=two-password')
+            two.flush()
+            three.write('hello')
+            three.flush()
+
+            with open(one.name, 'r') as one_in, \
+                    patch('os.path.exists', MagicMock(return_value=True)), \
+                    patch('builtins.open', MagicMock(return_value=one_in)):
+                self.assertEqual(
+                    docker_resolver.load_docker_credentials('test'),
+                    ('one', 'one-password')
+                )
+
+            with open(two.name, 'r') as two_in, \
+                    patch('os.path.exists', MagicMock(return_value=True)), \
+                    patch('builtins.open', MagicMock(return_value=two_in)):
+                self.assertEqual(
+                    docker_resolver.load_docker_credentials('test'),
+                    ('two', 'two-password')
+                )
+
+            with open(three.name, 'r') as three_in, \
+                    patch('os.path.exists', MagicMock(return_value=True)), \
+                    patch('builtins.open', MagicMock(return_value=three_in)):
+                self.assertIsNone(docker_resolver.load_docker_credentials('test'))
+
+            path_exists_mock = MagicMock(side_effect=[False, True])
+
+            with open(one.name, 'r') as one_in, \
+                    patch('os.path.exists', path_exists_mock), \
+                    MagicMock(return_value=one_in) as open_mock, \
+                    patch('builtins.open', open_mock):
+                docker_resolver.load_docker_credentials('test')
+
+                path_exists_mock.assert_has_calls([
+                    call('{}-{}'.format(docker_resolver.DOCKER_CREDENTIAL_FILE_PATH, 'test')),
+                    call(docker_resolver.DOCKER_CREDENTIAL_FILE_PATH)
+                ])
+
+
+class TestFetchManifest(TestCase):
+
     def test_offline_mode(self):
         mock_is_file = MagicMock(return_value=True)
         mock_json_load = MagicMock(return_value='1234')
@@ -51,55 +102,7 @@ class TestResolverDocker(TestCase):
         mock_is_file.assert_called_once_with('/tmp/docker-manifest-624ab327c0f6bb1039ca62'
                                              '9a2c1ec806514b9194c30491c02e9800254c73d998')
 
-    def test_load_docker_credentials(self):
-        with \
-                tempfile.NamedTemporaryFile('w') as one, \
-                tempfile.NamedTemporaryFile('w') as two, \
-                tempfile.NamedTemporaryFile('w') as three:
-            one.write('user=one\npassword=one-password')
-            one.flush()
-            two.write('username=two\npassword=two-password')
-            two.flush()
-            three.write('hello')
-            three.flush()
 
-            with \
-                    open(one.name, 'r') as one_in, \
-                    patch('os.path.exists', MagicMock(return_value=True)), \
-                    patch('builtins.open', MagicMock(return_value=one_in)):
-                self.assertEqual(
-                    docker_resolver.load_docker_credentials('test'),
-                    ('one', 'one-password')
-                )
-
-            with \
-                    open(two.name, 'r') as two_in, \
-                    patch('os.path.exists', MagicMock(return_value=True)), \
-                    patch('builtins.open', MagicMock(return_value=two_in)):
-                self.assertEqual(
-                    docker_resolver.load_docker_credentials('test'),
-                    ('two', 'two-password')
-                )
-
-            with \
-                    open(three.name, 'r') as three_in, \
-                    patch('os.path.exists', MagicMock(return_value=True)), \
-                    patch('builtins.open', MagicMock(return_value=three_in)):
-                self.assertEqual(
-                    docker_resolver.load_docker_credentials('test'),
-                    None
-                )
-
-            path_exists_mock = MagicMock(side_effect=[False, True])
-
-            with \
-                    open(one.name, 'r') as one_in, \
-                    patch('os.path.exists', path_exists_mock), \
-                    MagicMock(return_value=one_in) as open_mock, \
-                    patch('builtins.open', open_mock):
-                docker_resolver.load_docker_credentials('test')
-
-                path_exists_mock.assert_has_calls([
-                    call('{}-{}'.format(docker_resolver.DOCKER_CREDENTIAL_FILE_PATH, 'test')),
-                    call(docker_resolver.DOCKER_CREDENTIAL_FILE_PATH)
-                ])
+class TestSupportedSchemes(TestCase):
+    def test_supported_schemes(self):
+        self.assertEqual([SCHEME_BUNDLE], docker_resolver.supported_schemes())

--- a/conductr_cli/resolvers/test/test_offline_resolver.py
+++ b/conductr_cli/resolvers/test/test_offline_resolver.py
@@ -1,6 +1,7 @@
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
 from conductr_cli import logging_setup
 from conductr_cli.resolvers import offline_resolver
+from conductr_cli.resolvers.schemes import SCHEME_BUNDLE, SCHEME_FILE
 from unittest.mock import call, patch, MagicMock
 
 
@@ -226,3 +227,8 @@ class TestIsBundleName(CliTestCase):
     def test_return_false(self):
         self.assertFalse(offline_resolver.is_bundle_name('/tmp/visualizer.zip'))
         self.assertFalse(offline_resolver.is_bundle_name('conductr-haproxy-dev-mode.zip'))
+
+
+class TestSupportedSchemes(CliTestCase):
+    def test_supported_schemes(self):
+        self.assertEqual([SCHEME_BUNDLE, SCHEME_FILE], offline_resolver.supported_schemes())

--- a/conductr_cli/resolvers/test/test_resolvers_util.py
+++ b/conductr_cli/resolvers/test/test_resolvers_util.py
@@ -1,11 +1,15 @@
 from unittest import TestCase
+from conductr_cli import bundle_shorthand
 from conductr_cli.resolvers import resolvers_util
+from conductr_cli.resolvers.schemes import SCHEME_BUNDLE, SCHEME_FILE, SCHEME_HTTP, SCHEME_HTTPS, SCHEME_S3, \
+    SCHEME_STDIN
+from unittest.mock import patch, MagicMock
 import os
 import shutil
 import tempfile
 
 
-class TestResolveBundle(TestCase):
+class TestIsLocalFile(TestCase):
     def test_is_local_file_with_file(self):
         with tempfile.NamedTemporaryFile() as temp:
             self.assertTrue(resolvers_util.is_local_file(temp.name, require_bundle_conf=True))
@@ -39,3 +43,95 @@ class TestResolveBundle(TestCase):
             self.assertTrue(resolvers_util.is_local_file(temp, require_bundle_conf=False))
         finally:
             shutil.rmtree(temp)
+
+
+class TestDetectSchemes(TestCase):
+    def test_bundle(self):
+        mock_isatty = MagicMock(return_value=True)
+        mock_exists = MagicMock(return_value=False)
+
+        with patch('os.path.exists', mock_exists), \
+                patch('sys.stdin.isatty', mock_isatty), \
+                patch.object(bundle_shorthand, 'parse_bundle',
+                             wraps=bundle_shorthand.parse_bundle) as parse_bundle:  # spy on the parse_bundle input args
+            self.assertEqual([SCHEME_BUNDLE], resolvers_util.detect_schemes('visualizer'))
+            parse_bundle.assert_called_once_with('visualizer')
+            mock_exists.assert_called_once_with('visualizer')
+
+    def test_bundle_and_file(self):
+        mock_isatty = MagicMock(return_value=True)
+        mock_exists = MagicMock(return_value=True)
+
+        with patch('os.path.exists', mock_exists), \
+                patch('sys.stdin.isatty', mock_isatty), \
+                patch.object(bundle_shorthand, 'parse_bundle',
+                             wraps=bundle_shorthand.parse_bundle) as parse_bundle:  # spy on the parse_bundle input args
+            self.assertEqual([SCHEME_BUNDLE, SCHEME_FILE], resolvers_util.detect_schemes('org/foo/bar'))
+            parse_bundle.assert_called_once_with('org/foo/bar')
+            mock_exists.assert_called_once_with('org/foo/bar')
+
+    def test_file(self):
+        mock_isatty = MagicMock(return_value=True)
+        mock_exists = MagicMock(return_value=False)
+
+        with patch('os.path.exists', mock_exists), \
+                patch('sys.stdin.isatty', mock_isatty), \
+                patch.object(bundle_shorthand, 'parse_bundle',
+                             wraps=bundle_shorthand.parse_bundle) as parse_bundle:  # spy on the parse_bundle input args
+            self.assertEqual([SCHEME_FILE], resolvers_util.detect_schemes('file:///tmp/foo/bundle.zip'))
+            parse_bundle.assert_called_once_with('file:///tmp/foo/bundle.zip')
+            mock_exists.assert_not_called()
+
+    def test_http(self):
+        mock_isatty = MagicMock(return_value=True)
+        mock_exists = MagicMock(return_value=False)
+
+        with patch('os.path.exists', mock_exists), \
+                patch('sys.stdin.isatty', mock_isatty), \
+                patch.object(bundle_shorthand, 'parse_bundle',
+                             wraps=bundle_shorthand.parse_bundle) as parse_bundle:  # spy on the parse_bundle input args
+            self.assertEqual([SCHEME_HTTP], resolvers_util.detect_schemes('http://foo/bundle.zip'))
+            parse_bundle.assert_called_once_with('http://foo/bundle.zip')
+            mock_exists.assert_called_once_with('http://foo/bundle.zip')
+
+    def test_https(self):
+        mock_isatty = MagicMock(return_value=True)
+        mock_exists = MagicMock(return_value=False)
+
+        with patch('os.path.exists', mock_exists), \
+                patch('sys.stdin.isatty', mock_isatty), \
+                patch.object(bundle_shorthand, 'parse_bundle',
+                             wraps=bundle_shorthand.parse_bundle) as parse_bundle:  # spy on the parse_bundle input args
+            self.assertEqual([SCHEME_HTTPS], resolvers_util.detect_schemes('https://foo/bundle.zip'))
+            parse_bundle.assert_called_once_with('https://foo/bundle.zip')
+            mock_exists.assert_called_once_with('https://foo/bundle.zip')
+
+    def test_s3(self):
+        mock_isatty = MagicMock(return_value=True)
+        mock_exists = MagicMock(return_value=False)
+
+        with patch('os.path.exists', mock_exists), \
+                patch('sys.stdin.isatty', mock_isatty), \
+                patch.object(bundle_shorthand, 'parse_bundle',
+                             wraps=bundle_shorthand.parse_bundle) as parse_bundle:  # spy on the parse_bundle input args
+            self.assertEqual([SCHEME_S3], resolvers_util.detect_schemes('s3://bucket/key/bundle.zip'))
+            parse_bundle.assert_called_once_with('s3://bucket/key/bundle.zip')
+            mock_exists.assert_called_once_with('s3://bucket/key/bundle.zip')
+
+    def test_no_tty_but_not_stdin(self):
+        mock_isatty = MagicMock(return_value=False)
+        mock_exists = MagicMock(return_value=False)
+
+        with patch('os.path.exists', mock_exists), \
+                patch('sys.stdin.isatty', mock_isatty), \
+                patch.object(bundle_shorthand, 'parse_bundle',
+                             wraps=bundle_shorthand.parse_bundle) as parse_bundle:  # spy on the parse_bundle input args
+            self.assertEqual([SCHEME_S3], resolvers_util.detect_schemes('s3://bucket/key/bundle.zip'))
+            parse_bundle.assert_called_once_with('s3://bucket/key/bundle.zip')
+            mock_exists.assert_called_once_with('s3://bucket/key/bundle.zip')
+
+    def test_stdin(self):
+        mock_isatty = MagicMock(return_value=False)
+
+        with patch('sys.stdin.isatty', mock_isatty):
+            self.assertEqual([SCHEME_STDIN], resolvers_util.detect_schemes('-'))

--- a/conductr_cli/resolvers/test/test_s3_resolver.py
+++ b/conductr_cli/resolvers/test/test_s3_resolver.py
@@ -1,0 +1,506 @@
+from conductr_cli.test.cli_test_case import CliTestCase
+from conductr_cli import logging_setup
+from conductr_cli.exceptions import S3InvalidArtefactError, S3MalformedUrlError
+from conductr_cli.resolvers import s3_resolver
+from conductr_cli.resolvers.schemes import SCHEME_S3
+from botocore.exceptions import ClientError, NoCredentialsError, ProfileNotFound
+from unittest.mock import call, patch, MagicMock
+import io
+
+
+class TestResolve(CliTestCase):
+    cache_dir = '/tmp'
+    bucket_name = 'myorg'
+    s3_key = 'bundle/weather/weather-v3-digest.zip'
+    valid_s3_url = 's3://{}/{}'.format(bucket_name, s3_key)
+
+    def test_resolve_bundle(self):
+        download_result = MagicMock()
+        mock_download_from_s3 = MagicMock(return_value=download_result)
+
+        with patch('conductr_cli.resolvers.s3_resolver.download_from_s3', mock_download_from_s3):
+            result = s3_resolver.resolve_bundle(self.cache_dir, self.valid_s3_url)
+            self.assertEqual(download_result, result)
+
+        mock_download_from_s3.assert_called_once_with(self.cache_dir, self.bucket_name, self.s3_key)
+
+    def test_resolve_bundle_configuration(self):
+        download_result = MagicMock()
+        mock_download_from_s3 = MagicMock(return_value=download_result)
+
+        with patch('conductr_cli.resolvers.s3_resolver.download_from_s3', mock_download_from_s3):
+            result = s3_resolver.resolve_bundle_configuration(self.cache_dir, self.valid_s3_url)
+            self.assertEqual(download_result, result)
+
+        mock_download_from_s3.assert_called_once_with(self.cache_dir, self.bucket_name, self.s3_key)
+
+    def test_resolve_bundle_non_s3_url(self):
+        mock_download_from_s3 = MagicMock()
+
+        with patch('conductr_cli.resolvers.s3_resolver.download_from_s3', mock_download_from_s3):
+            result = s3_resolver.resolve_bundle(self.cache_dir, 'http://example.org')
+            self.assertEqual((False, None, None, None), result)
+
+        mock_download_from_s3.assert_not_called()
+
+    def test_resolve_bundle_configuration_non_s3_url(self):
+        mock_download_from_s3 = MagicMock()
+
+        with patch('conductr_cli.resolvers.s3_resolver.download_from_s3', mock_download_from_s3):
+            result = s3_resolver.resolve_bundle_configuration(self.cache_dir, 'http://example.org')
+            self.assertEqual((False, None, None, None), result)
+
+        mock_download_from_s3.assert_not_called()
+
+    def test_resolve_bundle_no_credentials_error(self):
+        error = NoCredentialsError()
+        mock_download_from_s3 = MagicMock(side_effect=error)
+
+        with patch('conductr_cli.resolvers.s3_resolver.download_from_s3', mock_download_from_s3):
+            result = s3_resolver.resolve_bundle(self.cache_dir, self.valid_s3_url)
+            self.assertEqual((False, None, None, error), result)
+
+        mock_download_from_s3.assert_called_once_with(self.cache_dir, self.bucket_name, self.s3_key)
+
+    def test_resolve_bundle_configuration_no_credentials_error(self):
+        error = NoCredentialsError()
+        mock_download_from_s3 = MagicMock(side_effect=error)
+
+        with patch('conductr_cli.resolvers.s3_resolver.download_from_s3', mock_download_from_s3):
+            result = s3_resolver.resolve_bundle_configuration(self.cache_dir, self.valid_s3_url)
+            self.assertEqual((False, None, None, error), result)
+
+    def test_resolve_bundle_malformed_url_error(self):
+        mock_download_from_s3 = MagicMock()
+
+        with patch('conductr_cli.resolvers.s3_resolver.download_from_s3', mock_download_from_s3):
+            is_resolved, file_name, file_path, error = s3_resolver.resolve_bundle(self.cache_dir, 's3://bucket')
+            self.assertFalse(is_resolved)
+            self.assertIsNone(file_name)
+            self.assertIsNone(file_path)
+            self.assertIsInstance(error, S3MalformedUrlError)
+
+        mock_download_from_s3.assert_not_called()
+
+    def test_resolve_bundle_configuration_malformed_url_error(self):
+        mock_download_from_s3 = MagicMock()
+
+        with patch('conductr_cli.resolvers.s3_resolver.download_from_s3', mock_download_from_s3):
+            is_resolved, file_name, file_path, error = s3_resolver.resolve_bundle_configuration(self.cache_dir,
+                                                                                                's3://bucket')
+            self.assertFalse(is_resolved)
+            self.assertIsNone(file_name)
+            self.assertIsNone(file_path)
+            self.assertIsInstance(error, S3MalformedUrlError)
+
+        mock_download_from_s3.assert_not_called()
+
+
+class TestLoadFromCache(CliTestCase):
+    cache_dir = '/tmp'
+    bucket_name = 'myorg'
+    s3_key = 'bundle/weather/weather-v3-digest.zip'
+    valid_s3_url = 's3://{}/{}'.format(bucket_name, s3_key)
+
+    def test_load_bundle_from_cache_found(self):
+        mock_exists = MagicMock(return_value=True)
+        stdout = MagicMock()
+
+        with patch('os.path.exists', mock_exists):
+            logging_setup.configure_logging(MagicMock(**{}), stdout)
+            result = s3_resolver.load_bundle_from_cache(self.cache_dir, self.valid_s3_url)
+            self.assertEqual((True, 'weather-v3-digest.zip', '/tmp/weather-v3-digest.zip', None), result)
+
+        mock_exists.assert_called_once_with('/tmp/weather-v3-digest.zip')
+        self.assertEqual('Retrieving from cache /tmp/weather-v3-digest.zip\n', self.output(stdout))
+
+    def test_load_bundle_from_cache_not_found(self):
+        mock_exists = MagicMock(return_value=False)
+        stdout = MagicMock()
+
+        with patch('os.path.exists', mock_exists):
+            logging_setup.configure_logging(MagicMock(**{}), stdout)
+            result = s3_resolver.load_bundle_from_cache(self.cache_dir, self.valid_s3_url)
+            self.assertEqual((False, None, None, None), result)
+
+        mock_exists.assert_called_once_with('/tmp/weather-v3-digest.zip')
+        self.assertEqual('', self.output(stdout))
+
+    def test_load_bundle_configuration_from_cache_found(self):
+        mock_exists = MagicMock(return_value=True)
+        stdout = MagicMock()
+
+        with patch('os.path.exists', mock_exists):
+            logging_setup.configure_logging(MagicMock(**{}), stdout)
+            result = s3_resolver.load_bundle_configuration_from_cache(self.cache_dir, self.valid_s3_url)
+            self.assertEqual((True, 'weather-v3-digest.zip', '/tmp/weather-v3-digest.zip', None), result)
+
+        mock_exists.assert_called_once_with('/tmp/weather-v3-digest.zip')
+        self.assertEqual('Retrieving from cache /tmp/weather-v3-digest.zip\n', self.output(stdout))
+
+    def test_load_bundle_configuration_from_cache_not_found(self):
+        mock_exists = MagicMock(return_value=False)
+        stdout = MagicMock()
+
+        with patch('os.path.exists', mock_exists):
+            logging_setup.configure_logging(MagicMock(**{}), stdout)
+            result = s3_resolver.load_bundle_configuration_from_cache(self.cache_dir, self.valid_s3_url)
+            self.assertEqual((False, None, None, None), result)
+
+        mock_exists.assert_called_once_with('/tmp/weather-v3-digest.zip')
+        self.assertEqual('', self.output(stdout))
+
+    def test_non_s3_url(self):
+        mock_exists = MagicMock()
+        stdout = MagicMock()
+
+        with patch('os.path.exists', mock_exists):
+            logging_setup.configure_logging(MagicMock(**{}), stdout)
+            result = s3_resolver.load_bundle_configuration_from_cache(self.cache_dir, 'http://example.org')
+            self.assertEqual((False, None, None, None), result)
+
+        mock_exists.assert_not_called()
+        self.assertEqual('', self.output(stdout))
+
+
+class TestOtherMethods(CliTestCase):
+    def test_resolve_bundle_version(self):
+        mock_uri = MagicMock()
+        self.assertIsNone(s3_resolver.resolve_bundle_version(mock_uri))
+        mock_uri.assert_not_called()
+
+    def test_continuous_delivery_uri(self):
+        mock_resolved_version = MagicMock()
+        self.assertIsNone(s3_resolver.continuous_delivery_uri(mock_resolved_version))
+        mock_resolved_version.assert_not_called()
+
+
+class TestS3BucketAndKeyFromUri(CliTestCase):
+    def test_success(self):
+        self.assertEqual(('bucket', 'path/to/key.zip'),
+                         s3_resolver.s3_bucket_and_key_from_uri('s3://bucket/path/to/key.zip'))
+        self.assertEqual(('bucket', 'key'),
+                         s3_resolver.s3_bucket_and_key_from_uri('s3://bucket/key'))
+
+    def test_s3_url_without_key(self):
+        self.assertEqual((None, None),
+                         s3_resolver.s3_bucket_and_key_from_uri('s3://bucket'))
+
+    def test_invalid_s3_url(self):
+        self.assertEqual((None, None),
+                         s3_resolver.s3_bucket_and_key_from_uri('s3://'))
+
+    def test_non_s3_url(self):
+        self.assertEqual((None, None),
+                         s3_resolver.s3_bucket_and_key_from_uri('visualizer'))
+        self.assertEqual((None, None),
+                         s3_resolver.s3_bucket_and_key_from_uri('/tmp/path'))
+        self.assertEqual((None, None),
+                         s3_resolver.s3_bucket_and_key_from_uri('http://example.org'))
+
+
+class TestIsS3Url(CliTestCase):
+    def test_urls(self):
+        self.assertTrue(s3_resolver.is_s3_url('s3://bucket/path/to/key.zip'))
+        self.assertTrue(s3_resolver.is_s3_url('s3://bucket/path/to/key'))
+        self.assertTrue(s3_resolver.is_s3_url('s3://bucket'))
+
+        self.assertFalse(s3_resolver.is_s3_url('/tmp/foo'))
+        self.assertFalse(s3_resolver.is_s3_url('/tmp'))
+        self.assertFalse(s3_resolver.is_s3_url('visualizer'))
+        self.assertFalse(s3_resolver.is_s3_url('http://test.com/abc/def'))
+        self.assertFalse(s3_resolver.is_s3_url('http://test.com'))
+
+
+class TestDownloadFromS3(CliTestCase):
+    cache_dir = '/tmp'
+    bucket_name = 'acme-org'
+    key_name = 'bundle/builder/builder-v1-digest.zip'
+
+    artefact_size = 100
+    artefact_data = MagicMock(name='artefact data')
+    artefact = {
+        'ContentLength': artefact_size,
+        'Body': artefact_data
+    }
+
+    def test_success(self):
+        mock_get_object = MagicMock(return_value=self.artefact)
+
+        mock_s3_client = MagicMock()
+        mock_s3_client.get_object = mock_get_object
+
+        mock_create_s3_client = MagicMock(return_value=mock_s3_client)
+        mock_validate_artefact = MagicMock()
+        mock_save_artefact_data_to_file = MagicMock()
+        mock_move = MagicMock()
+
+        with patch('conductr_cli.resolvers.s3_resolver.create_s3_client', mock_create_s3_client), \
+                patch('conductr_cli.resolvers.s3_resolver.validate_artefact', mock_validate_artefact), \
+                patch('conductr_cli.resolvers.s3_resolver.save_artefact_data_to_file',
+                      mock_save_artefact_data_to_file), \
+                patch('shutil.move', mock_move):
+            result = s3_resolver.download_from_s3(self.cache_dir, self.bucket_name, self.key_name)
+            self.assertEqual((True, 'builder-v1-digest.zip', '/tmp/builder-v1-digest.zip', None), result)
+
+        mock_create_s3_client.assert_called_once_with()
+        mock_s3_client.get_object.assert_called_once_with(Bucket=self.bucket_name, Key=self.key_name)
+        mock_validate_artefact.assert_called_once_with(self.artefact)
+        mock_save_artefact_data_to_file.assert_called_once_with(self.artefact_size,
+                                                                self.artefact_data,
+                                                                '/tmp/builder-v1-digest.zip.tmp')
+        mock_move.assert_called_once_with('/tmp/builder-v1-digest.zip.tmp', '/tmp/builder-v1-digest.zip')
+
+    def test_client_error(self):
+        error = ClientError(MagicMock(), MagicMock())
+        mock_get_object = MagicMock(side_effect=error)
+
+        mock_s3_client = MagicMock()
+        mock_s3_client.get_object = mock_get_object
+
+        mock_create_s3_client = MagicMock(return_value=mock_s3_client)
+        mock_validate_artefact = MagicMock()
+        mock_save_artefact_data_to_file = MagicMock()
+        mock_move = MagicMock()
+
+        with patch('conductr_cli.resolvers.s3_resolver.create_s3_client', mock_create_s3_client), \
+                patch('conductr_cli.resolvers.s3_resolver.validate_artefact', mock_validate_artefact), \
+                patch('conductr_cli.resolvers.s3_resolver.save_artefact_data_to_file',
+                      mock_save_artefact_data_to_file), \
+                patch('shutil.move', mock_move):
+            result = s3_resolver.download_from_s3(self.cache_dir, self.bucket_name, self.key_name)
+            self.assertEqual((False, None, None, error), result)
+
+        mock_create_s3_client.assert_called_once_with()
+        mock_s3_client.get_object.assert_called_once_with(Bucket=self.bucket_name, Key=self.key_name)
+        mock_validate_artefact.assert_not_called()
+        mock_save_artefact_data_to_file.assert_not_called()
+        mock_move.assert_not_called()
+
+    def test_invalid_artefact_error(self):
+        mock_get_object = MagicMock(return_value=self.artefact)
+
+        mock_s3_client = MagicMock()
+        mock_s3_client.get_object = mock_get_object
+
+        mock_create_s3_client = MagicMock(return_value=mock_s3_client)
+        error = S3InvalidArtefactError('test')
+        mock_validate_artefact = MagicMock(side_effect=error)
+        mock_save_artefact_data_to_file = MagicMock()
+        mock_move = MagicMock()
+
+        with patch('conductr_cli.resolvers.s3_resolver.create_s3_client', mock_create_s3_client), \
+                patch('conductr_cli.resolvers.s3_resolver.validate_artefact', mock_validate_artefact), \
+                patch('conductr_cli.resolvers.s3_resolver.save_artefact_data_to_file',
+                      mock_save_artefact_data_to_file), \
+                patch('shutil.move', mock_move):
+            result = s3_resolver.download_from_s3(self.cache_dir, self.bucket_name, self.key_name)
+            self.assertEqual((False, None, None, error), result)
+
+        mock_create_s3_client.assert_called_once_with()
+        mock_s3_client.get_object.assert_called_once_with(Bucket=self.bucket_name, Key=self.key_name)
+        mock_validate_artefact.assert_called_once_with(self.artefact)
+        mock_save_artefact_data_to_file.assert_not_called()
+        mock_move.assert_not_called()
+
+
+class TestValidateArtefact(CliTestCase):
+    def test_success(self):
+        artefact = {
+            'ContentType': 'application/zip',
+            'ContentLength': 2,
+            'Body': MagicMock()
+        }
+        s3_resolver.validate_artefact(artefact)
+
+    def test_missing_content_length(self):
+        artefact = {
+            'ContentType': 'application/zip',
+            'Body': MagicMock()
+        }
+        with self.assertRaises(S3InvalidArtefactError):
+            s3_resolver.validate_artefact(artefact)
+
+    def test_invalid_content_length(self):
+        artefact = {
+            'ContentType': 'application/zip',
+            'ContentLength': -1,
+            'Body': MagicMock()
+        }
+        with self.assertRaises(S3InvalidArtefactError):
+            s3_resolver.validate_artefact(artefact)
+
+    def test_missing_content_type(self):
+        artefact = {
+            'ContentLength': 2,
+            'Body': MagicMock()
+        }
+        with self.assertRaises(S3InvalidArtefactError):
+            s3_resolver.validate_artefact(artefact)
+
+    def test_invalid_content_type(self):
+        artefact = {
+            'ContentType': 'text/plain',
+            'ContentLength': 2,
+            'Body': MagicMock()
+        }
+        with self.assertRaises(S3InvalidArtefactError):
+            s3_resolver.validate_artefact(artefact)
+
+    def test_missing_body(self):
+        artefact = {
+            'ContentType': 'application/zip',
+            'ContentLength': -1,
+        }
+        with self.assertRaises(S3InvalidArtefactError):
+            s3_resolver.validate_artefact(artefact)
+
+
+class TestSaveArtefactDataToFile(CliTestCase):
+    artefact_size = 2
+    file_path = '/tmp/bar/foo.zip'
+    args = MagicMock(**{})
+
+    def test_success(self):
+        mock_makedirs = MagicMock()
+        mock_exists = MagicMock(side_effect=[False, True])
+        mock_remove = MagicMock()
+
+        mock_artefact_data = MagicMock()
+
+        mock_artefact_data_read = MagicMock(return_value=b'0')
+        mock_artefact_data.read = mock_artefact_data_read
+
+        mock_artefact_data_close = MagicMock()
+        mock_artefact_data.close = mock_artefact_data_close
+
+        written_data = io.BytesIO()
+        written_data.write = MagicMock()
+        mock_open = MagicMock(return_value=written_data)
+
+        mock_progress_bar = MagicMock(return_value='#')
+
+        mock_time = MagicMock(side_effect=[i for i in range(0, 100)])
+
+        stdout = MagicMock()
+
+        with patch('os.makedirs', mock_makedirs), \
+                patch('os.path.exists', mock_exists), \
+                patch('os.remove', mock_remove), \
+                patch('builtins.open', mock_open), \
+                patch('time.time', mock_time), \
+                patch('conductr_cli.screen_utils.progress_bar', mock_progress_bar):
+            logging_setup.configure_logging(self.args, stdout)
+            result = s3_resolver.save_artefact_data_to_file(self.artefact_size, mock_artefact_data, self.file_path)
+            self.assertEqual(self.file_path, result)
+
+        mock_makedirs.assert_called_once_with('/tmp/bar', mode=0o700)
+
+        self.assertEqual([
+            call('/tmp/bar'),
+            call(self.file_path),
+        ], mock_exists.call_args_list)
+
+        mock_remove.assert_called_once_with(self.file_path)
+
+        self.assertEqual([
+            call(s3_resolver.DATA_READ_CHUNK_SIZE),
+            call(s3_resolver.DATA_READ_CHUNK_SIZE),
+        ], mock_artefact_data_read.call_args_list)
+
+        self.assertEqual([
+            call(0.5),
+            call(1.0),
+        ], mock_progress_bar.call_args_list)
+
+        self.assertEqual([
+            call(b'0'),
+            call(b'0'),
+        ], written_data.write.call_args_list)
+
+        mock_artefact_data_close.assert_called_once_with()
+
+        self.assertTrue(written_data.closed)
+
+        self.assertEqual('#\r#\n', self.output(stdout))
+
+    def test_error(self):
+        mock_makedirs = MagicMock()
+        mock_exists = MagicMock(side_effect=[False, True])
+        mock_remove = MagicMock()
+
+        mock_artefact_data = MagicMock()
+
+        mock_artefact_data_read = MagicMock(return_value=b'0')
+        mock_artefact_data.read = mock_artefact_data_read
+
+        mock_artefact_data_close = MagicMock()
+        mock_artefact_data.close = mock_artefact_data_close
+
+        written_data = io.BytesIO()
+        error = IOError('test only')
+        written_data.write = MagicMock(side_effect=error)
+        mock_open = MagicMock(return_value=written_data)
+
+        mock_progress_bar = MagicMock(return_value='#')
+
+        mock_time = MagicMock(side_effect=[i for i in range(0, 100)])
+
+        stdout = MagicMock()
+
+        with patch('os.makedirs', mock_makedirs), \
+                patch('os.path.exists', mock_exists), \
+                patch('os.remove', mock_remove), \
+                patch('builtins.open', mock_open), \
+                patch('time.time', mock_time), \
+                patch('conductr_cli.screen_utils.progress_bar', mock_progress_bar), \
+                self.assertRaises(IOError) as e:
+            logging_setup.configure_logging(self.args, stdout)
+            s3_resolver.save_artefact_data_to_file(self.artefact_size, mock_artefact_data, self.file_path)
+
+        self.assertEqual(error, e.exception)
+        mock_artefact_data_close.assert_called_once_with()
+
+
+class TestCreateS3Client(CliTestCase):
+
+    def test_use_conductr_profile(self):
+        mock_session = MagicMock()
+
+        mock_create_session = MagicMock(return_value=mock_session)
+
+        mock_client = MagicMock()
+        mock_session.client = MagicMock(return_value=mock_client)
+
+        with patch('boto3.Session', mock_create_session):
+            result = s3_resolver.create_s3_client()
+            self.assertEqual(mock_client, result)
+
+        mock_create_session.assert_called_once_with(profile_name='conductr')
+        mock_session.client.assert_called_once_with('s3')
+
+    def test_use_default_profile(self):
+        mock_session = MagicMock()
+
+        mock_create_session = MagicMock(side_effect=[
+            ProfileNotFound(profile='conductr'),
+            mock_session
+        ])
+
+        mock_client = MagicMock()
+        mock_session.client = MagicMock(return_value=mock_client)
+
+        with patch('boto3.Session', mock_create_session):
+            result = s3_resolver.create_s3_client()
+            self.assertEqual(mock_client, result)
+
+        self.assertEqual([
+            call(profile_name='conductr'),
+            call(),
+        ], mock_create_session.call_args_list)
+        mock_session.client.assert_called_once_with('s3')
+
+
+class TestSupportedSchemes(CliTestCase):
+    def test_supported_schemes(self):
+        self.assertEqual([SCHEME_S3], s3_resolver.supported_schemes())

--- a/conductr_cli/resolvers/test/test_stdin_resolver.py
+++ b/conductr_cli/resolvers/test/test_stdin_resolver.py
@@ -1,4 +1,5 @@
 from conductr_cli.resolver import stdin_resolver
+from conductr_cli.resolvers.schemes import SCHEME_STDIN
 from unittest import TestCase
 from unittest.mock import patch, MagicMock
 import tempfile
@@ -72,3 +73,8 @@ class TestResolverStdIn(TestCase):
     def test_is_bundle_name(self):
         self.assertTrue(stdin_resolver.is_bundle_name('visualizer'))
         self.assertFalse(stdin_resolver.is_bundle_name('/tmp/foo.zip'))
+
+
+class TestSupportedSchemes(TestCase):
+    def test_supported_schemes(self):
+        self.assertEqual([SCHEME_STDIN], stdin_resolver.supported_schemes())

--- a/conductr_cli/test/test_bundle_shorthand.py
+++ b/conductr_cli/test/test_bundle_shorthand.py
@@ -74,6 +74,14 @@ class TestParseBundleWithMalformedExpression(TestCase):
         uri = 'http://some-url.com/dist/bundle/my-project-1.0.0-023f9da22.zip'
         self.assertRaises(MalformedBundleUriError, bundle_shorthand.parse_bundle, uri)
 
+    def test_empty_parts_should_be_invalid(self):
+        uri = 'typesafe//conductr-haproxy-dev-mode:1.0.0-023f9da22'
+        self.assertRaises(MalformedBundleUriError, bundle_shorthand.parse_bundle, uri)
+
+    def test_empty_string_should_be_invalid(self):
+        self.assertRaises(MalformedBundleUriError, bundle_shorthand.parse_bundle, '')
+        self.assertRaises(MalformedBundleUriError, bundle_shorthand.parse_bundle, ' ')
+
 
 class TestParseBundleConfiguration(TestCase):
     def test_full_address(self):
@@ -138,3 +146,11 @@ class TestParseBundleConfigurationWithMalformedExpression(TestCase):
     def test_http_url_should_be_invalid(self):
         uri = 'http://some-url.com/dist/bundle-configuration/my-project-1.0.0-023f9da22.zip'
         self.assertRaises(MalformedBundleUriError, bundle_shorthand.parse_bundle_configuration, uri)
+
+    def test_empty_parts_should_be_invalid(self):
+        uri = 'typesafe//conductr-haproxy-dev-mode:1.0.0-023f9da22'
+        self.assertRaises(MalformedBundleUriError, bundle_shorthand.parse_bundle_configuration, uri)
+
+    def test_empty_string_should_be_invalid(self):
+        self.assertRaises(MalformedBundleUriError, bundle_shorthand.parse_bundle_configuration, '')
+        self.assertRaises(MalformedBundleUriError, bundle_shorthand.parse_bundle_configuration, '  ')

--- a/conductr_cli/test/test_resolver.py
+++ b/conductr_cli/test/test_resolver.py
@@ -1,81 +1,129 @@
 from unittest import TestCase
 from unittest.mock import patch, MagicMock, Mock
-from conductr_cli.test.cli_test_case import strip_margin, create_mock_logger
+from conductr_cli.test.cli_test_case import CliTestCase, as_warn, strip_margin, create_mock_logger
 from conductr_cli.exceptions import BundleResolutionError, ContinuousDeliveryError
-from conductr_cli import resolver
-from conductr_cli.resolvers import \
-    bintray_resolver, docker_resolver, docker_offline_resolver, uri_resolver, offline_resolver, stdin_resolver
+from conductr_cli import logging_setup, resolver
+from conductr_cli.resolvers import bintray_resolver, docker_resolver, docker_offline_resolver, uri_resolver, \
+    offline_resolver, stdin_resolver, s3_resolver
+from conductr_cli.resolvers.schemes import SCHEME_HTTP, SCHEME_BUNDLE
 from pyhocon import ConfigFactory
 
 
-class TestResolver(TestCase):
+class TestResolver(CliTestCase):
 
     def test_resolve_bundle_success(self):
         custom_settings = Mock()
 
-        first_resolver_mock = Mock()
+        first_resolver_mock = Mock(name='first_resolver')
+        first_resolver_mock.__name__ = 'first_resolver'
         first_resolver_mock.load_bundle_from_cache = MagicMock(return_value=(False, None, None, None))
         first_resolver_mock.resolve_bundle = MagicMock(return_value=(False, None, None, None))
+        first_resolver_mock.supported_schemes = MagicMock(return_value=[SCHEME_BUNDLE])
 
-        second_resolver_mock = Mock()
+        second_resolver_mock = Mock(name='second_resolver')
+        second_resolver_mock.__name__ = 'second_resolver'
         second_resolver_mock.load_bundle_from_cache = MagicMock(return_value=(False, None, None, None))
         second_resolver_mock.resolve_bundle = MagicMock(return_value=(True, 'bundle_name', 'mock bundle_file', None))
+        # Mock the second resolver doesn't provide is_supported_uri by raising AttributeError
+        second_resolver_mock.supported_schemes = MagicMock(side_effect=AttributeError('has no attribute '
+                                                                                      '\'supported_schemes\''))
 
-        resolver_chain_mock = MagicMock(return_value=[first_resolver_mock, second_resolver_mock])
+        third_resolver_mock = Mock(name='third_resolver')
+        third_resolver_mock.__name__ = 'first_resolver'
+        third_resolver_mock.load_bundle_from_cache = MagicMock()
+        third_resolver_mock.resolve_bundle = MagicMock()
+        third_resolver_mock.supported_schemes = MagicMock(return_value=[SCHEME_HTTP])
 
-        with patch('conductr_cli.resolver.resolver_chain', resolver_chain_mock):
+        resolver_chain_mock = MagicMock(return_value=[first_resolver_mock, second_resolver_mock, third_resolver_mock])
+
+        detect_schemes_mock = MagicMock(return_value=[SCHEME_BUNDLE])
+
+        stdout = MagicMock()
+
+        with patch('conductr_cli.resolver.resolver_chain', resolver_chain_mock), \
+                patch('conductr_cli.resolvers.resolvers_util.detect_schemes', detect_schemes_mock):
+            logging_setup.configure_logging(MagicMock(**{}), stdout)
             bundle_name, bundle_file = resolver.resolve_bundle(custom_settings, '/some-cache-dir', '/some-bundle-path')
             self.assertEqual('bundle_name', bundle_name)
             self.assertEqual('mock bundle_file', bundle_file)
 
         resolver_chain_mock.assert_called_with(custom_settings, False)
 
-        first_resolver_mock.load_from_cache('/some-cache-dir', '/some-bundle-path')
-        first_resolver_mock.resolve_bundle.assert_called_with('/some-cache-dir', '/some-bundle-path')
+        detect_schemes_mock.assert_called_once_with('/some-bundle-path')
 
-        second_resolver_mock.load_from_cache('/some-cache-dir', '/some-bundle-path')
+        first_resolver_mock.supported_schemes.assert_called_once_with()
+        first_resolver_mock.load_bundle_from_cache.assert_called_once_with('/some-cache-dir', '/some-bundle-path')
+        first_resolver_mock.resolve_bundle.assert_called_once_with('/some-cache-dir', '/some-bundle-path')
+
+        second_resolver_mock.supported_schemes.assert_called_once_with()
+        second_resolver_mock.load_bundle_from_cache.assert_called_once_with('/some-cache-dir', '/some-bundle-path')
         second_resolver_mock.resolve_bundle.assert_called_with('/some-cache-dir', '/some-bundle-path')
+
+        third_resolver_mock.supported_schemes.assert_called_once_with()
+        third_resolver_mock.load_bundle_from_cache.assert_not_called()
+        third_resolver_mock.resolve_bundle.assert_not_called()
+
+        expected_output = strip_margin(
+            as_warn("""|Warning: The resolver second_resolver does not provide `supported_schemes()` method.
+                       |Resolving bundle using [first_resolver, second_resolver]
+                       |"""))
+        self.assertEqual(expected_output, self.output(stdout))
 
     def test_resolve_bundle_success_with_some_resolver_returning_errors(self):
         custom_settings = Mock()
 
         first_resolver_mock = Mock()
+        first_resolver_mock.__name__ = 'first_resolver'
         first_resolver_load_bundle_from_cache_error = MagicMock(name='first_resolver_load_bundle_from_cache_error')
         first_resolver_mock.load_bundle_from_cache = MagicMock(
             return_value=(False, None, None, first_resolver_load_bundle_from_cache_error))
         first_resolver_mock.resolve_bundle = MagicMock(return_value=(False, None, None, None))
+        first_resolver_mock.supported_schemes = MagicMock(return_value=[SCHEME_BUNDLE])
 
         second_resolver_mock = Mock()
+        second_resolver_mock.__name__ = 'second_resolver'
         second_resolver_load_bundle_from_cache_error = MagicMock(name='second_resolver_load_bundle_from_cache_error')
         second_resolver_mock.load_bundle_from_cache = MagicMock(
             return_value=(False, None, None, second_resolver_load_bundle_from_cache_error))
         second_resolver_mock.resolve_bundle = MagicMock(return_value=(True, 'bundle_name', 'mock bundle_file', None))
+        second_resolver_mock.supported_schemes = MagicMock(return_value=[SCHEME_HTTP])
 
         resolver_chain_mock = MagicMock(return_value=[first_resolver_mock, second_resolver_mock])
 
-        with patch('conductr_cli.resolver.resolver_chain', resolver_chain_mock):
+        detect_schemes_mock = MagicMock(return_value=[SCHEME_BUNDLE, SCHEME_HTTP])
+
+        with patch('conductr_cli.resolver.resolver_chain', resolver_chain_mock), \
+                patch('conductr_cli.resolvers.resolvers_util.detect_schemes', detect_schemes_mock):
             bundle_name, bundle_file = resolver.resolve_bundle(custom_settings, '/some-cache-dir', '/some-bundle-path')
             self.assertEqual('bundle_name', bundle_name)
             self.assertEqual('mock bundle_file', bundle_file)
 
         resolver_chain_mock.assert_called_with(custom_settings, False)
+        detect_schemes_mock.assert_called_once_with('/some-bundle-path')
 
-        first_resolver_mock.load_from_cache('/some-cache-dir', '/some-bundle-path')
-        first_resolver_mock.resolve_bundle.assert_called_with('/some-cache-dir', '/some-bundle-path')
+        first_resolver_mock.supported_schemes.assert_called_once_with()
+        first_resolver_mock.load_bundle_from_cache.assert_called_once_with('/some-cache-dir', '/some-bundle-path')
+        first_resolver_mock.resolve_bundle.assert_called_once_with('/some-cache-dir', '/some-bundle-path')
 
-        second_resolver_mock.load_from_cache('/some-cache-dir', '/some-bundle-path')
-        second_resolver_mock.resolve_bundle.assert_called_with('/some-cache-dir', '/some-bundle-path')
+        second_resolver_mock.supported_schemes.assert_called_once_with()
+        second_resolver_mock.load_bundle_from_cache.assert_called_once_with('/some-cache-dir', '/some-bundle-path')
+        second_resolver_mock.resolve_bundle.assert_called_once_with('/some-cache-dir', '/some-bundle-path')
 
     def test_resolve_bundle_not_found(self):
         custom_settings = Mock()
 
         first_resolver_mock = Mock()
-
+        first_resolver_mock.__name__ = 'first_resolver'
         first_resolver_mock.load_bundle_from_cache = MagicMock(return_value=(False, None, None, None))
         first_resolver_mock.resolve_bundle = MagicMock(return_value=(False, None, None, None))
+        first_resolver_mock.supported_schemes = MagicMock(return_value=[SCHEME_BUNDLE])
 
         resolver_chain_mock = MagicMock(return_value=[first_resolver_mock])
+
+        detect_schemes_mock = MagicMock(return_value=[SCHEME_BUNDLE, SCHEME_HTTP])
+
         with patch('conductr_cli.resolver.resolver_chain', resolver_chain_mock), \
+                patch('conductr_cli.resolvers.resolvers_util.detect_schemes', detect_schemes_mock), \
                 self.assertRaises(BundleResolutionError) as e:
             resolver.resolve_bundle(custom_settings, '/some-cache-dir', '/some-bundle-path')
 
@@ -83,29 +131,39 @@ class TestResolver(TestCase):
         self.assertEqual([], e.exception.bundle_resolution_errors)
 
         resolver_chain_mock.assert_called_with(custom_settings, False)
+        detect_schemes_mock.assert_called_once_with('/some-bundle-path')
 
-        first_resolver_mock.load_from_cache('/some-cache-dir', '/some-bundle-path')
-        first_resolver_mock.resolve_bundle.assert_called_with('/some-cache-dir', '/some-bundle-path')
+        first_resolver_mock.supported_schemes.assert_called_once_with()
+        first_resolver_mock.load_bundle_from_cache.assert_called_once_with('/some-cache-dir', '/some-bundle-path')
+        first_resolver_mock.resolve_bundle.assert_called_once_with('/some-cache-dir', '/some-bundle-path')
 
     def test_resolve_bundle_error(self):
         custom_settings = Mock()
 
         first_resolver_mock = Mock()
+        first_resolver_mock.__name__ = 'first_resolver'
         first_resolver_load_bundle_from_cache_error = MagicMock(name='first_resolver_load_bundle_from_cache_error')
         first_resolver_mock.load_bundle_from_cache = MagicMock(
             return_value=(False, None, None, first_resolver_load_bundle_from_cache_error))
         first_resolver_mock.resolve_bundle = MagicMock(return_value=(False, None, None, None))
+        first_resolver_mock.supported_schemes = MagicMock(return_value=[SCHEME_BUNDLE])
 
         second_resolver_mock = Mock()
+        second_resolver_mock.__name__ = 'second_resolver'
         second_resolver_load_bundle_from_cache_error = MagicMock(name='second_resolver_load_bundle_from_cache_error')
         second_resolver_mock.load_bundle_from_cache = MagicMock(
             return_value=(False, None, None, second_resolver_load_bundle_from_cache_error))
         second_resolver_resolve_bundle_error = MagicMock(name='second_resolver_resolve_bundle_error')
         second_resolver_mock.resolve_bundle = MagicMock(
             return_value=(False, None, None, second_resolver_resolve_bundle_error))
+        second_resolver_mock.supported_schemes = MagicMock(return_value=[SCHEME_BUNDLE])
 
         resolver_chain_mock = MagicMock(return_value=[first_resolver_mock, second_resolver_mock])
+
+        detect_schemes_mock = MagicMock(return_value=[SCHEME_BUNDLE, SCHEME_HTTP])
+
         with patch('conductr_cli.resolver.resolver_chain', resolver_chain_mock), \
+                patch('conductr_cli.resolvers.resolvers_util.detect_schemes', detect_schemes_mock), \
                 self.assertRaises(BundleResolutionError) as e:
             resolver.resolve_bundle(custom_settings, '/some-cache-dir', '/some-bundle-path')
 
@@ -120,63 +178,155 @@ class TestResolver(TestCase):
 
         resolver_chain_mock.assert_called_with(custom_settings, False)
 
-        first_resolver_mock.load_from_cache('/some-cache-dir', '/some-bundle-path')
-        first_resolver_mock.resolve_bundle.assert_called_with('/some-cache-dir', '/some-bundle-path')
+        detect_schemes_mock.assert_called_once_with('/some-bundle-path')
+
+        first_resolver_mock.supported_schemes.assert_called_once_with()
+        first_resolver_mock.load_bundle_from_cache.assert_called_once_with('/some-cache-dir', '/some-bundle-path')
+        first_resolver_mock.resolve_bundle.assert_called_once_with('/some-cache-dir', '/some-bundle-path')
+
+        second_resolver_mock.supported_schemes.assert_called_once_with()
+        second_resolver_mock.load_bundle_from_cache.assert_called_once_with('/some-cache-dir', '/some-bundle-path')
+        second_resolver_mock.resolve_bundle.assert_called_once_with('/some-cache-dir', '/some-bundle-path')
 
     def test_resolve_bundle_from_cache(self):
         custom_settings = Mock()
 
         first_resolver_mock = Mock()
+        first_resolver_mock.__name__ = 'first_resolver'
         first_resolver_mock.load_bundle_from_cache = MagicMock(return_value=(True, 'bundle_name', 'mock bundle_file', None))
+        first_resolver_mock.resolve_bundle = MagicMock()
+        first_resolver_mock.supported_schemes = MagicMock(return_value=[SCHEME_BUNDLE])
 
         resolver_chain_mock = MagicMock(return_value=[first_resolver_mock])
-        with patch('conductr_cli.resolver.resolver_chain', resolver_chain_mock):
+
+        detect_schemes_mock = MagicMock(return_value=[SCHEME_BUNDLE, SCHEME_HTTP])
+
+        stdout = MagicMock()
+        with patch('conductr_cli.resolver.resolver_chain', resolver_chain_mock), \
+                patch('conductr_cli.resolvers.resolvers_util.detect_schemes', detect_schemes_mock):
+            logging_setup.configure_logging(MagicMock(**{}), stdout)
             bundle_name, bundle_file = resolver.resolve_bundle(custom_settings, '/some-cache-dir',
                                                                '/some-bundle-path')
             self.assertEqual('bundle_name', bundle_name)
             self.assertEqual('mock bundle_file', bundle_file)
 
         resolver_chain_mock.assert_called_with(custom_settings, False)
+        detect_schemes_mock.assert_called_with('/some-bundle-path')
 
-        first_resolver_mock.load_from_cache('/some-cache-dir', '/some-bundle-path')
+        first_resolver_mock.supported_schemes.assert_called_once_with()
+        first_resolver_mock.load_bundle_from_cache.assert_called_once_with('/some-cache-dir', '/some-bundle-path')
+        first_resolver_mock.resolve_bundle.assert_not_called()
+
+        self.assertEqual('Resolving bundle using [first_resolver]\n', self.output(stdout))
+
+    def test_resolve_bundle_no_suitable_resolver(self):
+        custom_settings = Mock()
+
+        first_resolver_mock = Mock()
+        first_resolver_mock.__name__ = 'first_resolver'
+        first_resolver_mock.load_bundle_from_cache = MagicMock()
+        first_resolver_mock.resolve_bundle = MagicMock()
+        first_resolver_mock.supported_schemes = MagicMock(return_value=[SCHEME_BUNDLE])
+
+        resolver_chain_mock = MagicMock(return_value=[first_resolver_mock])
+
+        detect_schemes_mock = MagicMock(return_value=[SCHEME_HTTP])
+
+        stdout = MagicMock()
+        with patch('conductr_cli.resolver.resolver_chain', resolver_chain_mock), \
+                patch('conductr_cli.resolvers.resolvers_util.detect_schemes', detect_schemes_mock), \
+                self.assertRaises(BundleResolutionError) as e:
+            logging_setup.configure_logging(MagicMock(**{}), stdout)
+            resolver.resolve_bundle(custom_settings, '/some-cache-dir', '/some-bundle-path')
+
+        self.assertEqual([], e.exception.cache_resolution_errors)
+        self.assertEqual([], e.exception.bundle_resolution_errors)
+
+        resolver_chain_mock.assert_called_with(custom_settings, False)
+
+        detect_schemes_mock.assert_called_once_with('/some-bundle-path')
+
+        first_resolver_mock.supported_schemes.assert_called_once_with()
+        first_resolver_mock.load_bundle_from_cache.assert_not_called()
+        first_resolver_mock.resolve_bundle.assert_not_called()
+
+        self.assertEqual('', self.output(stdout))
 
     def test_resolve_bundle_configuration_success(self):
         custom_settings = Mock()
 
         first_resolver_mock = Mock()
+        first_resolver_mock.__name__ = 'first_resolver'
         first_resolver_mock.load_bundle_configuration_from_cache = MagicMock(return_value=(False, None, None, None))
         first_resolver_mock.resolve_bundle_configuration = MagicMock(return_value=(False, None, None, None))
+        first_resolver_mock.supported_schemes = MagicMock(return_value=[SCHEME_BUNDLE])
 
         second_resolver_mock = Mock()
+        second_resolver_mock.__name__ = 'second_resolver'
         second_resolver_mock.load_bundle_configuration_from_cache = MagicMock(return_value=(False, None, None, None))
         second_resolver_mock.resolve_bundle_configuration = MagicMock(return_value=(True, 'bundle_name',
                                                                                     'mock bundle_file', None))
+        # Mock the second resolver doesn't provide is_supported_uri by raising AttributeError
+        second_resolver_mock.supported_schemes = MagicMock(side_effect=AttributeError('has no attribute '
+                                                                                      '\'supported_schemes\''))
 
-        resolver_chain_mock = MagicMock(return_value=[first_resolver_mock, second_resolver_mock])
+        third_resolver_mock = Mock(name='third_resolver')
+        third_resolver_mock.__name__ = 'third_resolver'
+        third_resolver_mock.load_bundle_from_cache = MagicMock()
+        third_resolver_mock.resolve_bundle = MagicMock()
+        third_resolver_mock.supported_schemes = MagicMock(return_value=[SCHEME_HTTP])
 
-        with patch('conductr_cli.resolver.resolver_chain', resolver_chain_mock):
+        resolver_chain_mock = MagicMock(return_value=[first_resolver_mock, second_resolver_mock, third_resolver_mock])
+
+        detect_schemes_mock = MagicMock(return_value=[SCHEME_BUNDLE])
+
+        stdout = MagicMock()
+        with patch('conductr_cli.resolver.resolver_chain', resolver_chain_mock), \
+                patch('conductr_cli.resolvers.resolvers_util.detect_schemes', detect_schemes_mock):
+            logging_setup.configure_logging(MagicMock(**{}), stdout)
             bundle_name, bundle_file = resolver.resolve_bundle_configuration(
                 custom_settings, '/some-cache-dir', '/some-bundle-path')
             self.assertEqual('bundle_name', bundle_name)
             self.assertEqual('mock bundle_file', bundle_file)
 
         resolver_chain_mock.assert_called_with(custom_settings, False)
+        detect_schemes_mock.assert_called_with('/some-bundle-path')
 
-        first_resolver_mock.load_bundle_configuration_from_cache('/some-cache-dir', '/some-bundle-path')
-        first_resolver_mock.resolve_bundle_configuration.assert_called_with('/some-cache-dir', '/some-bundle-path')
+        first_resolver_mock.supported_schemes.assert_called_once_with()
+        first_resolver_mock.load_bundle_configuration_from_cache.assert_called_once_with('/some-cache-dir',
+                                                                                         '/some-bundle-path')
+        first_resolver_mock.resolve_bundle_configuration.assert_called_once_with('/some-cache-dir', '/some-bundle-path')
 
-        second_resolver_mock.load_bundle_configuration_from_cache('/some-cache-dir', '/some-bundle-path')
-        second_resolver_mock.resolve_bundle_configuration.assert_called_with('/some-cache-dir', '/some-bundle-path')
+        second_resolver_mock.supported_schemes.assert_called_once_with()
+        second_resolver_mock.load_bundle_configuration_from_cache.assert_called_once_with('/some-cache-dir',
+                                                                                          '/some-bundle-path')
+        second_resolver_mock.resolve_bundle_configuration.assert_called_once_with('/some-cache-dir', '/some-bundle-path')
+
+        third_resolver_mock.supported_schemes.assert_called_once_with()
+        third_resolver_mock.load_bundle_configuration_from_cache.assert_not_called()
+        third_resolver_mock.resolve_bundle_configuration.assert_not_called()
+
+        expected_output = strip_margin(
+            as_warn("""|Warning: The resolver second_resolver does not provide `supported_schemes()` method.
+                       |Resolving bundle configuration using [first_resolver, second_resolver]
+                       |"""))
+        self.assertEqual(expected_output, self.output(stdout))
 
     def test_resolve_bundle_configuration_failure(self):
         custom_settings = Mock()
 
         first_resolver_mock = Mock()
+        first_resolver_mock.__name__ = 'first_resolver'
         first_resolver_mock.load_bundle_configuration_from_cache = MagicMock(return_value=(False, None, None, None))
         first_resolver_mock.resolve_bundle_configuration = MagicMock(return_value=(False, None, None, None))
+        first_resolver_mock.supported_schemes = MagicMock(return_value=[SCHEME_BUNDLE])
 
         resolver_chain_mock = MagicMock(return_value=[first_resolver_mock])
+
+        detect_schemes_mock = MagicMock(return_value=[SCHEME_BUNDLE])
+
         with patch('conductr_cli.resolver.resolver_chain', resolver_chain_mock), \
+                patch('conductr_cli.resolvers.resolvers_util.detect_schemes', detect_schemes_mock), \
                 self.assertRaises(BundleResolutionError) as e:
             resolver.resolve_bundle_configuration(custom_settings, '/some-cache-dir', '/some-bundle-path')
 
@@ -184,85 +334,219 @@ class TestResolver(TestCase):
         self.assertEqual([], e.exception.bundle_resolution_errors)
 
         resolver_chain_mock.assert_called_with(custom_settings, False)
+        detect_schemes_mock.assert_called_with('/some-bundle-path')
 
-        first_resolver_mock.load_bundle_configuration_from_cache('/some-cache-dir', '/some-bundle-path')
-        first_resolver_mock.resolve_bundle_configuration.assert_called_with('/some-cache-dir', '/some-bundle-path')
+        first_resolver_mock.supported_schemes.assert_called_once_with()
+        first_resolver_mock.load_bundle_configuration_from_cache.assert_called_once_with('/some-cache-dir',
+                                                                                         '/some-bundle-path')
+        first_resolver_mock.resolve_bundle_configuration.assert_called_once_with('/some-cache-dir', '/some-bundle-path')
+
+    def test_resolve_bundle_configuration_no_suitable_resolver(self):
+        custom_settings = Mock()
+
+        first_resolver_mock = Mock()
+        first_resolver_mock.__name__ = 'first_resolver'
+        first_resolver_mock.load_bundle_configuration_from_cache = MagicMock()
+        first_resolver_mock.resolve_bundle_configuration = MagicMock()
+        first_resolver_mock.supported_schemes = MagicMock(return_value=[SCHEME_BUNDLE])
+
+        resolver_chain_mock = MagicMock(return_value=[first_resolver_mock])
+
+        detect_schemes_mock = MagicMock(return_value=[SCHEME_HTTP])
+
+        with patch('conductr_cli.resolver.resolver_chain', resolver_chain_mock), \
+                patch('conductr_cli.resolvers.resolvers_util.detect_schemes', detect_schemes_mock), \
+                self.assertRaises(BundleResolutionError) as e:
+            resolver.resolve_bundle_configuration(custom_settings, '/some-cache-dir', '/some-bundle-path')
+
+        self.assertEqual([], e.exception.cache_resolution_errors)
+        self.assertEqual([], e.exception.bundle_resolution_errors)
+
+        resolver_chain_mock.assert_called_with(custom_settings, False)
+        detect_schemes_mock.assert_called_with('/some-bundle-path')
+
+        first_resolver_mock.supported_schemes.assert_called_once_with()
+        first_resolver_mock.load_bundle_configuration_from_cache.assert_not_called()
+        first_resolver_mock.resolve_bundle_configuration.assert_not_called()
 
     def test_resolve_bundle_configuration_from_cache(self):
         custom_settings = Mock()
 
         first_resolver_mock = Mock()
+        first_resolver_mock.__name__ = 'first_resolver'
         first_resolver_mock.load_bundle_configuration_from_cache = MagicMock(return_value=(True, 'bundle_name',
                                                                                            'mock bundle_file', None))
+        first_resolver_mock.resolve_bundle_configuration = MagicMock()
+        first_resolver_mock.supported_schemes = MagicMock(return_value=[SCHEME_BUNDLE])
 
         resolver_chain_mock = MagicMock(return_value=[first_resolver_mock])
-        with patch('conductr_cli.resolver.resolver_chain', resolver_chain_mock):
+
+        detect_schemes_mock = MagicMock(return_value=[SCHEME_BUNDLE])
+
+        with patch('conductr_cli.resolver.resolver_chain', resolver_chain_mock), \
+                patch('conductr_cli.resolvers.resolvers_util.detect_schemes', detect_schemes_mock):
             bundle_name, bundle_file = resolver.resolve_bundle_configuration(custom_settings, '/some-cache-dir',
                                                                              '/some-bundle-path')
             self.assertEqual('bundle_name', bundle_name)
             self.assertEqual('mock bundle_file', bundle_file)
 
         resolver_chain_mock.assert_called_with(custom_settings, False)
+        detect_schemes_mock.assert_called_with('/some-bundle-path')
 
-        first_resolver_mock.load_bundle_configuration_from_cache('/some-cache-dir', '/some-bundle-path')
+        first_resolver_mock.supported_schemes.assert_called_once_with()
+        first_resolver_mock.load_bundle_configuration_from_cache.assert_called_once_with('/some-cache-dir',
+                                                                                         '/some-bundle-path')
+        first_resolver_mock.resolve_bundle_configuration.assert_not_called()
 
 
-class TestResolverResolveBundleVersion(TestCase):
+class TestResolverResolveBundleVersion(CliTestCase):
     def test_resolve_bundle_version_success(self):
         custom_settings = Mock()
 
         first_resolver_mock = Mock()
+        first_resolver_mock.__name__ = 'first_resolver'
         first_resolver_mock.resolve_bundle_version = MagicMock(return_value=(None, None))
+        first_resolver_mock.supported_schemes = MagicMock(return_value=[SCHEME_BUNDLE])
 
         second_resolver_mock = Mock()
+        second_resolver_mock.__name__ = 'second_resolver'
         resolved_version = {'test': 'only'}
         second_resolver_mock.resolve_bundle_version = MagicMock(return_value=(resolved_version, None))
+        second_resolver_mock.supported_schemes = MagicMock(return_value=[SCHEME_HTTP])
 
         resolver_chain_mock = MagicMock(return_value=[first_resolver_mock, second_resolver_mock])
 
-        with patch('conductr_cli.resolver.resolver_chain', resolver_chain_mock):
+        detect_schemes_mock = MagicMock(return_value=[SCHEME_BUNDLE, SCHEME_HTTP])
+
+        stdout = MagicMock()
+
+        with patch('conductr_cli.resolver.resolver_chain', resolver_chain_mock), \
+                patch('conductr_cli.resolvers.resolvers_util.detect_schemes', detect_schemes_mock):
+            logging_setup.configure_logging(MagicMock(**{}), stdout)
             result = resolver.resolve_bundle_version(custom_settings, 'bundle')
             self.assertEqual(resolved_version, result)
 
         resolver_chain_mock.assert_called_with(custom_settings, False)
+        detect_schemes_mock.assert_called_once_with('bundle')
+
+        first_resolver_mock.supported_schemes.assert_called_with()
         first_resolver_mock.resolve_bundle_version.assert_called_with('bundle')
+
+        second_resolver_mock.supported_schemes.assert_called_with()
         second_resolver_mock.resolve_bundle_version.assert_called_with('bundle')
+
+        expected_output = strip_margin("""|Resolving bundle version using [first_resolver, second_resolver]
+                                          |""")
+        self.assertEqual(expected_output, self.output(stdout))
 
     def test_resolve_bundle_version_success_offline(self):
         custom_settings = Mock()
 
         first_resolver_mock = Mock()
+        first_resolver_mock.__name__ = 'first_resolver'
         first_resolver_mock.resolve_bundle_version = MagicMock(return_value=(None, None))
+        first_resolver_mock.supported_schemes = MagicMock(return_value=[SCHEME_BUNDLE])
 
         second_resolver_mock = Mock()
+        second_resolver_mock.__name__ = 'second_resolver'
         resolved_version = {'test': 'only'}
         second_resolver_mock.resolve_bundle_version = MagicMock(return_value=(resolved_version, None))
+        # Mock the second resolver doesn't provide is_supported_uri by raising AttributeError
+        second_resolver_mock.supported_schemes = MagicMock(side_effect=AttributeError('has no attribute '
+                                                                                      '\'supported_schemes\''))
 
         resolver_chain_mock = MagicMock(return_value=[first_resolver_mock, second_resolver_mock])
 
-        with patch('conductr_cli.resolver.resolver_chain', resolver_chain_mock):
+        detect_schemes_mock = MagicMock(return_value=[SCHEME_BUNDLE, SCHEME_HTTP])
+
+        stdout = MagicMock()
+
+        with patch('conductr_cli.resolver.resolver_chain', resolver_chain_mock), \
+                patch('conductr_cli.resolvers.resolvers_util.detect_schemes', detect_schemes_mock):
+            logging_setup.configure_logging(MagicMock(**{}), stdout)
             result = resolver.resolve_bundle_version(custom_settings, 'bundle', offline_mode=True)
             self.assertEqual(resolved_version, result)
 
         resolver_chain_mock.assert_called_with(custom_settings, True)
-        first_resolver_mock.resolve_bundle_version.assert_called_with('bundle')
-        second_resolver_mock.resolve_bundle_version.assert_called_with('bundle')
+
+        detect_schemes_mock.assert_called_once_with('bundle')
+
+        first_resolver_mock.supported_schemes.assert_called_once_with()
+        first_resolver_mock.resolve_bundle_version.assert_called_once_with('bundle')
+
+        second_resolver_mock.supported_schemes.assert_called_once_with()
+        second_resolver_mock.resolve_bundle_version.assert_called_once_with('bundle')
+
+        expected_output = strip_margin(
+            as_warn("""|Warning: The resolver second_resolver does not provide `supported_schemes()` method.
+                       |Resolving bundle version using [first_resolver, second_resolver]
+                       |"""))
+        self.assertEqual(expected_output, self.output(stdout))
 
     def test_resolve_bundle_version_failure(self):
         custom_settings = Mock()
 
         first_resolver_mock = Mock()
+        first_resolver_mock.__name__ = 'first_resolver'
         first_resolver_mock.resolve_bundle_version = MagicMock(return_value=(None, None))
+        first_resolver_mock.supported_schemes = MagicMock(return_value=[SCHEME_BUNDLE])
 
         resolver_chain_mock = MagicMock(return_value=[first_resolver_mock])
-        with patch('conductr_cli.resolver.resolver_chain', resolver_chain_mock),\
+
+        detect_schemes_mock = MagicMock(return_value=[SCHEME_BUNDLE, SCHEME_HTTP])
+
+        stdout = MagicMock()
+
+        with patch('conductr_cli.resolver.resolver_chain', resolver_chain_mock), \
+                patch('conductr_cli.resolvers.resolvers_util.detect_schemes', detect_schemes_mock), \
                 self.assertRaises(BundleResolutionError) as e:
+            logging_setup.configure_logging(MagicMock(**{}), stdout)
             resolver.resolve_bundle_version(custom_settings, 'bundle')
 
         self.assertEqual([], e.exception.cache_resolution_errors)
         self.assertEqual([], e.exception.bundle_resolution_errors)
+
         resolver_chain_mock.assert_called_with(custom_settings, False)
-        first_resolver_mock.resolve_bundle_version.assert_called_with('bundle')
+        detect_schemes_mock.assert_called_once_with('bundle')
+
+        first_resolver_mock.supported_schemes.assert_called_once_with()
+        first_resolver_mock.resolve_bundle_version.assert_called_once_with('bundle')
+
+        expected_output = strip_margin("""|Resolving bundle version using [first_resolver]
+                                          |""")
+        self.assertEqual(expected_output, self.output(stdout))
+
+    def test_resolve_bundle_version_no_suitable_resolver(self):
+        custom_settings = Mock()
+
+        first_resolver_mock = Mock()
+        first_resolver_mock.__name__ = 'first_resolver'
+        first_resolver_mock.resolve_bundle_version = MagicMock()
+        first_resolver_mock.supported_schemes = MagicMock(return_value=[SCHEME_BUNDLE])
+
+        resolver_chain_mock = MagicMock(return_value=[first_resolver_mock])
+
+        detect_schemes_mock = MagicMock(return_value=[SCHEME_HTTP])
+
+        stdout = MagicMock()
+
+        with patch('conductr_cli.resolver.resolver_chain', resolver_chain_mock), \
+                patch('conductr_cli.resolvers.resolvers_util.detect_schemes', detect_schemes_mock), \
+                self.assertRaises(BundleResolutionError) as e:
+            logging_setup.configure_logging(MagicMock(**{}), stdout)
+            resolver.resolve_bundle_version(custom_settings, 'bundle')
+
+        self.assertEqual([], e.exception.cache_resolution_errors)
+        self.assertEqual([], e.exception.bundle_resolution_errors)
+
+        resolver_chain_mock.assert_called_with(custom_settings, False)
+
+        detect_schemes_mock.assert_called_with('bundle')
+
+        first_resolver_mock.supported_schemes.assert_called_once_with()
+        first_resolver_mock.resolve_bundle_version.assert_not_called()
+
+        self.assertEqual('', self.output(stdout))
 
 
 class TestResolverContinuousDeliveryUri(TestCase):
@@ -353,7 +637,7 @@ class TestResolverChain(TestCase):
 
     def test_none_input(self):
         result = resolver.resolver_chain(None, False)
-        expected_result = [stdin_resolver, uri_resolver, bintray_resolver, docker_resolver]
+        expected_result = [stdin_resolver, uri_resolver, bintray_resolver, docker_resolver, s3_resolver]
         self.assertEqual(expected_result, result)
 
     def test_custom_settings_no_resolver_config(self):
@@ -362,7 +646,7 @@ class TestResolverChain(TestCase):
                             |""")
         )
         result = resolver.resolver_chain(custom_settings, False)
-        expected_result = [stdin_resolver, uri_resolver, bintray_resolver, docker_resolver]
+        expected_result = [stdin_resolver, uri_resolver, bintray_resolver, docker_resolver, s3_resolver]
         self.assertEqual(expected_result, result)
 
     def test_offline_mode(self):

--- a/sandbox.spec
+++ b/sandbox.spec
@@ -2,6 +2,14 @@
 
 import os
 
+# FIXME: Remove once we have PyInstaller 3.3
+# Temporary workaround until PyInstaller's boto hook imports the correct method
+# https://github.com/pyinstaller/pyinstaller/issues/2384
+# Fix is scheduled for PyInstaller 3.3
+from PyInstaller.utils.hooks import is_module_satisfies
+import PyInstaller.compat
+PyInstaller.compat.is_module_satisfies = is_module_satisfies
+
 
 block_cipher = None
 
@@ -10,7 +18,7 @@ a = Analysis(['conductr_cli/sandbox.py'],
              pathex=[os.path.abspath(os.getcwd())],
              binaries=[],
              datas=[],
-             hiddenimports=['psutil'],
+             hiddenimports=['configparser', 'psutil'],
              hookspath=[],
              runtime_hooks=[],
              excludes=[],

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ install_requires = [
     'pyreadline>=2.1',
     'www-authenticate==0.9.2',
     'certifi>=2017.4.17',
+    'boto3>=1.4.4',
 
     # FIXME: Remove the following dependencies when dcos can be depended on
     'jsonschema>=2.5, <3.0',


### PR DESCRIPTION
Provide additional resolver which will be able to resolve a given S3 URL:

```
s3://<bucket name>/<key to bundle or configuration zip>
```

The S3 resolver relies on AWS provided `boto3` library which has been added as dependency.

**Boto3 PyInstaller Notes**

Some workaround is in place to ensure `boto3` is included correctly into native executable. This is required due to PyInstaller's `boto3` hooks importing incorrect module name:

https://github.com/pyinstaller/pyinstaller/issues/2384

Fix is scheduled for PyInstaller 3.3, and the workaround should be able to be removed afterwards.

Additionally, `boto3` in native executable requires having the module `configparser` to be declared as hidden import.

**Modification to resolver mechanism**

Resolver now declares `supported_schemes()` which returns a list of URI schemes supported by a particular resolver, i.e. `file`, `http`, or `urn:x-bundle`.

Applicable URI schemes is now derived from the input URI. The applicable schemes derived from the input URI is compared against the URI schemes supported by each resolver, and the resolver chain is filtered based on the result of this comparison.

---

- [x] Ensure `boto3` can be packaged successfully using PyInstaller
- [x] Support downloading from `s3://` style URLs
- [x] Add support progress bar
- [x] Unit test