### PR TITLE
Ensure that the current working directory exists or exit with intelligible error

### DIFF
--- a/conductr_cli/main_handler.py
+++ b/conductr_cli/main_handler.py
@@ -11,6 +11,7 @@ SUPPORTED_PYTHON_VERSION = (3, 4)
 def run(callback):
     try:
         enforce_python_version()
+        enforce_cwd_exists()
         result = callback()
         return result
     except KeyboardInterrupt:
@@ -44,6 +45,14 @@ def run(callback):
         exception_log.error('Failure running the following command: {}'.format(sys.argv), exc_info=True)
 
         sys.exit(1)
+
+
+def enforce_cwd_exists():
+    try:
+        os.getcwd()
+    except FileNotFoundError:
+        sys.exit('Unable to start CLI due to missing current/working directory.\n'
+                 'Change into a new directory and try again.\n')
 
 
 def enforce_python_version():


### PR DESCRIPTION
This PR adds a check when the CLI starts to ensure the current working directory exists. This can help mitigate weird environmental issues, I know I've launched the CLI from unlinked directories and it wasn't clear what was wrong.

Fixes #502.

**Manual test**
```bash
$ (mkdir ~/testing-wd && cd ~/testing-wd && rm -r ~/testing-wd && bndl -h)
sh: 0: getcwd() failed: No such file or directory
Unable to start CLI due to missing current/working directory.
Change into a new directory and try again.
-> 1
```