### PR TITLE
New sandbox version notification

### DIFF
--- a/conductr_cli/sandbox_version.py
+++ b/conductr_cli/sandbox_version.py
@@ -1,3 +1,5 @@
+import semver
+
 
 def is_sandbox_docker_based(version):
     return major_version(version) == 1
@@ -17,7 +19,8 @@ def is_cinnamon_grafana_docker_based(version):
 
 
 def version_parts(version):
-    return tuple(map(int, version.split('-')[0].split('.')))
+    version_info = semver.parse_version_info(version)
+    return version_info.major, version_info.minor, version_info.patch
 
 
 def major_version(version):

--- a/conductr_cli/test/test_sandbox_run.py
+++ b/conductr_cli/test/test_sandbox_run.py
@@ -89,7 +89,9 @@ class TestSandboxRunCommand(CliTestCase):
         mock_collect_features = MagicMock(return_value=features)
 
         sandbox_run_result = sandbox_run_jvm.SandboxRunResult([1001], ['192.168.1.1'], [1002], ['192.168.1.1'],
-                                                              wait_for_conductr=True, license_validation_error=None)
+                                                              wait_for_conductr=True,
+                                                              license_validation_error=None,
+                                                              sandbox_upgrade_requirements=None)
         mock_sandbox_run_jvm = MagicMock(return_value=sandbox_run_result)
         mock_wait_for_conductr = MagicMock(return_value=True)
         mock_log_run_attempt = MagicMock()

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ install_requires = [
     'www-authenticate==0.9.2',
     'certifi>=2017.4.17',
     'boto3>=1.4.4',
+    'semver>=2.7.7',
 
     # FIXME: Remove the following dependencies when dcos can be depended on
     'jsonschema>=2.5, <3.0',


### PR DESCRIPTION
Notify end user when a newer sandbox version is available.

Notification will be displayed when:
- There's a newer version of sandbox compared to what is currently being run by `sandbox run`.
- The user has not downloaded the newer version of sandbox.

