### PR TITLE
Ensure correct field is used for DC/OS service name

### DIFF
--- a/conductr_cli/conduct_dcos.py
+++ b/conductr_cli/conduct_dcos.py
@@ -27,12 +27,13 @@ def service_name(args):
 
         if marathon_groups.status_code == 200:
             groups = json.loads(marathon_groups.text)
-
             if 'apps' in groups:
                 conductr_services = [
-                    a['id'].strip('/') for a in groups['apps']
+                    a['labels']['DCOS_SERVICE_NAME'] for a in groups['apps']
 
-                    if a['id'].strip('/').startswith(CONDUCTR_DCOS_SERVICE)
+                    if 'labels' in a and
+                       'DCOS_SERVICE_NAME' in a['labels'] and
+                       a['labels']['DCOS_SERVICE_NAME'].startswith(CONDUCTR_DCOS_SERVICE)
                 ]
 
                 if len(conductr_services) > 0:

--- a/conductr_cli/test/test_conduct_dcos.py
+++ b/conductr_cli/test/test_conduct_dcos.py
@@ -105,7 +105,15 @@ class TestConductDcos(CliTestCase):
 
     def test_service_name_defaults(self):
         args = MagicMock()
-        text = '''{ "apps": [{ "id": "/conductr-2.1.5" }, { "id": "/conductr-2.1.6" }] }'''
+        text = '''
+          {
+            "apps": [
+              { "id": "/conductr-2.1.5", "labels": { "DCOS_SERVICE_NAME": "conductr-2.1.5" } },
+              { "id": "/conductr-2.1.6", "labels": { "DCOS_SERVICE_NAME": "conductr-2.1.6" } },
+              { "id": "/elastic" }
+            ]
+          }
+        '''
 
         with patch('conductr_cli.conduct_request.get', self.respond_with(200, text)):
             self.assertEqual(conduct_dcos.service_name(args), 'conductr-2.1.5')


### PR DESCRIPTION
Follow-up on #543 - I should be using `DCOS_SERVICE_NAME` instead of `id`.