### PR TITLE
conduct load/deploy now reads the first bundle.conf file listed in the archive central directory

### DIFF
--- a/conductr_cli/bundle_utils.py
+++ b/conductr_cli/bundle_utils.py
@@ -10,8 +10,8 @@ def short_id(bundle_id):
 
 def conf(bundle_path):
     bundle_zip = ZipFile(bundle_path)
-    bundle_configuration = [bundle_zip.read(name) for name in bundle_zip.namelist() if name.endswith('bundle.conf')]
-    return bundle_configuration[0].decode('utf-8') if len(bundle_configuration) == 1 else ''
+    bundle_configurations = [bundle_zip.read(name) for name in bundle_zip.namelist() if name.endswith('bundle.conf')]
+    return bundle_configurations[0].decode('utf-8') if len(bundle_configurations) > 0 else None
 
 
 def digest_extract_and_open(path):

--- a/conductr_cli/test/cli_test_case.py
+++ b/conductr_cli/test/cli_test_case.py
@@ -98,7 +98,10 @@ def create_temp_bundle_with_contents(contents):
     os.makedirs(basedir)
 
     for name, content in contents.items():
-        with open(os.path.join(basedir, name), 'w', encoding="utf-8") as file:
+        file_name = os.path.join(basedir, name)
+        dir_name = os.path.dirname(file_name)
+        os.makedirs(dir_name, exist_ok=True)
+        with open(file_name, 'w', encoding="utf-8") as file:
             file.write(content)
 
     return tmpdir, shutil.make_archive(os.path.join(tmpdir, 'bundle'), 'zip', unpacked, 'bundle-1.0.0')

--- a/conductr_cli/test/test_bundle_utils.py
+++ b/conductr_cli/test/test_bundle_utils.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from conductr_cli import bundle_utils, constants
-from conductr_cli.test.cli_test_case import create_temp_bundle
+from conductr_cli.test.cli_test_case import create_temp_bundle_with_contents
 import shutil
 import tempfile
 
@@ -18,7 +18,11 @@ class ShortId(TestCase):
 
 class Conf(TestCase):
     def setUp(self):  # noqa
-        self.tmpdir, self.bundle_path = create_temp_bundle('bundle conf contents')
+        self.tmpdir, self.bundle_path = create_temp_bundle_with_contents({
+            'bundle.conf': 'bundle conf contents',
+            'password.txt': 'monkey',
+            'dir/bundle.conf': 'another bundle conf contents'
+        })
 
     def test(self):
         conf_contents = bundle_utils.conf(self.bundle_path)


### PR DESCRIPTION
Adjust `conduct load` and `conduct deploy` to read the first `bundle.conf`. Previously, this errored out if a bundle had multiple `bundle.conf` files. By reading the first one listed, we're also consistent with the logic in ConductR core.

 Fixes https://github.com/typesafehub/conductr/issues/1811