### PR TITLE
rename the configuration zip to bundle_name-configurationdigest.

### DIFF
--- a/conductr_cli/bundle_core_info.py
+++ b/conductr_cli/bundle_core_info.py
@@ -7,8 +7,8 @@ class BundleCoreInfo(object):
         self.bundle_name = bundle_name
         self.bundle_digest = bundle_digest
         self.configuration_digest = configuration_digest
-        self.bundle_name_with_digest = str.format(
-            '{0}-{1}', bundle_name, bundle_digest)
+        self.bundle_name_with_digest = '{0}-{1}'.format(bundle_name, bundle_digest)
+        self.bundle_name_with_configuration_digest = '{0}-{1}'.format(bundle_name, configuration_digest)
 
     @classmethod
     def from_bundles(cls, bundles_json):

--- a/conductr_cli/conductr_backup.py
+++ b/conductr_cli/conductr_backup.py
@@ -100,8 +100,7 @@ def backup_bundle(args, backup_path, bundle_core_info: BundleCoreInfo):
 
     # the config is also present
     if len(bundle_files_response) == 2:
-        bundle_conf_validated = backup_bundle_conf(backup_path, bundle_files_response[1],
-                                                   bundle_core_info.configuration_digest)
+        bundle_conf_validated = backup_bundle_conf(backup_path, bundle_files_response[1], bundle_core_info)
 
     validation_failed = bundle_validated is False or bundle_conf_validated is False
     if validation_failed:
@@ -142,10 +141,10 @@ def backup_bundle_file(backup_path, bundle_file, bundle_info):
     return validate_artifact(bundle_file_path, bundle_info.bundle_digest)
 
 
-def backup_bundle_conf(backup_path, bundle_conf, configuration_digest):
-    bundle_conf_path = '{}.zip'.format(os.path.join(backup_path, configuration_digest))
+def backup_bundle_conf(backup_path, bundle_conf, bundle_info):
+    bundle_conf_path = '{}.zip'.format(os.path.join(backup_path, bundle_info.bundle_name_with_configuration_digest))
     file_write_bytes(bundle_conf_path, bundle_conf)
-    bundle_conf_validated = validate_artifact(bundle_conf_path, configuration_digest)
+    bundle_conf_validated = validate_artifact(bundle_conf_path, bundle_info.configuration_digest)
     return bundle_conf_validated
 
 

--- a/conductr_cli/test/test_conductr_backup.py
+++ b/conductr_cli/test/test_conductr_backup.py
@@ -234,16 +234,16 @@ class TestBackup(CliTestCase):
         mock_bundle_conf = MagicMock()
 
         backup_path = 'bkp_path'
-        digest = 'digest'
+        mock_bundle_info = BundleCoreInfo('b_id', 'b_name', '12345', '789')
 
         open_mock = mock.mock_open()
         with patch('builtins.open', open_mock):
-            validated = backup_bundle_conf(backup_path, mock_bundle_conf, digest)
+            validated = backup_bundle_conf(backup_path, mock_bundle_conf, mock_bundle_info)
 
-        bundle_conf_path = '{}.zip'.format(os.path.join(backup_path, digest))
+        bundle_conf_path = '{}.zip'.format(os.path.join(backup_path, 'b_name-789'))
         self.assertTrue(validated)
 
-        validate_mock.assert_called_once_with(bundle_conf_path, digest)
+        validate_mock.assert_called_once_with(bundle_conf_path, '789')
 
     @patch('tempfile.mkdtemp')
     @patch('conductr_cli.conductr_backup.remove_backup_directory')
@@ -323,7 +323,7 @@ class TestBackup(CliTestCase):
 
         bundle_files_mock.assert_called_once_with(mock_args, bundle_info.bundle_id)
         backup_bundle_mock.assert_called_once_with(backup_path, 1, bundle_info)
-        backup_bundle_conf_mock.assert_called_once_with(backup_path, 2, bundle_info.configuration_digest)
+        backup_bundle_conf_mock.assert_called_once_with(backup_path, 2, bundle_info)
 
     @patch('conductr_cli.conductr_backup.bundle_files')
     @patch('conductr_cli.conductr_backup.backup_bundle_file')
@@ -343,7 +343,7 @@ class TestBackup(CliTestCase):
 
         bundle_files_mock.assert_called_once_with(mock_args, bundle_info.bundle_id)
         backup_bundle_file_mock.assert_called_once_with(backup_path, 1, bundle_info)
-        backup_bundle_conf_mock.assert_called_once_with(backup_path, 2, bundle_info.configuration_digest)
+        backup_bundle_conf_mock.assert_called_once_with(backup_path, 2, bundle_info)
 
     @patch('conductr_cli.conductr_backup.bundle_files')
     @patch('conductr_cli.conductr_backup.backup_bundle_file')
@@ -365,7 +365,7 @@ class TestBackup(CliTestCase):
 
         bundle_files_mock.assert_called_once_with(mock_args, bundle_info.bundle_id)
         backup_bundle_file_mock.assert_called_once_with(backup_path, 1, bundle_info)
-        backup_bundle_conf_mock.assert_called_once_with(backup_path, 2, bundle_info.configuration_digest)
+        backup_bundle_conf_mock.assert_called_once_with(backup_path, 2, bundle_info)
 
     @patch('conductr_cli.conductr_backup.bundle_files')
     @patch('conductr_cli.conductr_backup.backup_bundle_file')


### PR DESCRIPTION
this fixes a bug where the configuration bundle needs to have the digest name as part of the file name.