### PR TITLE
Fail if docker run exits with non-zero, thus failing if haproxy fails to start

### DIFF
--- a/conductr_cli/terminal.py
+++ b/conductr_cli/terminal.py
@@ -28,7 +28,9 @@ def docker_inspect(container_id, inspect_format=None):
 
 def docker_run(optional_args, image, positional_args):
     cmd = ['docker', 'run'] + optional_args + [image] + positional_args
-    return subprocess.call(cmd)
+    status = subprocess.call(cmd)
+    assert status == 0, 'docker exited with {}'.format(status)
+    return 0
 
 
 def docker_rm(containers):

--- a/conductr_cli/test/test_terminal.py
+++ b/conductr_cli/test/test_terminal.py
@@ -72,10 +72,25 @@ class TestTerminal(CliTestCase):
         image = 'image:version'
         positional_args = ['--discover-host-ip']
         stdout = MagicMock()
-        subprocess_call_mock = MagicMock()
+        subprocess_call_mock = MagicMock(return_value=0)
 
         with patch('subprocess.call', subprocess_call_mock), \
                 patch('sys.stdout', stdout):
+            terminal.docker_run(optional_args, image, positional_args)
+
+        self.assertEqual('', self.output(stdout))
+        subprocess_call_mock.assert_called_with(['docker', 'run'] + optional_args + [image] + positional_args)
+
+    def test_docker_run_fail(self):
+        optional_args = ['-p', '9001:9001', '-e', 'AKKA_LOGLEVEL=info']
+        image = 'image:version'
+        positional_args = ['--discover-host-ip']
+        stdout = MagicMock()
+        subprocess_call_mock = MagicMock(return_value=1)
+
+        with patch('subprocess.call', subprocess_call_mock), \
+                patch('sys.stdout', stdout), \
+                self.assertRaises(AssertionError):
             terminal.docker_run(optional_args, image, positional_args)
 
         self.assertEqual('', self.output(stdout))


### PR DESCRIPTION
Fixes #536 - if starting haproxy in the sandbox fails, an error is raised.

### Manual test
Start a process on port 9000, Start the sandbox

```bash
$ sandbox run 2.1.4 --no-default-features --feature proxying
|------------------------------------------------|
| Stopping HAProxy                               |
|------------------------------------------------|
sandbox-haproxy
HAProxy has been successfully stopped
|------------------------------------------------|
| Stopping ConductR                              |
|------------------------------------------------|
ConductR core pid 20636 stopped
ConductR agent pid 20753 stopped
ConductR has been successfully stopped
|------------------------------------------------|
| Starting ConductR                              |
|------------------------------------------------|
Bintray credentials loaded from /home/longshorej/.lightbend/commercial.credentials
Extracting ConductR core to /home/longshorej/.conductr/images/core
Extracting ConductR agent to /home/longshorej/.conductr/images/agent
Starting ConductR core instance on 192.168.10.1..
Waiting for ConductR to start.
Starting ConductR agent instance on 192.168.10.1..
|------------------------------------------------|
| Starting HAProxy                               |
|------------------------------------------------|
Exposing the following ports [80, 443, 3000, 5601, 8999, 9000, 9200, 9999]
06e9195c304a506de7b53f27be2c3e3bb168725e3552ba18ba3dc907d2b8cc0e
docker: Error response from daemon: driver failed programming external connectivity on endpoint sandbox-haproxy (776a303db2ee86a86c259788f79bb2acdddd096f9d9b50be7a7d19f3895135a2): Error starting userland proxy: listen tcp 192.168.10.1:9000: bind: address already in use.
Error: Encountered unexpected error.
Error: Reason: AssertionError docker exited with 125
Error: Further information of the error can be found in the error log file: /home/longshorej/.conductr/errors.log
-> 1
```