### PR TITLE
bndl: Treat empty list args as None

### DIFF
--- a/conductr_cli/bndl_utils.py
+++ b/conductr_cli/bndl_utils.py
@@ -184,7 +184,6 @@ def load_bundle_args_into_conf(config, args, application_type):
     args_memory = getattr(args, 'memory', None)
     args_name = getattr(args, 'name', None)
     args_nr_of_cpus = getattr(args, 'nr_of_cpus', None)
-    args_roles = getattr(args, 'roles', None)
     args_start_commands = getattr(args, 'start_commands', None)
     args_system = getattr(args, 'system', None)
     args_system_version = getattr(args, 'system_version', None)
@@ -321,8 +320,12 @@ def load_bundle_args_into_conf(config, args, application_type):
     if config_defaults and 'nrOfCpus' not in config:
         config.put('nrOfCpus', config_defaults['nrOfCpus'])
 
-    if args_roles is not None:
-        config.put('roles', args_roles)
+    if hasattr(args, 'roles') and len(args.roles) > 0:
+        roles = []
+        for role in args.roles:
+            if role not in roles:
+                roles.append(role)
+        config.put('roles', roles)
     if config_defaults and 'roles' not in config:
         config.put('roles', config_defaults['roles'])
 

--- a/conductr_cli/test/test_bndl_utils.py
+++ b/conductr_cli/test/test_bndl_utils.py
@@ -124,6 +124,29 @@ class TestBndlUtils(CliTestCase):
         finally:
             shutil.rmtree(tmpdir)
 
+    def test_load_bundle_args_into_conf_with_empty_lists(self):
+        simple_config = ConfigFactory.parse_string('')
+        args = create_attributes_object({
+            'annotations': [],
+            'format': BndlFormat.BUNDLE,
+            'roles': [],
+            'tags': []
+        })
+        application_type = ApplicationType.GENERIC
+        defaults = application_type.config_defaults('universal')
+        bndl_utils.load_bundle_args_into_conf(simple_config, args, application_type)
+        self.assertEqual(simple_config.get('annotations'), defaults['annotations'])
+        self.assertEqual(simple_config.get('compatibilityVersion'), defaults['compatibilityVersion'])
+        self.assertEqual(simple_config.get('diskSpace'), defaults['diskSpace'])
+        self.assertEqual(simple_config.get('memory'), defaults['memory'])
+        self.assertEqual(simple_config.get('name'), defaults['name'])
+        self.assertEqual(simple_config.get('nrOfCpus'), defaults['nrOfCpus'])
+        self.assertEqual(simple_config.get('roles'), defaults['roles'])
+        self.assertEqual(simple_config.get('system'), defaults['system'])
+        self.assertEqual(simple_config.get('systemVersion'), defaults['systemVersion'])
+        self.assertEqual(simple_config.get('tags'), defaults['tags'])
+        self.assertEqual(simple_config.get('version'), defaults['version'])
+
     def test_load_bundle_args_into_conf_with_generic_defaults(self):
         simple_config = ConfigFactory.parse_string('')
         args = create_attributes_object({


### PR DESCRIPTION
Empty `bndl` list arguments such as annotations, tags and roles need to be treated as None in `bndl_utils.load_bundle_args_into_conf`. This was the case for annotations and tags, but not for roles.

The PR is changes the roles logic so that empty lists are treated as None.

Fixes the sbt-conductr build issues on Travis: https://travis-ci.org/typesafehub/sbt-conductr/builds/246078520#L1980-L2019

In other words, without fixing this bug, the roles of each loaded bundle during `conduct load` is overridden to an empty roles list in case no additional bundle configuration has been provided. This is because without this fix the `bndl_utils.load_bundle_args_into_conf` function always created a bundle configuration overlay with empty roles, considering that the defaults roles argument of `bndl` is `[]`, which got invoked during a `conduct load` and therefore overriding the roles of bundle itself.

The original bug got introduced by PR https://github.com/typesafehub/conductr-cli/pull/503.

Unit tests have been added to check that bndl arguments with an empty list are not added to the bundle configuration file.