### PR TITLE
Add missing `return False` for HTTP error supression

### DIFF
--- a/conductr_cli/validation.py
+++ b/conductr_cli/validation.py
@@ -63,6 +63,7 @@ def handle_http_error(func):
             log.error('{} {}'.format(err.response.status_code, err.response.reason))
             if err.response.text != '':
                 log.error(err.response.text)
+            return False
         except dcos.errors.DCOSHTTPException as err:
             log = get_logger_for_func(func)
             log.error(err)


### PR DESCRIPTION
This CLI fixes a small bug in the CLI where one case wasn't returning `False` when contractually it should have been. This manifested in a `None`-related error when running `conduct logs` instead of a proper error message.