### PR TITLE
Modify `conduct load-license` to treat 403 the same as 401 and 303 and thus delete auth-token file when invalid

### DIFF
--- a/conductr_cli/license.py
+++ b/conductr_cli/license.py
@@ -44,11 +44,8 @@ def download_license(args, save_to, use_cached_auth_token):
     if log.is_verbose_enabled():
         log.verbose(response.text)
 
-    if response.status_code == 401 or response.status_code == 303:
+    if response.status_code == 401 or response.status_code == 303 or response.status_code == 403:
         license_auth.remove_cached_auth_token()
-        raise LicenseDownloadError([response.text])
-
-    elif response.status_code == 403:
         raise LicenseDownloadError([response.text])
 
     validation.raise_for_status_inc_3xx(response)


### PR DESCRIPTION
Fixes #497 

The thing I'm not clear on is why we were treating 403 differently to begin with. @fsat can you comment on that?