### PR TITLE
Adjust bintray resolver credentials to honor realm values

### DIFF
--- a/conductr_cli/resolvers/bintray_resolver.py
+++ b/conductr_cli/resolvers/bintray_resolver.py
@@ -15,7 +15,7 @@ BINTRAY_API_BASE_URL = 'https://api.bintray.com'
 BINTRAY_DOWNLOAD_BASE_URL = 'https://dl.bintray.com'
 BINTRAY_DOWNLOAD_REALM = 'Bintray'
 BINTRAY_CREDENTIAL_FILE_PATH = '{}/.lightbend/commercial.credentials'.format(os.path.expanduser('~'))
-BINTRAY_PROPERTIES_RE = re.compile('^\s*(\S+)\s*=\s*([\S]+)\s*$')
+BINTRAY_PROPERTIES_RE = re.compile('^\s*(\S+)\s*=\s*((\S|\S+\s+\S+)+)\s*$')
 BINTRAY_LIGHTBEND_ORG = 'lightbend'
 BINTRAY_CONDUCTR_COMMERCIAL_REPO = 'commercial-releases'
 BINTRAY_CONDUCTR_GENERIC_REPO = 'generic'
@@ -168,12 +168,16 @@ def load_bintray_credentials(raise_error=True, disable_instructions=False):
         with open(BINTRAY_CREDENTIAL_FILE_PATH, 'r') as cred_file:
             lines = [line.replace('\n', '') for line in cred_file.readlines()]
             data = dict()
+            realm = BINTRAY_DOWNLOAD_REALM
             for line in lines:
                 match = BINTRAY_PROPERTIES_RE.match(line)
                 if match is not None:
                     try:
                         key, value = match.group(1, 2)
-                        data[key] = value
+                        if key == 'realm':
+                            realm = value
+                        elif realm == BINTRAY_DOWNLOAD_REALM:
+                            data[key] = value
                     except IndexError:
                         pass
 

--- a/conductr_cli/resolvers/test/test_bintray_resolver.py
+++ b/conductr_cli/resolvers/test/test_bintray_resolver.py
@@ -1018,6 +1018,29 @@ class TestLoadBintrayCredentials(TestCase):
         exists_mock.assert_called_with('{}/.lightbend/commercial.credentials'.format(os.path.expanduser('~')))
         open_mock.assert_called_with('{}/.lightbend/commercial.credentials'.format(os.path.expanduser('~')), 'r')
 
+    def test_success_multiple_realms(self):
+        bintray_credential_file = (
+            'realm = Bintray\n'
+            'user = user1\n'
+            'password = sec=ret\n'
+            'realm = Bintray API Realm\n'
+            'user = user2\n'
+            'password = sec=ret2\n'
+        )
+
+        exists_mock = MagicMock(return_value=True)
+        open_mock = MagicMock(return_value=io.StringIO(bintray_credential_file))
+
+        with patch('os.path.exists', exists_mock), \
+                patch('builtins.open', open_mock):
+            realm, username, password = bintray_resolver.load_bintray_credentials()
+            self.assertEqual('Bintray', realm)
+            self.assertEqual('user1', username)
+            self.assertEqual('sec=ret', password)
+
+        exists_mock.assert_called_with('{}/.lightbend/commercial.credentials'.format(os.path.expanduser('~')))
+        open_mock.assert_called_with('{}/.lightbend/commercial.credentials'.format(os.path.expanduser('~')), 'r')
+
     def test_credential_file_not_having_username_password(self):
         bintray_credential_file = strip_margin(
             """|dummy = yes


### PR DESCRIPTION
This PR ensures that the Bintray resolver only uses credentials if realm is omitted or equal to `Bintray`. Values following other realm declarations are omitted.

Fixes #507

### Manual Test

Ensure that the test below fails on `master`, then rerun and ensure it passes with this PR.

```bash
$ rm /home/longshorej/.conductr/cache/bundle/visualizer-2.1.0-cabaae7cf37b1cf99b3861515cd5e77a16fa9638e225fa234929cc1d46dde937.zip
-> 0
$ cat ~/.lightbend/commercial.credentials 
realm = Bintray
host = dl.bintray.com
user = <redacted>
password = <redacted>
realm = Bintray API Realm
host = api.bintray.com
user = myuser
password = mypassword

-> 0
