### PR TITLE
Add support for restoring a backup

### DIFF
--- a/conductr_cli/conduct_main.py
+++ b/conductr_cli/conduct_main.py
@@ -3,7 +3,8 @@ import argparse
 from conductr_cli import \
     bndl_main, conduct_agents, conduct_deploy, conduct_info, conduct_load, conduct_members, conduct_run, \
     conduct_service_names, conduct_stop, conduct_unload, version, conduct_logs, conduct_events, conduct_acls, \
-    conduct_dcos, conduct_load_license, host, logging_setup, conduct_url, custom_settings, conductr_backup
+    conduct_dcos, conduct_load_license, host, logging_setup, conduct_url, custom_settings, conductr_backup, \
+    conductr_restore
 from conductr_cli.constants import \
     DEFAULT_SCHEME, DEFAULT_PORT, DEFAULT_BASE_PATH, \
     DEFAULT_API_VERSION, DEFAULT_DCOS_SERVICE, DEFAULT_CLI_SETTINGS_DIR, \
@@ -494,6 +495,20 @@ def build_parser(dcos_mode):
 
     add_default_arguments(backup_parser, dcos_mode)
     backup_parser.set_defaults(func=conductr_backup.backup)
+
+    restore_parser = subparsers.add_parser('restore',
+                                           help='Restore a cluster from backup.',
+                                           formatter_class=argparse.RawTextHelpFormatter)
+
+    restore_parser.add_argument('backup',
+                                default=None if sys.stdin.isatty() else '-',
+                                nargs=None if sys.stdin.isatty() else '?',
+                                action='store',
+                                help='The path to the backup.'
+                                     'Specify "-" when using stdin')
+
+    add_default_arguments(restore_parser, dcos_mode)
+    restore_parser.set_defaults(func=conductr_restore.restore)
     return parser
 
 
@@ -586,8 +601,7 @@ def run(_args=[], configure_logging=True):
                 default_http_port = 80 if dcos_url.scheme == 'http' else 443
                 args.port = dcos_url.port if dcos_url.port else default_http_port
                 dcos_url_path = dcos_url.path if dcos_url.path else '/'
-                dcos_service_name = conduct_dcos.service_name(args)
-                args.base_path = dcos_url_path + 'service/{}/'.format(dcos_service_name)
+                args.base_path = dcos_url_path + 'service/{}/'.format(DEFAULT_DCOS_SERVICE)
             else:
                 args.command = 'conduct'
 

--- a/conductr_cli/conductr_restore.py
+++ b/conductr_cli/conductr_restore.py
@@ -1,0 +1,134 @@
+import json
+import os
+import shutil
+import tempfile
+
+import io
+import copy
+import logging
+
+import sys
+
+from io import BytesIO
+
+from conductr_cli import control_protocol, bundle_utils, validation, conduct_load, bundle_scale
+from conductr_cli.bundle_core_info import BundleCoreInfo
+from conductr_cli.exceptions import ConductRestoreError
+
+
+@validation.handle_connection_error
+@validation.handle_http_error
+@validation.handle_wait_timeout_error
+@validation.handle_conductr_restore_error
+def restore(args):
+    log = logging.getLogger(__name__)
+
+    isatty = os.isatty(sys.stdin.fileno())
+    if args.backup is '-' and isatty:
+        raise ConductRestoreError('Specify a backup file. Cannot read from stdin(-)')
+
+    destination_bundles = control_protocol.get_bundles(args)
+    destination_bundles_info = BundleCoreInfo.from_bundles(destination_bundles)
+
+    restore_directory = unpack_backup(args.backup)
+    bundle_json_file = open(os.path.join(restore_directory, 'bundles.json'), 'r')
+    bundles_json = bundle_json_file.read()
+    bundle_json_file.close()
+
+    bundles_info = sorted(BundleCoreInfo.from_bundles(json.loads(bundles_json)), key=lambda b: b.start_time)
+
+    restore_errors = []
+    for bundle_info in bundles_info:
+        new_bundle_id = None
+        log.info('Restoring bundle : {}.'.format(bundle_info.bundle_name))
+
+        try:
+            new_bundle_id = process_bundle(args, restore_directory, bundle_info)
+            log.info('Loaded {} with bundleId : {}'.format(bundle_info.bundle_name, new_bundle_id))
+        except:
+            restore_errors.append('{} could not be loaded.'.format(bundle_info.bundle_name))
+
+        try:
+            if new_bundle_id is not None:
+                affinity = compatible_bundle(destination_bundles_info, bundle_info.bundle_name,
+                                             bundle_info.compatibility_Version)
+                if affinity == new_bundle_id:
+                    affinity = None
+
+                scale_bundle(args, new_bundle_id, bundle_info.scale, affinity)
+                log.info('Scaled {} to : {}.'.format(new_bundle_id, bundle_info.scale))
+        except:
+            restore_errors.append('{} could not be scaled.'.format(bundle_info.bundle_name))
+
+    for error in restore_errors:
+        log.error(error)
+
+    return len(restore_errors) == 0
+
+
+def unpack_backup(backup):
+    restore_directory = tempfile.mkdtemp()
+    isatty = os.isatty(sys.stdin.fileno())
+    has_stdin = not isatty
+
+    if backup is '-' and has_stdin:
+        buffer = sys.stdin.buffer.read()
+        shutil.unpack_archive(BytesIO(buffer), restore_directory, format='zip')
+    else:
+        shutil.unpack_archive(backup, restore_directory, format='zip')
+    return restore_directory
+
+
+def process_bundle(args, restore_directory, bundle_info: BundleCoreInfo):
+    log = logging.getLogger(__name__)
+
+    files = []
+
+    bundle = '{}.zip'.format(bundle_info.bundle_name_with_digest)
+    bundle_path = os.path.join(restore_directory, bundle)
+
+    bundle_conf = bundle_utils.conf(bundle_path)
+    files.append(('bundleConf', ('bundle.conf', io.StringIO(bundle_conf))))
+
+    bundle_archive = open(bundle_path, 'rb')
+
+    if len(bundle_info.configuration_digest) != 0:
+        configuration = '{}.zip'.format(bundle_info.bundle_name_with_configuration_digest)
+        bundle_configuration_path = os.path.join(restore_directory, configuration)
+
+        bundle_conf_overlay = bundle_utils.conf(bundle_configuration_path)
+        files.append(('bundleConfOverlay', ('bundle.conf', io.StringIO(bundle_conf_overlay))))
+
+        files.append(('bundle', (bundle, bundle_archive)))
+
+        configuration_archive = open(bundle_configuration_path, 'rb')
+        files.append(('configuration', (configuration, configuration_archive)))
+    else:
+        files.append(('bundle', (bundle, bundle_archive)))
+
+    multipart = conduct_load.create_multipart(log, files)
+    response = control_protocol.load_bundle(args, multipart)
+
+    return response['bundleId']
+
+
+def scale_bundle(args, bundle_id, scale, affinity):
+    modified_args = copy.deepcopy(args)
+    modified_args.wait_timeout = 60
+    modified_args.bundle = bundle_id
+    modified_args.lines = 10
+    modified_args.utc = False
+    modified_args.follow = False
+    modified_args.affinity = affinity
+    modified_args.scale = scale
+
+    response_json = control_protocol.run_bundle(modified_args)
+
+    bundle_scale.wait_for_scale(response_json['bundleId'], scale, wait_for_is_active=True, args=modified_args)
+
+
+def compatible_bundle(bundle_infos, bundle_name, compatibility_version):
+    for bundle_info in bundle_infos:
+        if bundle_info.bundle_name == bundle_name and bundle_info.compatibility_Version == compatibility_version:
+            return bundle_info.bundle_id
+    return None

--- a/conductr_cli/exceptions.py
+++ b/conductr_cli/exceptions.py
@@ -275,3 +275,11 @@ class ConductBackupError(Exception):
 
     def __str__(self):
         return repr('{} {}'.format(self.message, self.cause))
+
+
+class ConductRestoreError(Exception):
+    def __init__(self, message):
+        self.message = message
+
+    def __str__(self):
+        return repr(self.message)

--- a/conductr_cli/test/data/bundles/bundle_json.json
+++ b/conductr_cli/test/data/bundles/bundle_json.json
@@ -232,10 +232,6 @@
         }
       }
     },
-    "bundleScale": {
-      "scale": 1,
-      "nrOfReschedules": 0
-    },
     "bundleExecutions": [
       {
         "host": "192.168.10.1",

--- a/conductr_cli/test/test_bundle_core_info.py
+++ b/conductr_cli/test/test_bundle_core_info.py
@@ -1,5 +1,7 @@
 import json
 
+import datetime
+
 from conductr_cli.bundle_core_info import BundleCoreInfo
 from conductr_cli.test.cli_test_case import CliTestCase, file_contents
 
@@ -9,6 +11,7 @@ class TestBundleCore(CliTestCase):
         bundles_json = file_contents('data/bundles/bundle_json.json')
         result = BundleCoreInfo.from_bundles(json.loads(bundles_json))
         self.assertEqual(6, len(result))
+        self.assertEqual('1', result[0].compatibility_Version)
 
     def test_bundle_core_filter(self):
         bundles_json = file_contents('data/bundles/bundle_json.json')
@@ -18,11 +21,15 @@ class TestBundleCore(CliTestCase):
         bundle_info = BundleCoreInfo.filter_by_bundle_id(bundle_infos, bundle_id)
         self.assertIsNotNone(bundle_info)
         self.assertEqual(bundle_id, bundle_info.bundle_id)
+        self.assertEqual(1, bundle_info.scale)
+        self.assertEqual('2', bundle_info.compatibility_Version)
 
         bundle_name = 'visualizer'
         bundle_info = BundleCoreInfo.filter_by_bundle_id(bundle_infos, bundle_name)
         self.assertIsNotNone(bundle_info)
         self.assertEqual(bundle_id, bundle_info.bundle_id)
+        self.assertEqual('2', bundle_info.compatibility_Version)
+        self.assertEqual(datetime.datetime(2017, 6, 29, 18, 39, 56), bundle_info.start_time)
 
         bad_bundle_id = 'ahoy'
         bad_bundle_info = BundleCoreInfo.filter_by_bundle_id(bundle_infos, bad_bundle_id)

--- a/conductr_cli/test/test_conduct_main.py
+++ b/conductr_cli/test/test_conduct_main.py
@@ -384,3 +384,29 @@ class TestConduct(TestCase):
         self.assertEqual(args.local_connection, True)
         self.assertEqual(args.output_path, '/my/fav/path')
         self.assertEqual(args.bundle, None)
+
+    def test_restore_parser_with_backup(self):
+        args = self.parser.parse_args('restore something.zip --host someotherhost'.split())
+
+        self.assertEqual(args.func.__name__, 'restore')
+        self.assertEqual(args.host, 'someotherhost')
+        self.assertEqual(args.port, 9005)
+        self.assertEqual(args.api_version, '2')
+        self.assertEqual(args.cli_settings_dir, '{}/.conductr'.format(os.path.expanduser('~')))
+        self.assertEqual(args.custom_settings_file, '{}/.conductr/settings.conf'.format(os.path.expanduser('~')))
+        self.assertEqual(args.custom_plugins_dir, '{}/.conductr/plugins'.format(os.path.expanduser('~')))
+        self.assertEqual(args.local_connection, True)
+        self.assertEqual(args.backup, 'something.zip')
+
+    def test_restore_parser_with_backup_from_stdin(self):
+        args = self.parser.parse_args('restore - --host someotherhost'.split())
+
+        self.assertEqual(args.func.__name__, 'restore')
+        self.assertEqual(args.host, 'someotherhost')
+        self.assertEqual(args.port, 9005)
+        self.assertEqual(args.api_version, '2')
+        self.assertEqual(args.cli_settings_dir, '{}/.conductr'.format(os.path.expanduser('~')))
+        self.assertEqual(args.custom_settings_file, '{}/.conductr/settings.conf'.format(os.path.expanduser('~')))
+        self.assertEqual(args.custom_plugins_dir, '{}/.conductr/plugins'.format(os.path.expanduser('~')))
+        self.assertEqual(args.local_connection, True)
+        self.assertEqual(args.backup, '-')

--- a/conductr_cli/test/test_conductr_backup.py
+++ b/conductr_cli/test/test_conductr_backup.py
@@ -384,11 +384,7 @@ class TestBackup(CliTestCase):
         with patch('builtins.open', open_mock):
             backup(mock_args)
 
-        bundle_info = BundleCoreInfo(bundle_id=bundle_id,
-                                     bundle_name='reactive-maps-backend-region',
-                                     bundle_digest='6273d7a5b059d0e978c6d69ee1a5d7b4f0185008d7e57614a4a20c253a18fe28',
-                                     configuration_digest='d54620c7bc91897bbb2f25faaac25f46b11e029ed327f91c7a10931ec45bd792')
-
+        bundle_info = BundleCoreInfo.from_bundles(self.bundle_json)[0]
         backup_bundle_json_mock.assert_called_once_with(temp_file, ANY)
         backup_bundle_mock.assert_called_once_with(mock_args, temp_file, bundle_info)
         members_mock.assert_called_once_with(mock_args, temp_file)

--- a/conductr_cli/test/test_conductr_restore.py
+++ b/conductr_cli/test/test_conductr_restore.py
@@ -1,0 +1,206 @@
+import json
+import os
+from unittest import mock
+from unittest.mock import patch, MagicMock, call
+
+from conductr_cli import logging_setup
+from conductr_cli.bundle_core_info import BundleCoreInfo
+from conductr_cli.conductr_restore import unpack_backup, process_bundle, compatible_bundle, scale_bundle, restore
+from conductr_cli.test.cli_test_case import file_contents, CliTestCase, as_error, strip_margin
+
+
+class TestConductrRestore(CliTestCase):
+    conductr_auth = ('username', 'password')
+    server_verification_file = MagicMock(name='server_verification_file')
+
+    args = {
+        'dcos_mode': False,
+        'command': 'conduct',
+        'scheme': 'http',
+        'host': '127.0.0.1',
+        'port': 9005,
+        'base_path': '/',
+        'api_version': '1',
+        'disable_instructions': False,
+        'verbose': False,
+        'no_wait': False,
+        'quiet': False,
+        'cli_parameters': '',
+        'backup': 'bkp.zip',
+        'output_path': '/my/fav/path',
+        'conductr_auth': conductr_auth,
+        'server_verification_file': server_verification_file
+    }
+
+    @patch('tempfile.mkdtemp')
+    @patch('shutil.unpack_archive')
+    def test_unpack_backup(self, archive_mock, tmp_mock):
+        backup = MagicMock()
+        tmp_mock.return_value = "something"
+        result = unpack_backup(backup)
+
+        archive_mock.assert_called_once_with(backup, tmp_mock.return_value, format='zip')
+        self.assertEqual(tmp_mock.return_value, result)
+
+    @patch('conductr_cli.control_protocol.load_bundle')
+    @patch('conductr_cli.conduct_load.create_multipart')
+    @patch('conductr_cli.bundle_utils.conf')
+    def test_process_bundle(self, mock_conf, mock_multipart, mock_load_bundle):
+        mock_args = MagicMock()
+        mock_conf.return_value = 'hello'
+        mock_multipart.return_value = MagicMock()
+        bundle_info = BundleCoreInfo('1', 'b_name', '1234', '5678')
+        open_mock = mock.mock_open()
+
+        with patch('builtins.open', open_mock):
+            process_bundle(mock_args, 'yolo', bundle_info)
+
+        calls = [call(os.path.join('yolo', 'b_name-1234.zip'), 'rb'),
+                 call(os.path.join('yolo', 'b_name-5678.zip'), 'rb')]
+        open_mock.assert_has_calls(calls)
+
+        conf_calls = [call(os.path.join('yolo', 'b_name-1234.zip')),
+                      call(os.path.join('yolo', 'b_name-5678.zip'))]
+        mock_conf.assert_has_calls(conf_calls)
+        mock_load_bundle.assert_called_once_with(mock_args, mock_multipart.return_value)
+
+    @patch('conductr_cli.control_protocol.load_bundle')
+    @patch('conductr_cli.conduct_load.create_multipart')
+    @patch('conductr_cli.bundle_utils.conf')
+    def test_process_bundle_with_no_configuration(self, mock_conf, mock_multipart, mock_load_bundle):
+        mock_args = MagicMock()
+        mock_conf.return_value = 'hello'
+        mock_multipart.return_value = MagicMock()
+        bundle_info = BundleCoreInfo('1', 'b_name', '1234', '')
+        open_mock = mock.mock_open()
+
+        with patch('builtins.open', open_mock):
+            process_bundle(mock_args, 'yolo', bundle_info)
+
+        open_mock.assert_called_once_with(os.path.join('yolo', 'b_name-1234.zip'), 'rb')
+        mock_conf.assert_called_once_with(os.path.join('yolo', 'b_name-1234.zip'))
+
+        mock_load_bundle.assert_called_once_with(mock_args, mock_multipart.return_value)
+
+    def test_should_find_compatible_bundles(self):
+        b1 = BundleCoreInfo('1', 'b1', 'abcd', 'efgh', 2, compatibility_version=1)
+        b2 = BundleCoreInfo('2', 'b2', 'qwer', 'ty', 2, compatibility_version=1)
+        b3 = BundleCoreInfo('3', 'b3', 'ghjk', 'polk', 3, compatibility_version=3)
+        b4 = BundleCoreInfo('4', 'b3', 'yolo', 'why', 3, compatibility_version=4)
+
+        matched = compatible_bundle([b1, b2, b3, b4], 'b3', 3)
+        self.assertEqual('3', matched)
+
+        no_match = compatible_bundle([b1, b2, b3, b4], 'b3', 2)
+        self.assertEqual(None, no_match)
+
+        not_matched = compatible_bundle([b1, b2, b3, b4], 'b5', 3)
+        self.assertEqual(None, not_matched)
+
+    @patch('copy.deepcopy')
+    @patch('conductr_cli.bundle_scale.wait_for_scale')
+    @patch('conductr_cli.control_protocol.run_bundle')
+    def test_should_call_run_with_modified_args(self, mock_run_bundle,
+                                                scale_mock, mock_copy):
+        mock_args = MagicMock(**self.args)
+        mock_run_bundle.return_value = json.loads('{"bundleId":"abcd"}')
+        mock_copy.return_value = MagicMock()
+        scale_bundle(mock_args, 'abcd', 3, 'efgh')
+
+        mock_run_bundle.assert_called_once_with(mock_copy.return_value)
+        scale_mock.assert_called_once_with('abcd', 3, wait_for_is_active=True, args=mock_copy.return_value)
+
+    @patch('conductr_cli.control_protocol.get_bundles')
+    @patch('conductr_cli.conductr_restore.unpack_backup')
+    def test_restore_should_log_load_errors(self, mock_unpack, mock_bundle):
+        mock_args = MagicMock(**self.args)
+        stdout = MagicMock()
+        stderr = MagicMock()
+
+        mock_unpack.return_value = 'my/path'
+        mock_bundle.return_value = json.loads(file_contents('data/bundles/bundle_json_modified.json'))
+
+        logging_setup.configure_logging(mock_args, stdout, stderr)
+
+        open_mock = mock.mock_open(read_data=file_contents('data/bundles/bundle_json.json'))
+
+        with patch('builtins.open', open_mock):
+            restore(mock_args)
+
+        mock_unpack.assert_called_once_with('bkp.zip')
+        mock_bundle.assert_called_once_with(mock_args)
+
+        self.assertEqual(
+            strip_margin("""|Restoring bundle : continuous-delivery.
+                            |Restoring bundle : eslite.
+                            |Restoring bundle : visualizer.
+                            |Restoring bundle : reactive-maps-backend-region.
+                            |Restoring bundle : reactive-maps-backend-summary.
+                            |Restoring bundle : reactive-maps-frontend.
+                            |"""),
+            self.output(stdout))
+
+        self.assertEqual(
+            as_error(strip_margin("""|Error: continuous-delivery could not be loaded.
+                                     |Error: eslite could not be loaded.
+                                     |Error: visualizer could not be loaded.
+                                     |Error: reactive-maps-backend-region could not be loaded.
+                                     |Error: reactive-maps-backend-summary could not be loaded.
+                                     |Error: reactive-maps-frontend could not be loaded.
+                                     |""")),
+            self.output(stderr))
+
+    @patch('conductr_cli.conductr_restore.scale_bundle')
+    @patch('conductr_cli.conductr_restore.compatible_bundle')
+    @patch('conductr_cli.conductr_restore.process_bundle')
+    @patch('conductr_cli.control_protocol.get_bundles')
+    @patch('conductr_cli.conductr_restore.unpack_backup')
+    def test_restore_should_scale_loaded_bundles(self, mock_unpack,
+                                                 mock_bundle, mock_process_bundle,
+                                                 mock_compatible, mock_scale_bundle):
+        mock_args = MagicMock(**self.args)
+
+        mock_unpack.return_value = 'my/path'
+        mock_process_bundle.return_value = '1234'
+        mock_compatible.return_value = 'yolo'
+
+        bundles = file_contents('data/bundles/bundle_json.json')
+        mock_bundle.return_value = json.loads(file_contents('data/bundles/bundle_json_modified.json'))
+        bundles_info = sorted(BundleCoreInfo.from_bundles(json.loads(bundles)),
+                              key=lambda b: b.start_time)
+
+        open_mock = mock.mock_open(read_data=bundles)
+
+        with patch('builtins.open', open_mock):
+            restore(mock_args)
+
+        mock_unpack.assert_called_once_with('bkp.zip')
+        mock_bundle.assert_called_once_with(mock_args)
+
+        calls = [call(mock_args, 'my/path', bundles_info[0]),
+                 call(mock_args, 'my/path', bundles_info[1]),
+                 call(mock_args, 'my/path', bundles_info[2]),
+                 call(mock_args, 'my/path', bundles_info[3]),
+                 call(mock_args, 'my/path', bundles_info[4]),
+                 call(mock_args, 'my/path', bundles_info[5])]
+
+        mock_process_bundle.assert_has_calls(calls)
+
+        dest_bundles_info = BundleCoreInfo.from_bundles(mock_bundle.return_value)
+        compat_calls = [call(dest_bundles_info, 'continuous-delivery', '3'),
+                        call(dest_bundles_info, 'eslite', '1'),
+                        call(dest_bundles_info, 'visualizer', '2'),
+                        call(dest_bundles_info, 'reactive-maps-backend-region', '1'),
+                        call(dest_bundles_info, 'reactive-maps-backend-summary', '1'),
+                        call(dest_bundles_info, 'reactive-maps-frontend', '1')]
+
+        mock_compatible.assert_has_calls(compat_calls)
+
+        scale_calls = [call(mock_args, '1234', 1, 'yolo'),
+                       call(mock_args, '1234', 1, 'yolo'),
+                       call(mock_args, '1234', 1, 'yolo'),
+                       call(mock_args, '1234', 1, 'yolo'),
+                       call(mock_args, '1234', 0, 'yolo'),
+                       call(mock_args, '1234', 1, 'yolo')]
+
+        mock_scale_bundle.assert_has_calls(scale_calls)

--- a/conductr_cli/test_control_protocol.py
+++ b/conductr_cli/test_control_protocol.py
@@ -4,8 +4,7 @@ from requests import HTTPError
 
 from conductr_cli import logging_setup
 from conductr_cli.control_protocol import load_bundle, stop_bundle, get_members, get_agents, \
-    run_bundle, get_bundles, unload_bundle, get_bundle_events
-from conductr_cli.http import DEFAULT_HTTP_TIMEOUT
+    run_bundle, get_bundles
 from conductr_cli.test.cli_test_case import CliTestCase
 
 
@@ -316,65 +315,3 @@ class TestControlProtocol(CliTestCase):
                                                 auth=self.conductr_auth,
                                                 verify=self.server_verification_file
                                                 )
-
-    def test_unload_bundle_success(self):
-        stdout = MagicMock()
-        stderr = MagicMock()
-        logging_setup.configure_logging(MagicMock(), stdout, stderr)
-
-        args_mock = MagicMock(**self.args)
-        agent_url = 'http://127.0.0.1:9005/bundles/{}'.format(self.bundle_id)
-        unload_bundle_mock = self.respond_with(status_code=200, text='{}')
-
-        with patch('conductr_cli.conduct_request.delete', unload_bundle_mock):
-            unload_bundle(args_mock)
-
-        unload_bundle_mock.assert_called_once_with(False, '127.0.0.1', agent_url,
-                                                   timeout=DEFAULT_HTTP_TIMEOUT,
-                                                   auth=self.conductr_auth,
-                                                   verify=self.server_verification_file
-                                                   )
-
-    def test_unload_bundle_failure(self):
-        stdout = MagicMock()
-        stderr = MagicMock()
-        logging_setup.configure_logging(MagicMock(), stdout, stderr)
-
-        args_mock = MagicMock(**self.args)
-        agent_url = 'http://127.0.0.1:9005/bundles/{}'.format(self.bundle_id)
-        unload_bundle_mock = self.respond_with(status_code=500, text='{}')
-
-        with patch('conductr_cli.conduct_request.delete', unload_bundle_mock):
-            self.assertRaises(HTTPError, unload_bundle, args_mock)
-
-        unload_bundle_mock.assert_called_once_with(False, '127.0.0.1', agent_url,
-                                                   timeout=DEFAULT_HTTP_TIMEOUT,
-                                                   auth=self.conductr_auth,
-                                                   verify=self.server_verification_file
-                                                   )
-
-    def test_get_bundle_events_success(self):
-        args_mock = MagicMock(**self.args)
-        mock_events_response = self.respond_with(200, '[]')
-
-        count = 3
-        request_url = 'http://127.0.0.1:9005/bundles/{}/events?count={}'.format(self.bundle_id, count)
-
-        with patch('conductr_cli.conduct_request.get', mock_events_response):
-            get_bundle_events(args_mock, count)
-
-        mock_events_response.assert_called_once_with(False, '127.0.0.1', request_url, auth=self.conductr_auth,
-                                                     timeout=5, verify=self.server_verification_file)
-
-    def test_get_bundle_events_failure(self):
-        args_mock = MagicMock(**self.args)
-        mock_events_response = self.respond_with(500, '[]')
-
-        count = 3
-        request_url = 'http://127.0.0.1:9005/bundles/{}/events?count={}'.format(self.bundle_id, count)
-
-        with patch('conductr_cli.conduct_request.get', mock_events_response):
-            self.assertRaises(HTTPError, lambda: get_bundle_events(args_mock, count))
-
-            mock_events_response.assert_called_once_with(False, '127.0.0.1', request_url, auth=self.conductr_auth,
-                                                         timeout=5, verify=self.server_verification_file)

--- a/conductr_cli/validation.py
+++ b/conductr_cli/validation.py
@@ -675,3 +675,21 @@ def handle_conductr_backup_error(func):
     handler.__name__ = func.__name__
 
     return handler
+
+
+def handle_conductr_restore_error(func):
+    def handler(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except ConductBackupError as err:
+            log = get_logger_for_func(func)
+            log.error('ConductR Restore could not be completed : {}'.format(err.message))
+            if err.cause:
+                log.error('Cause : '.format(err.cause))
+            return False
+
+    # Do not change the wrapped function name,
+    # so argparse configuration can be tested.
+    handler.__name__ = func.__name__
+
+    return handler


### PR DESCRIPTION
* Loads the bundles and then tries to run them.
* Makes the best effort by restoring the bundles in the order in which they were loaded in the source cluster.
* Writes out simple error messages if load or run fails.