### PR TITLE
CLI now ignores whitespace for resolver credentials

### DIFF
--- a/conductr_cli/resolvers/bintray_resolver.py
+++ b/conductr_cli/resolvers/bintray_resolver.py
@@ -14,7 +14,7 @@ BINTRAY_API_BASE_URL = 'https://api.bintray.com'
 BINTRAY_DOWNLOAD_BASE_URL = 'https://dl.bintray.com'
 BINTRAY_DOWNLOAD_REALM = 'Bintray'
 BINTRAY_CREDENTIAL_FILE_PATH = '{}/.lightbend/commercial.credentials'.format(os.path.expanduser('~'))
-BINTRAY_PROPERTIES_RE = re.compile('^(\S+)\s*=\s*([\S]+)$')
+BINTRAY_PROPERTIES_RE = re.compile('^\s*(\S+)\s*=\s*([\S]+)\s*$')
 BINTRAY_LIGHTBEND_ORG = 'lightbend'
 BINTRAY_CONDUCTR_COMMERCIAL_REPO = 'commercial-releases'
 BINTRAY_CONDUCTR_GENERIC_REPO = 'generic'

--- a/conductr_cli/resolvers/test/test_bintray_resolver.py
+++ b/conductr_cli/resolvers/test/test_bintray_resolver.py
@@ -998,6 +998,25 @@ class TestLoadBintrayCredentials(TestCase):
         exists_mock.assert_called_with('{}/.lightbend/commercial.credentials'.format(os.path.expanduser('~')))
         open_mock.assert_called_with('{}/.lightbend/commercial.credentials'.format(os.path.expanduser('~')), 'r')
 
+    def test_success_whitespace(self):
+        bintray_credential_file = \
+            ' user = user1  \n' \
+            ' password = sec=ret \n' \
+            '# Some comment'
+
+        exists_mock = MagicMock(return_value=True)
+        open_mock = MagicMock(return_value=io.StringIO(bintray_credential_file))
+
+        with patch('os.path.exists', exists_mock), \
+                patch('builtins.open', open_mock):
+            realm, username, password = bintray_resolver.load_bintray_credentials()
+            self.assertEqual('Bintray', realm)
+            self.assertEqual('user1', username)
+            self.assertEqual('sec=ret', password)
+
+        exists_mock.assert_called_with('{}/.lightbend/commercial.credentials'.format(os.path.expanduser('~')))
+        open_mock.assert_called_with('{}/.lightbend/commercial.credentials'.format(os.path.expanduser('~')), 'r')
+
     def test_credential_file_not_having_username_password(self):
         bintray_credential_file = strip_margin(
             """|dummy = yes


### PR DESCRIPTION
This PR adjusts the credentials file for Bintray to ignore spaces at the beginning and end of properties.