### PR TITLE
Adjust `conduct logs` default lines fetched to be 50 when follow is enabled

### DIFF
--- a/conductr_cli/conduct_logs.py
+++ b/conductr_cli/conduct_logs.py
@@ -16,6 +16,9 @@ def logs(args):
 
     log = logging.getLogger(__name__)
 
+    if args.lines == 0:
+        args.lines = 50 if args.follow else 10
+
     if args.follow:
         old_data = []
 

--- a/conductr_cli/conduct_main.py
+++ b/conductr_cli/conduct_main.py
@@ -179,10 +179,10 @@ def add_date_args(sub_parser, show_help=True):
                             help='Convert the date/time of the events to UTC' if show_help else argparse.SUPPRESS)
 
 
-def add_lines_args(subparser, show_help=True):
+def add_lines_args(subparser, show_help=True, default=10):
     subparser.add_argument('-n', '--lines',
                            type=int,
-                           default=10,
+                           default=default,
                            help='The number of logs to fetch\n'
                                 'Defaults to 10' if show_help else argparse.SUPPRESS)
 
@@ -362,7 +362,7 @@ def build_parser(dcos_mode):
                                         help='Show bundle logs',
                                         formatter_class=argparse.RawTextHelpFormatter)
     add_default_arguments(logs_parser, dcos_mode)
-    add_lines_args(logs_parser)
+    add_lines_args(logs_parser, default=0)
     add_follow_args(logs_parser)
     add_date_args(logs_parser)
     logs_parser.add_argument('bundle',


### PR DESCRIPTION
This adjusts the default value for `lines` for `conduct logs` when `-f` is provided. This is done so that reconciliation of the logs is less likely to fail.

Failure can and will happen when log volume is high, as the CLI needs to calculate the difference between old and new logs to determine which lines to print. By increasing the default size, we're making this less likely to happen.