### PR TITLE
Support /32 CIDR notation, Fix `sandbox run --addr-range`

### DIFF
--- a/conductr_cli/sandbox_proxy.py
+++ b/conductr_cli/sandbox_proxy.py
@@ -1,4 +1,4 @@
-from conductr_cli import conduct_main, docker, terminal
+from conductr_cli import docker, terminal
 from conductr_cli.constants import DEFAULT_SANDBOX_PROXY_DIR, DEFAULT_SANDBOX_PROXY_CONTAINER_NAME
 from conductr_cli.exceptions import NOT_FOUND_ERROR
 from conductr_cli.screen_utils import h1
@@ -36,7 +36,6 @@ def start_proxy(proxy_bind_addr, bundle_http_port, proxy_ports, all_feature_port
         setup_haproxy_dirs()
         stop_proxy()
         start_docker_instance(proxy_bind_addr, bundle_http_port, proxy_ports, all_feature_ports)
-        start_conductr_haproxy()
         return True
     else:
         return False
@@ -99,12 +98,3 @@ def start_docker_instance(proxy_bind_addr, bundle_http_port, proxy_ports, all_fe
 
     log.info('Exposing the following ports {}'.format(all_proxy_ports))
     terminal.docker_run(docker_args, HAPROXY_DOCKER_IMAGE, positional_args=[])
-
-
-def start_conductr_haproxy():
-    log = logging.getLogger(__name__)
-    bundle_name = 'conductr-haproxy'
-    configuration_name = 'conductr-haproxy-dev-mode'
-    log.info('Deploying bundle {} with configuration {}'.format(bundle_name, configuration_name))
-    conduct_main.run(['load', bundle_name, configuration_name, '--disable-instructions'], configure_logging=False)
-    conduct_main.run(['run', bundle_name, '--disable-instructions'], configure_logging=False)

--- a/conductr_cli/sandbox_run_jvm.py
+++ b/conductr_cli/sandbox_run_jvm.py
@@ -360,7 +360,10 @@ def find_bind_addrs(nr_of_addrs, addr_range):
 
     addrs_to_bind = []
     addrs_unavailable = []
-    for ip_addr in addr_range.hosts():
+
+    # If we're given the max subnet (i.e. 255.255.255.255 on IPV4), use the subnet address as the ip address
+    # This allows usage such as sandbox run --addr-range 0.0.0.0 which can be useful when running in a VM
+    for ip_addr in addr_range if addr_range.netmask._ALL_ONES == int(addr_range.netmask) else addr_range.hosts(): # noqa
         if host.can_bind(ip_addr, BIND_TEST_PORT):
             addrs_to_bind.append(ip_addr)
         else:

--- a/conductr_cli/test/test_sandbox_proxy.py
+++ b/conductr_cli/test/test_sandbox_proxy.py
@@ -1,6 +1,6 @@
 from conductr_cli.test.cli_test_case import CliTestCase, strip_margin
 from conductr_cli import logging_setup, sandbox_proxy
-from unittest.mock import call, patch, MagicMock
+from unittest.mock import patch, MagicMock
 from subprocess import CalledProcessError
 import ipaddress
 
@@ -14,15 +14,13 @@ class TestStartProxy(CliTestCase):
         mock_setup_haproxy_dirs = MagicMock()
         mock_stop_proxy = MagicMock()
         mock_start_docker_instance = MagicMock()
-        mock_start_conductr_haproxy = MagicMock()
 
         args = MagicMock(**{})
 
         with patch('conductr_cli.docker.is_docker_present', mock_is_docker_present), \
                 patch('conductr_cli.sandbox_proxy.setup_haproxy_dirs', mock_setup_haproxy_dirs), \
                 patch('conductr_cli.sandbox_proxy.stop_proxy', mock_stop_proxy), \
-                patch('conductr_cli.sandbox_proxy.start_docker_instance', mock_start_docker_instance), \
-                patch('conductr_cli.sandbox_proxy.start_conductr_haproxy', mock_start_conductr_haproxy):
+                patch('conductr_cli.sandbox_proxy.start_docker_instance', mock_start_docker_instance):
             logging_setup.configure_logging(args, stdout)
             sandbox_proxy.start_proxy(ipaddress.ip_address('192.168.1.1'), 9000, [3003], [9999, 9200])
 
@@ -30,7 +28,6 @@ class TestStartProxy(CliTestCase):
         mock_setup_haproxy_dirs.assert_called_once_with()
         mock_stop_proxy.assert_called_once_with()
         mock_start_docker_instance.assert_called_once_with(ipaddress.ip_address('192.168.1.1'), 9000, [3003], [9999, 9200])
-        mock_start_conductr_haproxy.assert_called_once_with()
 
         self.assertEqual('', self.output(stdout))
 
@@ -41,15 +38,13 @@ class TestStartProxy(CliTestCase):
         mock_setup_haproxy_dirs = MagicMock()
         mock_stop_proxy = MagicMock()
         mock_start_docker_instance = MagicMock()
-        mock_start_conductr_haproxy = MagicMock()
 
         args = MagicMock(**{})
 
         with patch('conductr_cli.docker.is_docker_present', mock_is_docker_present), \
                 patch('conductr_cli.sandbox_proxy.setup_haproxy_dirs', mock_setup_haproxy_dirs), \
                 patch('conductr_cli.sandbox_proxy.stop_proxy', mock_stop_proxy), \
-                patch('conductr_cli.sandbox_proxy.start_docker_instance', mock_start_docker_instance), \
-                patch('conductr_cli.sandbox_proxy.start_conductr_haproxy', mock_start_conductr_haproxy):
+                patch('conductr_cli.sandbox_proxy.start_docker_instance', mock_start_docker_instance):
             logging_setup.configure_logging(args, stdout)
             sandbox_proxy.start_proxy(ipaddress.ip_address('192.168.1.1'), 9000, [3003], [9999, 9200])
 
@@ -57,7 +52,6 @@ class TestStartProxy(CliTestCase):
         mock_setup_haproxy_dirs.assert_not_called()
         mock_stop_proxy.assert_not_called()
         mock_start_docker_instance.assert_not_called()
-        mock_start_conductr_haproxy.assert_not_called()
 
         self.assertEqual('', self.output(stdout))
 
@@ -329,19 +323,3 @@ class TestStartDockerInstance(CliTestCase):
                                           |Exposing the following ports [80, 443, 3003, 8999, 9000, 19001]
                                           |""")
         self.assertEqual(expected_output, self.output(stdout))
-
-
-class TestStartConductrHAProxy(CliTestCase):
-    def test_success(self):
-        stdout = MagicMock()
-        mock_run = MagicMock()
-        args = MagicMock(**{})
-
-        with patch('conductr_cli.conduct_main.run', mock_run):
-            logging_setup.configure_logging(args, stdout)
-            sandbox_proxy.start_conductr_haproxy()
-
-        self.assertEqual([
-            call(['load', 'conductr-haproxy', 'conductr-haproxy-dev-mode', '--disable-instructions'], configure_logging=False),
-            call(['run', 'conductr-haproxy', '--disable-instructions'], configure_logging=False)
-        ], mock_run.call_args_list)

--- a/conductr_cli/test/test_sandbox_run_jvm.py
+++ b/conductr_cli/test/test_sandbox_run_jvm.py
@@ -637,6 +637,17 @@ class TestFindBindAddresses(CliTestCase):
             4)
         mock_subprocess_check_call.assert_not_called()
 
+    def test_cidr_max_mask(self):
+        with patch('conductr_cli.host.can_bind', MagicMock(return_value=True)):
+            self.assertEqual(
+                sandbox_run_jvm.find_bind_addrs(1, ipaddress.ip_network('192.168.1.15/32', strict=True)),
+                [ipaddress.IPv4Address('192.168.1.15')]
+            )
+            self.assertEquals(
+                sandbox_run_jvm.find_bind_addrs(1, ipaddress.ip_network('0.0.0.0/32', strict=True)),
+                [ipaddress.IPv4Address('0.0.0.0')]
+            )
+
 
 class TestObtainSandboxImage(CliTestCase):
     def test_obtain_macos_artefact_from_bintray(self):


### PR DESCRIPTION
This PR ensures that the calls to `conduct load` and `conduct run`, when invoked by `sandbox run`, given a custom value for `--addr-range`, are successful. It also tweaks the IP selection logic to allow a `/32` (or the corresponding max value on IPV6) CIDR to be used when using `sandbox run`, thus allowing you to guarantee a specific address is used.

The net result of this is that the following commands now work as expected, thus allowing the sandbox to bind to an address that could be externally reachable (for instance, when in a VM):

`sandbox run 2.1.5  --addr-range 192.168.1.11/32`
`sandbox run 2.1.5 --addr-range 0.0.0.0/32`

### Manual Test

Start up a sandbox with monitoring and a custom range, which uses all of the affected features.

```bash
sandbox run 2.1.5 --addr-range 192.168.1.11/32 --feature monitoring
|------------------------------------------------|
| Stopping HAProxy                               |
|------------------------------------------------|
sandbox-haproxy
HAProxy has been successfully stopped
|------------------------------------------------|
| Stopping ConductR                              |
|------------------------------------------------|
ConductR core pid 25390 stopped
ConductR agent pid 25550 stopped
ConductR has been successfully stopped
|------------------------------------------------|
| Starting ConductR                              |
|------------------------------------------------|
Bintray credentials loaded from /home/longshorej/.lightbend/commercial.credentials
Extracting ConductR core to /home/longshorej/.conductr/images/core
Extracting ConductR agent to /home/longshorej/.conductr/images/agent
Starting ConductR core instance on 192.168.1.11..
Waiting for ConductR to start..
Starting ConductR agent instance on 192.168.1.11..
|------------------------------------------------|
| Starting continuous delivery feature           |
|------------------------------------------------|
Deploying bundle continuous-delivery..
Retrieving bundle..
Resolving bundle using [bintray_resolver, docker_resolver]
Loading bundle from cache typesafe/bundle/continuous-delivery
Bintray credentials loaded from /home/longshorej/.lightbend/commercial.credentials
Retrieving from cache /home/longshorej/.conductr/cache/bundle/continuous-delivery-2.1.4-2fb7f832dee671764033ef0ad63a0df3f81732551a613a7ec7ff328ae9273ddf.zip
Loading bundle to ConductR..
[##################################################] 100%
Bundle 2fb7f832dee671764033ef0ad63a0df3 is installed
Bundle loaded.
Bundle run request sent.
Bundle 2fb7f832dee671764033ef0ad63a0df3 waiting to reach expected scale 1
Bundle 2fb7f832dee671764033ef0ad63a0df3 has scale 0, expected 1...
Bundle 2fb7f832dee671764033ef0ad63a0df3 expected scale 1 is met
|------------------------------------------------|
| Starting HAProxy                               |
|------------------------------------------------|
Exposing the following ports [80, 443, 3000, 5601, 8999, 9000, 9200, 9999]
4e9e3d6fc1ed061c127d27b0c6b3247bc3e8f7575ca9423470a9c872ca97d94b
Deploying bundle conductr-haproxy..
Retrieving bundle..
Resolving bundle using [bintray_resolver, docker_resolver]
Loading bundle from cache typesafe/bundle/conductr-haproxy
Bintray credentials loaded from /home/longshorej/.lightbend/commercial.credentials
Retrieving from cache /home/longshorej/.conductr/cache/bundle/conductr-haproxy-2.1.0-b53247232309ca17ab3872529b9f64f5f231a2708d4e1e18c985bceabeb8e919.zip
Retrieving configuration..
Resolving bundle configuration using [bintray_resolver, docker_resolver]
Loading bundle configuration from cache typesafe/bundle-configuration/conductr-haproxy-dev-mode
Bintray credentials loaded from /home/longshorej/.lightbend/commercial.credentials
Retrieving from cache /home/longshorej/.conductr/cache/configuration/conductr-haproxy-dev-mode-2.1.0-92feca565e8cbe4a0e08b617829767f2c8a1a000212e14eb8b096175b3aab02e.zip
Loading bundle to ConductR..
[##################################################] 100%
Bundle b53247232309ca17ab3872529b9f64f5-92feca565e8cbe4a0e08b617829767f2 is installed
Bundle loaded.
Bundle run request sent.
Bundle b53247232309ca17ab3872529b9f64f5-92feca565e8cbe4a0e08b617829767f2 waiting to reach expected scale 1
Bundle b53247232309ca17ab3872529b9f64f5-92feca565e8cbe4a0e08b617829767f2 has scale 0, expected 1.
Bundle b53247232309ca17ab3872529b9f64f5-92feca565e8cbe4a0e08b617829767f2 expected scale 1 is met
|------------------------------------------------|
| Starting OCI-in-Docker support                 |
|------------------------------------------------|
OCI-in-Docker provided by image lightbend-docker-registry.bintray.io/conductr/oci-in-docker:0.1.0
|------------------------------------------------|
| Starting logging feature based on              |
| elasticsearch and kibana                       |
|------------------------------------------------|
conductr-kibana bundle is packaged as a Docker image. Checking Docker requirements..
Docker is installed and configured correctly.
Deploying bundle conductr-elasticsearch..
Retrieving bundle..
Resolving bundle using [bintray_resolver, docker_resolver]
Loading bundle from cache typesafe/bundle/conductr-elasticsearch
Bintray credentials loaded from /home/longshorej/.lightbend/commercial.credentials
Retrieving from cache /home/longshorej/.conductr/cache/bundle/conductr-elasticsearch-2.1.0-5f16eba7264c4fbc65376a7c288a418b1f99408aed61c43edfece9151af770bd.zip
Loading bundle to ConductR..
[##################################################] 100%
Bundle 5f16eba7264c4fbc65376a7c288a418b is installed
Bundle loaded.
Bundle run request sent.
Bundle 5f16eba7264c4fbc65376a7c288a418b waiting to reach expected scale 1
Bundle 5f16eba7264c4fbc65376a7c288a418b has scale 0, expected 1.
Bundle 5f16eba7264c4fbc65376a7c288a418b expected scale 1 is met
Deploying bundle conductr-kibana..
Retrieving bundle..
Resolving bundle using [bintray_resolver, docker_resolver]
Loading bundle from cache typesafe/bundle/conductr-kibana
Bintray credentials loaded from /home/longshorej/.lightbend/commercial.credentials
Retrieving from cache /home/longshorej/.conductr/cache/bundle/conductr-kibana-2.1.0-9e4284c3760551bcca433a02de6a7eb17c4b49d0197d7992e7596aef712b811d.zip
Loading bundle to ConductR..
[##################################################] 100%
Bundle 9e4284c3760551bcca433a02de6a7eb1 is installed
Bundle loaded.
Bundle run request sent.
Bundle 9e4284c3760551bcca433a02de6a7eb1 waiting to reach expected scale 1
Bundle 9e4284c3760551bcca433a02de6a7eb1 has scale 0, expected 1..
Bundle 9e4284c3760551bcca433a02de6a7eb1 expected scale 1 is met
|------------------------------------------------|
| Starting monitoring feature                    |
|------------------------------------------------|
Deploying bundle cinnamon-grafana-docker..
Retrieving bundle..
Resolving bundle using [bintray_resolver, docker_resolver]
Loading bundle from cache typesafe/bundle/cinnamon-grafana-docker
Bintray credentials loaded from /home/longshorej/.lightbend/commercial.credentials
Resolving bundle typesafe/bundle/cinnamon-grafana-docker
Bintray credentials loaded from /home/longshorej/.lightbend/commercial.credentials
Retrieving https://dl.bintray.com/typesafe/bundle/typesafe/cinnamon-grafana-docker/v2-adf2166889efcb8dba88546dc437815906ae2d528f2a4ce56e3acdeb9a43f0dc/cinnamon-grafana-docker-v2-adf2166889efcb8dba88546dc437815906ae2d528f2a4ce56e3acdeb9a43f0dc.zip
[##################################################] 100%
Loading bundle to ConductR..
[##################################################] 100%
Bundle adf2166889efcb8dba88546dc4378159 is installed
Bundle loaded.
Bundle run request sent.
Bundle adf2166889efcb8dba88546dc4378159 waiting to reach expected scale 1
Bundle adf2166889efcb8dba88546dc4378159 has scale 0, expected 1.....
Bundle adf2166889efcb8dba88546dc4378159 expected scale 1 is met
|------------------------------------------------|
| Summary                                        |
|------------------------------------------------|
|- - - - - - - - - - - - - - - - - - - - - - - - |
| ConductR                                       |
|- - - - - - - - - - - - - - - - - - - - - - - - |
ConductR has been started:
  core instance on 192.168.1.11
  agent instance on 192.168.1.11
ConductR service locator has been started on:
  192.168.1.11:9008
|- - - - - - - - - - - - - - - - - - - - - - - - |
| Proxy                                          |
|- - - - - - - - - - - - - - - - - - - - - - - - |
HAProxy has been started
By default, your bundles are accessible on:
  192.168.1.11:9000
|- - - - - - - - - - - - - - - - - - - - - - - - |
| Features                                       |
|- - - - - - - - - - - - - - - - - - - - - - - - |
The following feature related bundles have been started:
  conductr-kibana on 192.168.1.11:5601
  conductr-elasticsearch on 192.168.1.11:9200
  cinnamon-grafana-docker on 192.168.1.11:3000
|- - - - - - - - - - - - - - - - - - - - - - - - |
| Bundles                                        |
|- - - - - - - - - - - - - - - - - - - - - - - - |
Check latest bundle status with:
  conduct info
Current bundle status:
Licensed To: cc64df31-ec6b-4e08-bb6b-3216721a56b@lightbend
Max ConductR agents: 3
ConductR Version(s): 0.1.0, 2.1.*
Grants: akka-sbr, cinnamon, conductr

ID               NAME                       TAG  #REP  #STR  #RUN  ROLES
b532472-92feca5  conductr-haproxy         2.1.0     1     0     1  haproxy
adf2166          cinnamon-grafana-docker            1     0     1  web
5f16eba          conductr-elasticsearch   2.1.0     1     0     1  elasticsearch
9e4284c          conductr-kibana          2.1.0     1     0     1  kibana
2fb7f83          continuous-delivery      2.1.4     1     0     1  continuous-delivery
-> 0
```