### PR TITLE
extract control protocol http calls

### DIFF
--- a/conductr_cli/conduct_load.py
+++ b/conductr_cli/conduct_load.py
@@ -15,7 +15,6 @@ import os
 import stat
 import sys
 import time
-import json
 import logging
 import tempfile
 import zipfile
@@ -117,9 +116,8 @@ def load_v1(args):
 
     log.info('Loading bundle to ConductR..')
     multipart = create_multipart(log, files)
-    response = load_bundle(args, multipart)
+    response_json = load_bundle(args, multipart)
 
-    response_json = json.loads(response)
     bundle_id = response_json['bundleId'] if args.long_ids else bundle_utils.short_id(response_json['bundleId'])
 
     if not args.no_wait:
@@ -286,9 +284,8 @@ def load_v2(args):
     log.info('Loading bundle to ConductR..')
     multipart = create_multipart(log, files)
 
-    response = load_bundle(args, multipart)
+    response_json = load_bundle(args, multipart)
 
-    response_json = json.loads(response)
     bundle_id = response_json['bundleId'] if args.long_ids else bundle_utils.short_id(response_json['bundleId'])
 
     if not args.no_wait:

--- a/conductr_cli/conduct_stop.py
+++ b/conductr_cli/conduct_stop.py
@@ -1,5 +1,4 @@
 from conductr_cli import bundle_utils, validation, bundle_scale
-import json
 import logging
 
 from conductr_cli.control_protocol import stop_bundle
@@ -12,9 +11,8 @@ def stop(args):
     """`conduct stop` command"""
 
     log = logging.getLogger(__name__)
-    response = stop_bundle(args)
+    response_json = stop_bundle(args)
 
-    response_json = json.loads(response)
     bundle_id = response_json['bundleId'] if args.long_ids else bundle_utils.short_id(response_json['bundleId'])
 
     log.info('Bundle stop request sent.')

--- a/conductr_cli/conduct_stop.py
+++ b/conductr_cli/conduct_stop.py
@@ -1,8 +1,8 @@
-from conductr_cli import bundle_utils, conduct_request, conduct_url, validation, bundle_scale
-from conductr_cli.conduct_url import conductr_host
+from conductr_cli import bundle_utils, validation, bundle_scale
 import json
 import logging
-from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
+
+from conductr_cli.control_protocol import stop_bundle
 
 
 @validation.handle_connection_error
@@ -12,16 +12,9 @@ def stop(args):
     """`conduct stop` command"""
 
     log = logging.getLogger(__name__)
-    path = 'bundles/{}?scale=0'.format(args.bundle)
-    url = conduct_url.url(path, args)
-    response = conduct_request.put(args.dcos_mode, conductr_host(args), url, auth=args.conductr_auth,
-                                   verify=args.server_verification_file, timeout=DEFAULT_HTTP_TIMEOUT)
-    validation.raise_for_status_inc_3xx(response)
+    response = stop_bundle(args)
 
-    if log.is_verbose_enabled():
-        log.verbose(validation.pretty_json(response.text))
-
-    response_json = json.loads(response.text)
+    response_json = json.loads(response)
     bundle_id = response_json['bundleId'] if args.long_ids else bundle_utils.short_id(response_json['bundleId'])
 
     log.info('Bundle stop request sent.')

--- a/conductr_cli/control_protocol.py
+++ b/conductr_cli/control_protocol.py
@@ -1,0 +1,21 @@
+import logging
+
+from conductr_cli import conduct_url, conduct_request, validation
+from conductr_cli.conduct_url import conductr_host
+
+
+def load_bundle(args, multipart_files):
+    log = logging.getLogger(__name__)
+
+    url = conduct_url.url('bundles', args)
+    response = conduct_request.post(args.dcos_mode, conductr_host(args), url,
+                                    data=multipart_files,
+                                    auth=args.conductr_auth,
+                                    verify=args.server_verification_file,
+                                    headers={'Content-Type': multipart_files.content_type})
+    validation.raise_for_status_inc_3xx(response)
+
+    if log.is_verbose_enabled():
+        log.verbose(validation.pretty_json(response.text))
+
+    return response.text

--- a/conductr_cli/control_protocol.py
+++ b/conductr_cli/control_protocol.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 from conductr_cli import conduct_url, conduct_request, validation
@@ -19,7 +20,7 @@ def load_bundle(args, multipart_files):
     if log.is_verbose_enabled():
         log.verbose(validation.pretty_json(response.text))
 
-    return response.text
+    return json.loads(response.text)
 
 
 def stop_bundle(args):
@@ -33,4 +34,4 @@ def stop_bundle(args):
     if log.is_verbose_enabled():
         log.verbose(validation.pretty_json(response.text))
 
-    return response.text
+    return json.loads(response.text)

--- a/conductr_cli/control_protocol.py
+++ b/conductr_cli/control_protocol.py
@@ -2,6 +2,7 @@ import logging
 
 from conductr_cli import conduct_url, conduct_request, validation
 from conductr_cli.conduct_url import conductr_host
+from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
 
 
 def load_bundle(args, multipart_files):
@@ -13,6 +14,20 @@ def load_bundle(args, multipart_files):
                                     auth=args.conductr_auth,
                                     verify=args.server_verification_file,
                                     headers={'Content-Type': multipart_files.content_type})
+    validation.raise_for_status_inc_3xx(response)
+
+    if log.is_verbose_enabled():
+        log.verbose(validation.pretty_json(response.text))
+
+    return response.text
+
+
+def stop_bundle(args):
+    log = logging.getLogger(__name__)
+    path = 'bundles/{}?scale=0'.format(args.bundle)
+    url = conduct_url.url(path, args)
+    response = conduct_request.put(args.dcos_mode, conductr_host(args), url, auth=args.conductr_auth,
+                                   verify=args.server_verification_file, timeout=DEFAULT_HTTP_TIMEOUT)
     validation.raise_for_status_inc_3xx(response)
 
     if log.is_verbose_enabled():

--- a/conductr_cli/test_control_protocol.py
+++ b/conductr_cli/test_control_protocol.py
@@ -47,7 +47,7 @@ class TestControlProtocol(CliTestCase):
                                           auth=self.conductr_auth, data=file_mock,
                                           verify=self.server_verification_file,
                                           headers={'Content-Type': file_mock.content_type})
-        self.assertEqual('{}', result)
+        self.assertEqual({}, result)
 
     def test_load_bundle_failure(self):
         stdout = MagicMock()
@@ -83,7 +83,7 @@ class TestControlProtocol(CliTestCase):
                                           auth=self.conductr_auth, timeout=5,
                                           verify=self.server_verification_file
                                           )
-        self.assertEqual('{}', result)
+        self.assertEqual({}, result)
 
     def test_stop_bundle_failure(self):
         stdout = MagicMock()

--- a/conductr_cli/test_control_protocol.py
+++ b/conductr_cli/test_control_protocol.py
@@ -1,0 +1,67 @@
+from unittest.mock import patch, MagicMock
+
+from requests import HTTPError
+
+from conductr_cli import logging_setup
+from conductr_cli.control_protocol import load_bundle
+from conductr_cli.test.cli_test_case import CliTestCase
+
+
+class TestControlProtocol(CliTestCase):
+    conductr_auth = ('username', 'password')
+    server_verification_file = MagicMock(name='server_verification_file')
+    args = {
+        'dcos_mode': False,
+        'command': 'conduct',
+        'scheme': 'http',
+        'host': '127.0.0.1',
+        'port': 9005,
+        'base_path': '/',
+        'api_version': '1',
+        'disable_instructions': False,
+        'verbose': False,
+        'no_wait': False,
+        'quiet': False,
+        'cli_parameters': '',
+        'bundle': '45e0c477d3e5ea92aa8d85c0d8f3e25c',
+        'output_path': '/my/fav/path',
+        'conductr_auth': conductr_auth,
+        'server_verification_file': server_verification_file
+    }
+
+    def test_load_bundle_success(self):
+        stdout = MagicMock()
+        stderr = MagicMock()
+        logging_setup.configure_logging(MagicMock(), stdout, stderr)
+
+        args_mock = MagicMock(**self.args)
+        file_mock = MagicMock()
+        bundle_url = 'http://127.0.0.1:9005/bundles'
+        post_mock = self.respond_with(status_code=200, text='{}')
+
+        with patch('conductr_cli.conduct_request.post', post_mock):
+            result = load_bundle(args_mock, file_mock)
+
+        post_mock.assert_called_once_with(False, '127.0.0.1', bundle_url,
+                                          auth=self.conductr_auth, data=file_mock,
+                                          verify=self.server_verification_file,
+                                          headers={'Content-Type': file_mock.content_type})
+        self.assertEqual('{}', result)
+
+    def test_load_bundle_failure(self):
+        stdout = MagicMock()
+        stderr = MagicMock()
+        logging_setup.configure_logging(MagicMock(), stdout, stderr)
+
+        args_mock = MagicMock(**self.args)
+        file_mock = MagicMock()
+        bundle_url = 'http://127.0.0.1:9005/bundles'
+        response_mock = self.respond_with(status_code=401)
+
+        with patch('conductr_cli.conduct_request.post', response_mock):
+            self.assertRaises(HTTPError, lambda: load_bundle(args_mock, file_mock))
+
+        response_mock.assert_called_once_with(False, '127.0.0.1', bundle_url,
+                                              auth=self.conductr_auth, data=file_mock,
+                                              verify=self.server_verification_file,
+                                              headers={'Content-Type': file_mock.content_type})

--- a/conductr_cli/test_control_protocol.py
+++ b/conductr_cli/test_control_protocol.py
@@ -3,13 +3,14 @@ from unittest.mock import patch, MagicMock
 from requests import HTTPError
 
 from conductr_cli import logging_setup
-from conductr_cli.control_protocol import load_bundle
+from conductr_cli.control_protocol import load_bundle, stop_bundle
 from conductr_cli.test.cli_test_case import CliTestCase
 
 
 class TestControlProtocol(CliTestCase):
     conductr_auth = ('username', 'password')
     server_verification_file = MagicMock(name='server_verification_file')
+    bundle_id = '45e0c477d3e5ea92aa8d85c0d8f3e25c'
     args = {
         'dcos_mode': False,
         'command': 'conduct',
@@ -23,7 +24,7 @@ class TestControlProtocol(CliTestCase):
         'no_wait': False,
         'quiet': False,
         'cli_parameters': '',
-        'bundle': '45e0c477d3e5ea92aa8d85c0d8f3e25c',
+        'bundle': bundle_id,
         'output_path': '/my/fav/path',
         'conductr_auth': conductr_auth,
         'server_verification_file': server_verification_file
@@ -65,3 +66,38 @@ class TestControlProtocol(CliTestCase):
                                               auth=self.conductr_auth, data=file_mock,
                                               verify=self.server_verification_file,
                                               headers={'Content-Type': file_mock.content_type})
+
+    def test_stop_bundle_success(self):
+        stdout = MagicMock()
+        stderr = MagicMock()
+        logging_setup.configure_logging(MagicMock(), stdout, stderr)
+
+        args_mock = MagicMock(**self.args)
+        stop_bundle_url = 'http://127.0.0.1:9005/bundles/{}?scale=0'.format(self.bundle_id)
+        post_mock = self.respond_with(status_code=200, text='{}')
+
+        with patch('conductr_cli.conduct_request.put', post_mock):
+            result = stop_bundle(args_mock)
+
+        post_mock.assert_called_once_with(False, '127.0.0.1', stop_bundle_url,
+                                          auth=self.conductr_auth, timeout=5,
+                                          verify=self.server_verification_file
+                                          )
+        self.assertEqual('{}', result)
+
+    def test_stop_bundle_failure(self):
+        stdout = MagicMock()
+        stderr = MagicMock()
+        logging_setup.configure_logging(MagicMock(), stdout, stderr)
+
+        args_mock = MagicMock(**self.args)
+        stop_bundle_url = 'http://127.0.0.1:9005/bundles/{}?scale=0'.format(self.bundle_id)
+        post_mock = self.respond_with(status_code=401)
+
+        with patch('conductr_cli.conduct_request.put', post_mock):
+            self.assertRaises(HTTPError, lambda: stop_bundle(args_mock))
+
+        post_mock.assert_called_once_with(False, '127.0.0.1', stop_bundle_url,
+                                          auth=self.conductr_auth, timeout=5,
+                                          verify=self.server_verification_file
+                                          )


### PR DESCRIPTION
This PR extracts the load control protocol call. This is the first step in centralising the control protocol calls to enable re-use across different CLI functions.
This is also needed to facilitate re-use with upcoming restore functionality.
Relates to #519 