### PR TITLE
Remove base64 encoding of Bearer token for load-license OAuth requests

### DIFF
--- a/conductr_cli/license.py
+++ b/conductr_cli/license.py
@@ -3,7 +3,6 @@ from conductr_cli.conduct_url import conductr_host
 from conductr_cli.exceptions import LicenseDownloadError
 from dcos.errors import DCOSHTTPException
 import arrow
-import base64
 import datetime
 import json
 import logging
@@ -33,10 +32,7 @@ def download_license(args, save_to, use_cached_auth_token):
     if not auth_token:
         auth_token = license_auth.prompt_for_auth_token()
 
-    auth_token_b64_bytes = base64.b64encode(bytes(auth_token, 'UTF-8'))
-    auth_token_b64 = auth_token_b64_bytes.decode('UTF-8')
-
-    auth_header = {'Authorization': 'Bearer {}'.format(auth_token_b64)}
+    auth_header = {'Authorization': 'Bearer {}'.format(auth_token)}
     response = requests.get(args.license_download_url,
                             headers=auth_header,
                             verify=args.server_verification_file)

--- a/conductr_cli/test/test_license.py
+++ b/conductr_cli/test/test_license.py
@@ -14,7 +14,6 @@ import tempfile
 
 class TestDownloadLicense(CliTestCase):
     cached_token = 'test-token'
-    cached_token_b64 = 'dGVzdC10b2tlbg=='
     license_text = 'test-license-text'
     license_download_url = 'http://test.com/download'
     server_verification_file = 'test-server_verification_file'
@@ -48,7 +47,7 @@ class TestDownloadLicense(CliTestCase):
         mock_get_cached_auth_token.assert_called_once_with()
         mock_prompt_for_auth_token.assert_not_called()
         mock_get.assert_called_once_with(self.license_download_url,
-                                         headers={'Authorization': 'Bearer {}'.format(self.cached_token_b64)},
+                                         headers={'Authorization': 'Bearer {}'.format(self.cached_token)},
                                          verify=self.server_verification_file)
         mock_save_auth_token.assert_called_once_with(self.cached_token)
         mock_save_license_data.assert_called_once_with(self.license_text, self.license_file)
@@ -58,7 +57,6 @@ class TestDownloadLicense(CliTestCase):
         mock_get_cached_auth_token = MagicMock(return_value=None)
 
         prompted_token = 'prompted-token'
-        prompted_token_b64 = 'cHJvbXB0ZWQtdG9rZW4='
         mock_prompt_for_auth_token = MagicMock(return_value=prompted_token)
 
         mock_get = self.respond_with(200, self.license_text)
@@ -78,7 +76,7 @@ class TestDownloadLicense(CliTestCase):
         mock_get_cached_auth_token.assert_called_once_with()
         mock_prompt_for_auth_token.assert_called_once_with()
         mock_get.assert_called_once_with(self.license_download_url,
-                                         headers={'Authorization': 'Bearer {}'.format(prompted_token_b64)},
+                                         headers={'Authorization': 'Bearer {}'.format(prompted_token)},
                                          verify=self.server_verification_file)
         mock_save_auth_token.assert_called_once_with(prompted_token)
         mock_save_license_data.assert_called_once_with(self.license_text, self.license_file)
@@ -104,7 +102,7 @@ class TestDownloadLicense(CliTestCase):
         mock_get_cached_auth_token.assert_called_once_with()
         mock_prompt_for_auth_token.assert_not_called()
         mock_get.assert_called_once_with(self.license_download_url,
-                                         headers={'Authorization': 'Bearer {}'.format(self.cached_token_b64)},
+                                         headers={'Authorization': 'Bearer {}'.format(self.cached_token)},
                                          verify=self.server_verification_file)
         mock_save_auth_token.assert_not_called()
         mock_save_license_data.assert_not_called()
@@ -130,7 +128,7 @@ class TestDownloadLicense(CliTestCase):
         mock_get_cached_auth_token.assert_called_once_with()
         mock_prompt_for_auth_token.assert_not_called()
         mock_get.assert_called_once_with(self.license_download_url,
-                                         headers={'Authorization': 'Bearer {}'.format(self.cached_token_b64)},
+                                         headers={'Authorization': 'Bearer {}'.format(self.cached_token)},
                                          verify=self.server_verification_file)
         mock_save_auth_token.assert_not_called()
         mock_save_license_data.assert_not_called()
@@ -140,7 +138,6 @@ class TestDownloadLicense(CliTestCase):
         mock_get_cached_auth_token = MagicMock(return_value=None)
 
         prompted_token = 'prompted-token'
-        prompted_token_b64 = 'cHJvbXB0ZWQtdG9rZW4='
         mock_prompt_for_auth_token = MagicMock(return_value=prompted_token)
 
         mock_get = self.respond_with(200, self.license_text)
@@ -160,7 +157,7 @@ class TestDownloadLicense(CliTestCase):
         mock_get_cached_auth_token.assert_not_called()
         mock_prompt_for_auth_token.assert_called_once_with()
         mock_get.assert_called_once_with(self.license_download_url,
-                                         headers={'Authorization': 'Bearer {}'.format(prompted_token_b64)},
+                                         headers={'Authorization': 'Bearer {}'.format(prompted_token)},
                                          verify=self.server_verification_file)
         mock_save_auth_token.assert_called_once_with(prompted_token)
         mock_save_license_data.assert_called_once_with(self.license_text, self.license_file)


### PR DESCRIPTION
This removes the encoding of the `Bearer` token -- OAuth spec isn't as clear as it could be here, but it's intent is that this token is not base64 encoded, only that it adheres to the grammar laid out in `b64token`.

See this discussion on the spec that confirms this: https://www.ietf.org/mail-archive/web/oauth/current/msg08481.html , notably the following quotes:

> Note that the name b64token does not imply base64 encoding but rather
is the name for an ABNF syntax definition from HTTP/1.1, Part 7
[I-D.ietf-httpbis-p7-auth]. Because of its use, the "access_token"
string value from an access token response MUST match the b64token
ABNF so it can be used with the Bearer HTTP scheme.
-----------------------------------------
> Yeah, something as simple as, "Note that the name 'b64token' does not imply
> base64 encoding, see the definition in [[INSERT REFERENCE HERE]]." would do
> it.

### Manual Test

This was performed against the current website, which doesn't accept base64 encoded tokens.

```bash
$ conduct load-license

An access token is required. Please visit https://www.lightbend.com/platform/enterprise-suite/access-token to 
obtain one for free or for your commercial licenses.

Please enter your access token: <redacted>
Loading license into ConductR at 192.168.10.6

Licensed To: 521e4ec3-6e40-4719-8ec5-17e44262c41e
Max ConductR agents: 3
Expires In: 92 days (Thu 09 Nov 2017 09:37AM)
ConductR Version(s): 2.1.*, 2.1.0-beta.1
Grants: akka-sbr, cinnamon, conductr

License successfully loaded
-> 0
```